### PR TITLE
Add build CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,25 @@ jobs:
             --settings:all build_type=${{ matrix.config }} \
             --build=missing \
             --output-folder=src/conan
-      - name: Generate nvnmos
+      - name: Generate nvnmos (Linux)
+        if: runner.os == 'Linux'
         run: |
           cmake -B build \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             src
-      - name: Build nvnmos
+      - name: Generate nvnmos (Windows)
+        if: runner.os == 'Windows'
         run: |
-          cmake --build build --parallel --config ${{ matrix.config }}
+          cmake -B build \
+            -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
+            -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} \
+            src
+      - name: Build nvnmos (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          cmake --build build --parallel
+      - name: Build nvnmos (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cmake --build build --config=${{ matrix.config }} --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        config: [Release]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Conan
+        run: pip install conan && conan profile detect
+      - name: Install dependencies
+        run: |
+          conan install src \
+            -g CMakeToolchain \
+            --settings:all build_type=${{ matrix.config }} \
+            --build=missing \
+            --output-folder=src/conan
+      - name: Build nvnmos
+        run: |
+          cmake -B build \
+            -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+            src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Conan
-        run: pip install conan && conan profile detect
+        run: pip install conan~=2.2 && conan profile detect
       - name: Install dependencies
         run: |
           conan install src \
@@ -27,9 +27,12 @@ jobs:
             --settings:all build_type=${{ matrix.config }} \
             --build=missing \
             --output-folder=src/conan
-      - name: Build nvnmos
+      - name: Generate nvnmos
         run: |
           cmake -B build \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
             src
+      - name: Build nvnmos
+        run: |
+          cmake --build build --parallel --config ${{ matrix.config }}

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Use the following CMake command to configure the build.
 
 ```sh
 cmake -B build \
-  -DCMAKE_TOOLCHAIN_FILE=src/conan/conan_toolchain.cmake \
+  -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
   -DCMAKE_BUILD_TYPE=<Release-or-Debug> \
   src
 ```

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Use the following CMake command to configure the build.
 ```PowerShell
 cmake -B build `
   -G "Visual Studio 17 2022" `
-  -DCMAKE_TOOLCHAIN_FILE=src/conan/conan_toolchain.cmake `
+  -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake `
   -DCMAKE_CONFIGURATION_TYPES="Debug;Release" `
   src
 ```


### PR DESCRIPTION
- add CI for building the package on Windows and Linux (MacOS unsupported by dependency nmos-cpp)
- fix error in README: toolchain file is relative to source directory not current working directory