### PR TITLE
Update some dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         config: [Release]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
       - name: Install dependencies
@@ -56,7 +56,7 @@ jobs:
   license-check:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: mkdir LICENSES && cp LICENSE LICENSES/Apache-2.0.txt
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v3
+      uses: fsfe/reuse-action@v6

--- a/.github/workflows/conan-canary.yml
+++ b/.github/workflows/conan-canary.yml
@@ -24,7 +24,7 @@ jobs:
         config: [Release]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
       - name: Install dependencies without lockfile
@@ -53,7 +53,7 @@ jobs:
           diff -u conan-canary/conan.lock conan-canary/conan-canary.lock | head -n 200 || true
       - name: Upload canary artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conan-canary-${{ matrix.os }}
           path: conan-canary/

--- a/.github/workflows/conan-canary.yml
+++ b/.github/workflows/conan-canary.yml
@@ -1,11 +1,15 @@
 # SPDX-FileCopyrightText: Copyright (C) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Build
+# Weekly unlocked Conan resolve + build (no src/conan.lock input), uploads a
+# candidate lockfile and metadata for comparison with the committed lock.
+
+name: Canary build
 
 on:
-  push:
-  pull_request:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -16,21 +20,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, windows-2025]
+        os: [ubuntu-latest, windows-latest]
         config: [Release]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
-      - name: Install dependencies
+      - name: Install dependencies without lockfile
+        id: conan_install
         run: |
+          mkdir -p conan-canary
           conan install src \
             -g CMakeToolchain \
             --settings:all build_type=${{ matrix.config }} \
             --build=missing \
             --output-folder=src/conan \
-            --lockfile=src/conan.lock
+            --lockfile-out=conan-canary/conan-canary.lock
+      - name: Record canary metadata
+        if: always()
+        run: |
+          mkdir -p conan-canary
+          cp src/conan.lock conan-canary/conan.lock
+          {
+            echo "workflow=${{ github.workflow }}"
+            echo "ref=${{ github.ref }}"
+            echo "sha=${{ github.sha }}"
+            echo "runner_os=${{ runner.os }}"
+            echo "conan_install_outcome=${{ steps.conan_install.outcome }}"
+          } >> conan-canary/summary.txt
+          cat conan-canary/summary.txt
+          diff -u conan-canary/conan.lock conan-canary/conan-canary.lock | head -n 200 || true
+      - name: Upload canary artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conan-canary-${{ matrix.os }}
+          path: conan-canary/
       - name: Generate nvnmos (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -53,10 +79,3 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cmake --build build --config=${{ matrix.config }} --parallel
-  license-check:
-    runs-on: ubuntu-24.04
-    steps:
-    - uses: actions/checkout@v4
-    - run: mkdir LICENSES && cp LICENSE LICENSES/Apache-2.0.txt
-    - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install Doxygen
       run: sudo apt update && sudo apt install -y doxygen graphviz
@@ -23,7 +23,7 @@ jobs:
       run: cd src && doxygen ../Doxyfile && mv html ../public
 
     - name: Upload Documentation Artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: public
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Python venv (README recommends `.venv` beside the repo)
+.venv/
+
+# CMake user presets (machine-specific paths, generators, etc.)
+CMakeUserPresets.json
+
+# Local Conan + CMake output (README layout)
+build/
+src/conan/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=ubuntu:22.04
+ARG BASE_IMAGE=ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 ARG PACKAGE_SUFFIX
 ARG PIP_BREAK_SYSTEM_PACKAGES=1
@@ -49,7 +49,6 @@ RUN conan install . \
     --build=missing \
     --output-folder=conan \
     --lockfile=${USE_CONAN_LOCK:+conan.lock} \
-    --lockfile-partial \
     --lockfile-out=conan.lock
 
 RUN cmake -B build \
@@ -82,6 +81,6 @@ ENV PACKAGE_NAME=nvnmos${PACKAGE_SUFFIX:--${_BASE_IMAGE//:/-}}
 COPY --from=builder \
     /src/${PACKAGE_NAME}.tar.gz \
     /entrypoint.sh \
-    .
+    ./
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ sudo apt install -y python3 python3-venv
 
 **Windows**
 
-Download the Python 3 installer from [python.org](https://www.python.org/downloads/windows/) and run it manually, or use the following PowerShell script.
+Download the Python 3 installer from [python.org](https://www.python.org/downloads/windows/) and run it manually, or use the following PowerShell commands.
 Python 3.14.4 (64-bit Windows, latest stable release at the time) has been tested.
 
 > 💬 **Note:**
@@ -123,7 +123,11 @@ Invoke-WebRequest `
 ./python-3.14.4-amd64.exe /quiet PrependPath=1 Include_tcltk=0 Include_test=0
 ```
 
-Close and reopen the terminal (or log off and on) so `PATH` picks up the new Python install, then use a virtual environment as below.
+Confirm this Python is available on the `PATH`. Try closing and reopening the terminal if not.
+
+```PowerShell
+python --version
+```
 
 ### Python Virtual Environment
 
@@ -139,20 +143,23 @@ pip install --upgrade pip
 
 **Windows**
 
-From PowerShell, use the following command.
+From PowerShell, use the following commands.
 
-```sh
+```PowerShell
 python -m venv .venv
 .\.venv\Scripts\Activate.ps1
-pip install --upgrade pip
+# If PowerShell reports that "running scripts is disabled on this system"
+# you can adjust the execution policy as follows and try again.
+# Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+python -m pip install --upgrade pip
 ```
 
 Or use Command Prompt instead.
 
-```sh
+```bat
 python -m venv .venv
 .\.venv\Scripts\activate.bat
-pip install --upgrade pip
+python -m pip install --upgrade pip
 ```
 
 To exit the virtual environment later, run `deactivate` (same on Linux and Windows).
@@ -171,7 +178,7 @@ pip install cmake~=3.17
 
 **Windows**
 
-```sh
+```PowerShell
 pip install cmake~=3.17
 ```
 
@@ -189,11 +196,39 @@ pip install conan~=2.2 --upgrade
 conan profile detect
 ```
 
+The detected profile is displayed, along with some `WARN` messages.
+For example, the following profile has been tested.
+
+```ini
+[settings]
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.cppstd=gnu17
+compiler.libcxx=libstdc++11
+compiler.version=13
+os=Linux
+```
+
 **Windows**
 
-```sh
+```PowerShell
 pip install conan~=2.2 --upgrade
 conan profile detect
+```
+
+The detected profile is displayed, along with some `WARN` messages.
+For example, the following profile has been tested.
+
+```ini
+[settings]
+arch=x86_64
+build_type=Release
+compiler=msvc
+compiler.cppstd=14
+compiler.runtime=dynamic
+compiler.version=193
+os=Windows
 ```
 
 ## Building the NvNmos Library
@@ -244,7 +279,7 @@ cmake --build build --parallel
 
 Prepare a _build_ directory adjacent to the _src_ directory.
 
-```sh
+```PowerShell
 mkdir build
 ```
 
@@ -271,7 +306,7 @@ Use the following CMake command to configure the build.
 ```PowerShell
 cmake -B build `
   -G "Visual Studio 17 2022" `
-  -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake `
+  -DCMAKE_TOOLCHAIN_FILE="conan/conan_toolchain.cmake" `
   -DCMAKE_CONFIGURATION_TYPES="Debug;Release" `
   src
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
- SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,7 +46,7 @@ The NvNmos library supports the following specifications, using the [Sony nmos-c
 The library is intended to be portable to different environments.
 The following operating systems and compilers have been tested.
 
-* Ubuntu 22.04 with GCC 11
+* Ubuntu 24.04 with GCC 13
 * Windows 10 with Visual Studio 2022
 
 ## Usage
@@ -68,7 +68,7 @@ The package can then be copied directly to the host system.
 
 ```sh
 docker create --name nvnmos-test nvnmos
-docker cp nvnmos-test:/nvnmos-ubuntu-22.04.tar.gz .
+docker cp nvnmos-test:/nvnmos-ubuntu-24.04.tar.gz .
 docker rm nvnmos-test
 ```
 
@@ -84,101 +84,115 @@ The following build arguments are available.
 
 | Argument | Explanation |
 | --- | --- |
-| BASE_IMAGE | Controls the base container image and therefore the compatibility of the created package. Default is `ubuntu:22.04`. | 
-| PACKAGE_SUFFIX | Controls the package filename, which will be _nvnmos\<suffix\>.tar.gz_. Default is based on the base image, e.g. `-ubuntu-22.04`. |
+| BASE_IMAGE | Controls the base container image and therefore the compatibility of the created package. Default is `ubuntu:24.04`. | 
+| PACKAGE_SUFFIX | Controls the package filename, which will be _nvnmos\<suffix\>.tar.gz_. Default is based on the base image, e.g. `-ubuntu-24.04`. |
 | USE_CONAN_LOCK | Controls whether the _conan.lock_ file is used to ensure reproducible dependencies, even when new versions are available. Default is `1` (on). |
 
 If this isn't sufficient for your purposes, read on for manual build instructions.
 
 ## Pre-Build Requirements
 
-### Python Package Installer
+### Python
 
 Having Python 3 isn't an absolute requirement but it makes the subsequent steps to install the dependencies easier.
 
 **Linux**
 
-Use the system package manager to install Python 3 and the [Package Installer for Python (pip)](https://pypi.org/project/pip/).
+Use the system package manager to install Python 3 and the `venv` module (on Debian and Ubuntu the package is `python3-venv`). A system-wide `python3-pip` install is optional if you follow the recommended virtual environment below: the virtual environment gets its own `pip`, which avoids touching the distribution's managed environment (PEP 668).
 
 > 💬 **Note:**
 > The `-y` option allows `apt install` to run non-interactively.
 
 ```sh
-sudo apt install -y python3-pip
-
-pip3 install --upgrade pip
+sudo apt install -y python3 python3-venv
 ```
 
 **Windows**
 
-Download the Python 3 installer and run it manually or use the following PowerShell script.
+Download the Python 3 installer from [python.org](https://www.python.org/downloads/windows/) and run it manually, or use the following PowerShell script.
+Python 3.14.4 (64-bit Windows, latest stable release at the time) has been tested.
 
 > 💬 **Note:**
 > The `` ` `` is the PowerShell line continuation character.
 
 ```PowerShell
 Invoke-WebRequest `
-  https://www.python.org/ftp/python/3.10.9/python-3.10.9-amd64.exe `
-  -OutFile python-3.10.9-amd64.exe
+  https://www.python.org/ftp/python/3.14.4/python-3.14.4-amd64.exe `
+  -OutFile python-3.14.4-amd64.exe
 
-./python-3.10.9-amd64.exe /quiet PrependPath=1 Include_tcltk=0 Include_test=0
-
-pip3 install --upgrade pip
+./python-3.14.4-amd64.exe /quiet PrependPath=1 Include_tcltk=0 Include_test=0
 ```
+
+Close and reopen the terminal (or log off and on) so `PATH` picks up the new Python install, then use a virtual environment as below.
+
+### Python Virtual Environment
+
+For manual builds, a **virtual environment** in the repository root (for example, `.venv`) is recommended. It isolates the Python environment used for Conan and other `pip`-installed build tools from the system interpreter, pins compatible tool versions on `PATH`, and on Linux avoids PEP 668 "externally managed" errors when using the system Python.
+
+**Linux**
+
+```sh
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+```
+
+**Windows**
+
+From PowerShell, use the following command.
+
+```sh
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install --upgrade pip
+```
+
+Or use Command Prompt instead.
+
+```sh
+python -m venv .venv
+.\.venv\Scripts\activate.bat
+pip install --upgrade pip
+```
+
+To exit the virtual environment later, run `deactivate` (same on Linux and Windows).
 
 ### CMake
 
-The project requires CMake 3.17 or higher. (The system-provided CMake 3.10 on the Jetson is not sufficient.)
+The project requires CMake 3.17 or higher; dependencies may require a higher version.
 
 There are x86_64 and arm64 packages for CMake 3.30.0 on the [Python Package Index (PyPI)](https://pypi.org/) which have been tested.
 
 **Linux**
 
 ```sh
-pip3 install cmake~=3.17
+pip install cmake~=3.17
 ```
-
-> 💬 **Note:**
-> Using `sudo` would overwrite an existing CMake package in _/usr/local/bin_.
-> Avoiding this is recommended; without `sudo` the installer puts binaries in a per-user directory, _/home/\<userid\>/.local/bin_.
-> On the Jetson, this isn't in the user's `PATH` by default.
-> To add it for the current session, use the following command.
-> Replace `<userid>` with the necessary value.
->
-> ```sh
-> export PATH=/home/<userid>/.local/bin:${PATH}
-> ```
 
 **Windows**
 
 ```sh
-pip3 install cmake~=3.17
+pip install cmake~=3.17
 ```
 
 ### Conan
 
 Using [Conan](https://conan.io/) simplifies fetching, building, and installing the required C++ dependencies from [Conan Center](https://conan.io/center/).
 
-The project requires Conan 2.2 or higher. Conan 2.5.0 has been tested.
+The project requires Conan 2.2 or higher; dependencies may require a higher version.
+Conan 2.28.0 (latest release at the time) has been tested.
 
 **Linux**
 
 ```sh
-pip3 install conan~=2.2 --upgrade
+pip install conan~=2.2 --upgrade
 conan profile detect
 ```
-
-> 💬 **Note:**
-> As per the CMake instructions, on the Jetson a warning is reported that the per-user install directory _/home/\<userid\>/.local/bin_ is not on the `PATH` if it hasn't yet been added.
-
-> On some platforms with Python 2 and Python 3 both installed this may need to be `pip3 install --upgrade conan~=2.2`
-
-> Conan 2.2 or higher is required; dependencies may require a higher version; version 2.5.0 (latest release at the time) has been tested
 
 **Windows**
 
 ```sh
-pip3 install conan~=2.2 --upgrade
+pip install conan~=2.2 --upgrade
 conan profile detect
 ```
 
@@ -196,19 +210,22 @@ To install the dependencies using Conan, use the following command.
 
 > 💬 **Note:**
 > Replace `<Release-or-Debug>` with the necessary value.
+> Passing `--lockfile=src/conan.lock` pins dependency versions per _src/conan.lock_, matching the default _Dockerfile_ and GitHub Actions behaviour.
 
 ```sh
 conan install src \
   -g CMakeToolchain \
   --settings:all build_type=<Release-or-Debug> \
   --build=missing \
-  --output-folder=src/conan
+  --output-folder=src/conan \
+  --lockfile=src/conan.lock
 ```
 
 Use the following CMake command to configure the build.
 
 > 💬 **Note:**
 > Replace `<Release-or-Debug>` with the necessary value.
+> The `CMAKE_TOOLCHAIN_FILE` path is resolved relative to the top-level _src_ directory passed as the last argument.
 
 ```sh
 cmake -B build \
@@ -236,13 +253,15 @@ To install the dependencies using Conan, use the following command.
 > 💬 **Note:**
 > The `` ` `` is the PowerShell line continuation character. In the Windows command prompt, use `^` instead.
 > Replace `<Release-or-Debug>` with the necessary value.
+> Passing `--lockfile=src/conan.lock` pins dependency versions per _src/conan.lock_, matching the default _Dockerfile_ and GitHub Actions behaviour.
 
 ```PowerShell
 conan install src `
   -g CMakeToolchain `
   --settings:all build_type=<Release-or-Debug> `
   --build=missing `
-  --output-folder=src/conan
+  --output-folder=src/conan `
+  --lockfile=src/conan.lock
 ```
 
 Repeat the command for both `Debug` and `Release` if required.
@@ -268,7 +287,7 @@ cmake --build build --config <Release-or-Debug> --parallel
 
 ## Run-Time Requirements
 
-*Linux*
+**Linux**
 
 Install and run the Avahi Daemon.
 
@@ -283,7 +302,7 @@ apt install -y dbus avahi-daemon
 > 💬 **Note:**
 > Since Ubuntu 24.04, an init script is not provided for the Avahi daemon; run `avahi-daemon --daemonize` instead.
 
-*Windows*
+**Windows**
 
 Install and start the Bonjour Service.
 


### PR DESCRIPTION
In this MR:
- Update README to recommend venv, and update to Ubuntu 24.04 by default
- Add scheduled Conan canary build workflow without lockfile
- Add .gitignore for Python venv and build artifacts
- Update GitHub Actions (fixes deprecation warning)

To follow:
- Test new **Canary build** workflow and updated **Pages** workflow
- Regenerate merged Conan lockfile to minimize local builds on Ubuntu 24.04
- Update OpenSSL version to 3.6.2 in conan.lock and conanfile.py
