### PR TITLE
Add support for fixed Registration API and disabling DNS-SD

### DIFF
--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -31,6 +31,7 @@
 #include "cpprest/host_utils.h"
 #include "nmos/asset.h"
 #include "nmos/log_gate.h"
+#include "nmos/mdns.h"
 #include "nmos/model.h"
 #include "nmos/node_server.h"
 #include "nmos/process_utils.h"
@@ -311,6 +312,20 @@ namespace nvnmos
                 return utility::s2us(category);
             }));
             web::json::insert(settings, std::make_pair(nmos::fields::logging_categories, std::move(categories)));
+        }
+
+        if (0 != config.registration_address)
+        {
+            web::json::insert(settings, std::make_pair(nmos::fields::registry_address, utility::s2us(config.registration_address)));
+            // disable DNS-SD discovery
+            web::json::insert(settings, std::make_pair(nmos::fields::highest_pri, nmos::service_priorities::no_priority));
+            // disable DNS-SD advertisement
+            web::json::insert(settings, std::make_pair(nmos::fields::pri, nmos::service_priorities::no_priority));
+        }
+        web::json::insert(settings, std::make_pair(nmos::fields::registration_port, 0 != config.registration_port ? config.registration_port : 80));
+        if (0 != config.registration_version)
+        {
+            web::json::insert(settings, std::make_pair(nmos::fields::registry_version, utility::s2us(config.registration_version)));
         }
 
         nmos::insert_node_default_settings(settings);

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -297,28 +297,34 @@ typedef struct _NvNmosSenderConfig
  */
 typedef struct _NvNmosNetworkServicesConfig
 {
-    /** Holds the domain for DNS-SD. May be null in which case a domain is
+    /** Holds the DNS domain. May be null in which case a domain is
         determined automatically. Use "local" to force multicast DNS-SD. */
     const char* domain;
 
     /** Holds the IP address or host name of a fixed IS-04 Registration
-        API to use. May be null in which case DNS-SD is used. */
+        API to use; in this case DNS-SD is disabled. May be null in which
+        case DNS-SD is used as required by IS-04. */
     const char* registration_address;
-    /** Holds the port number for a fixed IS-04 Registration API, e.g.
-        80. May be zero in which case port 80 is used for HTTP. */
+    /** Holds the port number for the fixed IS-04 Registration API, if
+        #registration_address is specified. May be zero in which case port
+        80 is used for HTTP. */
     unsigned int registration_port;
-    /** Holds the version number of a fixed IS-04 Registration API. May
-        be null in which case "v1.3" is used by default. */
+    /** Holds the version number of the fixed IS-04 Registration API, if
+        #registration_address is specified. May be null in which case
+        "v1.3" is used by default. */
     const char* registration_version;
 
     /** Holds the IP address or host name of a fixed IS-09 System API
-        to use. May be null in which case a System API is not used. */
+        to use, if #registration_address is also specified. May be null
+        in which case a System API is not used; not recommended. */
     const char* system_address;
-    /** Holds the port number for a fixed IS-09 System API, e.g. 80.
-        May be zero in which case port 80 is used for HTTP. */
+    /** Holds the port number for the fixed IS-09 System API, if
+        #system_address is specified. May be zero in which case port 80
+        is used for HTTP. */
     unsigned int system_port;
-    /** Holds the version number of a fixed IS-09 System API. May be
-        null in which case "v1.0" is used by default. */
+    /** Holds the version number of the fixed IS-09 System API, if
+        #system_address is specified. May be null in which case "v1.0" is
+        used by default. */
     const char* system_version;
 } NvNmosNetworkServicesConfig;
 

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -164,6 +164,7 @@ typedef void (* nmos_logging_callback)(
 typedef struct _NvNmosAssetConfig NvNmosAssetConfig;
 typedef struct _NvNmosReceiverConfig NvNmosReceiverConfig;
 typedef struct _NvNmosSenderConfig NvNmosSenderConfig;
+typedef struct _NvNmosNetworkServicesConfig NvNmosNetworkServicesConfig;
 
 /**
  * Defines configuration settings used to create an @ref NvNmosNodeServer.
@@ -226,15 +227,9 @@ typedef struct _NvNmosNodeConfig
     /** Holds the number of #log_categories. May be zero. */
     unsigned int num_log_categories;
 
-    /** Holds the IP address or host name of a fixed IS-04 Registration API
-        to use; this disables DNS-SD. May be null. */
-    const char* registration_address;
-    /** Holds the port number for a fixed IS-04 Registration API, e.g.
-        80. May be zero in which case port 80 is used for HTTP. */
-    unsigned int registration_port;
-    /** Holds the version number of a fixed IS-04 Registration API. May
-        be null in which case "v1.3" is used by default. */
-    const char* registration_version;
+    /** Holds configuration settings for network services to use. May be
+        null in which case DNS-SD is used based on the #host_name. */
+    NvNmosNetworkServicesConfig* network_services;
 } NvNmosNodeConfig;
 
 /**
@@ -295,6 +290,37 @@ typedef struct _NvNmosSenderConfig
         the source port from which the stream is transmitted. */
     const char *sdp;
 } NvNmosSenderConfig;
+
+/**
+ * Defines configuration settings for network services to use in an
+ * @ref NvNmosNodeServer. The structure should be zero initialized.
+ */
+typedef struct _NvNmosNetworkServicesConfig
+{
+    /** Holds the domain for DNS-SD. May be null in which case a domain is
+        determined automatically. Use "local" to force multicast DNS-SD. */
+    const char* domain;
+
+    /** Holds the IP address or host name of a fixed IS-04 Registration
+        API to use. May be null in which case DNS-SD is used. */
+    const char* registration_address;
+    /** Holds the port number for a fixed IS-04 Registration API, e.g.
+        80. May be zero in which case port 80 is used for HTTP. */
+    unsigned int registration_port;
+    /** Holds the version number of a fixed IS-04 Registration API. May
+        be null in which case "v1.3" is used by default. */
+    const char* registration_version;
+
+    /** Holds the IP address or host name of a fixed IS-09 System API
+        to use. May be null in which case a System API is not used. */
+    const char* system_address;
+    /** Holds the port number for a fixed IS-09 System API, e.g. 80.
+        May be zero in which case port 80 is used for HTTP. */
+    unsigned int system_port;
+    /** Holds the version number of a fixed IS-09 System API. May be
+        null in which case "v1.0" is used by default. */
+    const char* system_version;
+} NvNmosNetworkServicesConfig;
 
 /**
  * Holds the implementation details of a running NvNmos server.

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -225,6 +225,16 @@ typedef struct _NvNmosNodeConfig
     const char **log_categories;
     /** Holds the number of #log_categories. May be zero. */
     unsigned int num_log_categories;
+
+    /** Holds the IP address or host name of a fixed IS-04 Registration API
+        to use; this disables DNS-SD. May be null. */
+    const char* registration_address;
+    /** Holds the port number for a fixed IS-04 Registration API, e.g.
+        80. May be zero in which case port 80 is used for HTTP. */
+    unsigned int registration_port;
+    /** Holds the version number of a fixed IS-04 Registration API. May
+        be null in which case "v1.3" is used by default. */
+    const char* registration_version;
 } NvNmosNodeConfig;
 
 /**


### PR DESCRIPTION
NvNmosNetworkServicesConfig is added to allow fixed Registration API and  System API to be specified. If the Registration API is specified, DNS-SD discovery and advertisement are disabled.

This change also allows the domain to be specified explicitly, overriding the simplistic use of the host name's parent domain or system domain name.

Given a bare system host name (e.g. via `gethostname`) of "my-host" and a system domain (e.g. from the system resolver looking at _/etc.resolv.conf_) of "my-domain", this allows the following behaviours...

| Input host name | Input domain | Output host name | Output domain | Notes |
|--|--|--|--|--|
|  |  | my-host.my-domain | my-domain | (as before) |
| nmos-node.local |  | nmos-node.local | local | (as before) |
| nmos-node.foo.example.com |  | nmos-node.foo.example.com | foo.example.com | (as before) |
|  | local | my-host.local | local | Force mDNS |
|  | example.com | my-host.example.com | example.com | Override auto domain |
| nmos-node.foo.example.com | example.com | nmos-node.foo.example.com | example.com | Override parent domain |
