### PR TITLE
Add MXL transport support (BCP-007-03 v1.0-dev)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
+
+      # DO NOT MERGE: build against jonathan-r-thorpe/nmos-cpp branch
+      # nmos-mxl-test until https://github.com/sony/nmos-cpp/pull/483
+      # is merged and a Conan Center release is published.
+      - name: Clone nmos-cpp alongside nvnmos
+        run: |
+          parent="$(dirname "${GITHUB_WORKSPACE}")"
+          git clone --depth 1 --branch nmos-mxl-test \
+            https://github.com/jonathan-r-thorpe/nmos-cpp.git \
+            "${parent}/nmos-cpp"
+
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
       - name: Install dependencies
@@ -29,13 +40,15 @@ jobs:
             --settings:all build_type=${{ matrix.config }} \
             --build=missing \
             --output-folder=src/conan \
-            --lockfile=src/conan.lock
+            --lockfile="" \
+            -o "&:nmos_cpp_from_source=True"
       - name: Generate nvnmos (Linux)
         if: runner.os == 'Linux'
         run: |
           cmake -B build \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.config }} \
+            -DUSE_ADD_SUBDIRECTORY=ON \
             src
       - name: Generate nvnmos (Windows)
         if: runner.os == 'Windows'
@@ -43,15 +56,17 @@ jobs:
           cmake -B build \
             -DCMAKE_TOOLCHAIN_FILE=conan/conan_toolchain.cmake \
             -DCMAKE_CONFIGURATION_TYPES=${{ matrix.config }} \
+            -DUSE_ADD_SUBDIRECTORY=ON \
             src
       - name: Build nvnmos (Linux)
         if: runner.os == 'Linux'
         run: |
-          cmake --build build --parallel
+          # default -j$(nproc) causes out of memory on hosted runners (cc1plus killed).
+          cmake --build build --parallel 2
       - name: Build nvnmos (Windows)
         if: runner.os == 'Windows'
         run: |
-          cmake --build build --config=${{ matrix.config }} --parallel
+          cmake --build build --config=${{ matrix.config }} --parallel 2
   license-check:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # DO NOT MERGE: build against jonathan-r-thorpe/nmos-cpp branch
-      # nmos-mxl-test until https://github.com/sony/nmos-cpp/pull/483
-      # is merged and a Conan Center release is published.
+      # build against a https://github.com/sony/nmos-cpp commit
+      # until a Conan Center release of nmos-cpp is published.
       - name: Clone nmos-cpp alongside nvnmos
+        env:
+          NMOS_CPP_REF: a8874989a7c40cb01d38cd19388af3f329e1421d
         run: |
           parent="$(dirname "${GITHUB_WORKSPACE}")"
-          git clone --depth 1 --branch nmos-mxl-test \
-            https://github.com/jonathan-r-thorpe/nmos-cpp.git \
-            "${parent}/nmos-cpp"
+          git init "${parent}/nmos-cpp"
+          git -C "${parent}/nmos-cpp" remote add origin https://github.com/sony/nmos-cpp.git
+          git -C "${parent}/nmos-cpp" fetch --depth 1 origin "${NMOS_CPP_REF}"
+          git -C "${parent}/nmos-cpp" checkout FETCH_HEAD
 
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect

--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,5 @@
 CMakeUserPresets.json
 
 # Local Conan + CMake output (README layout)
-build/
-src/conan/
+build*/
+src/conan*/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Each `NvNmosSenderConfig` and `NvNmosReceiverConfig` includes a `transport` fiel
 | `NVNMOS_TRANSPORT_RTP`  | Session Description Protocol (SDP) per SMPTE ST 2110 / IETF RFCs     | RFC 4566   |
 | `NVNMOS_TRANSPORT_MXL`  | MXL flow definition (JSON) as consumed by the MXL SDK                | MXL SDK    |
 
-### NvNmos extensions to the transport file
+### NvNmos Extensions to the Transport File
 
 NvNmos uses a small set of extensions in the transport file to convey configuration that the standard transport file format does not carry. The same conceptual extensions are carried differently in the two transport file formats:
 
@@ -97,9 +97,46 @@ NvNmos also publishes the `urn:x-nvnmos:tag:name` tag on the corresponding NMOS 
 
 For MXL Senders, the top-level `id` field of the flow definition (if present, a UUID) is used as the MXL flow identity (i.e. the `mxl_flow_id` IS-05 transport parameter); if absent, the generated NMOS Flow id is used in its place. The NMOS Flow id itself is always derived from the `seed` and the name (`urn:x-nvnmos:tag:name` value) and is independent of the flow definition's `id` field. For MXL Receivers, the MXL flow identity is supplied dynamically through IS-05 Connection Management, so the `id` field of the flow definition is ignored.
 
-### Connection activations
+### Connection Activations
 
 When an IS-05 Connection API activation occurs, the library invokes the application's `connection_activated` callback with an `NvNmosSide` (Sender or Receiver), the application's `name`, and an updated `transport_file` reflecting the new active transport parameters. For an RTP Sender or Receiver, the callback receives an SDP file; for an MXL Sender or Receiver, the callback receives an MXL flow definition (JSON) with the new active `mxl_domain_id` and `mxl_flow_id` spliced in (as the `urn:x-nvnmos:tag:mxl-domain-id` tag value and the top-level `id` field, respectively). The application is expected to dispatch on `(side, name)` to identify the Sender or Receiver and react accordingly (for example, by reconfiguring its data plane). Conversely, if an activation (or deactivation) has already occurred in the application's data plane by some other means, outside the NMOS API, the application calls `nmos_connection_activate` (also passing the `side`) to update the IS-04 and IS-05 model to reflect it. The library does not initiate any activation on the application's behalf.
+
+## API Changes for MXL Support
+
+Existing application code needs to be updated as itemised below - mostly possible with search-and-replace.
+
+### Configuration Changes
+
+- `NvNmosSenderConfig::sdp` and `NvNmosReceiverConfig::sdp` (`const char *`) are now `NvNmosSenderConfig::transport_file` and `NvNmosReceiverConfig::transport_file`. A new sibling `NvNmosTransport transport` field selects the format: `NVNMOS_TRANSPORT_RTP` for SDP (the zero-initialised default), `NVNMOS_TRANSPORT_MXL` for an MXL flow definition (JSON).
+- The SDP identity attribute `a=x-nvnmos-id:<id>` is now `a=x-nvnmos-name:<name>` — renamed for clarity, since its value has always been the caller-chosen name (unique within the Node), not a UUID. The NMOS resource UUIDs are generated deterministically by the library from `NvNmosNodeConfig::seed` + name and are now also exposed via the new ID accessors below.
+- `remove_nmos_sender_from_node_server` and `remove_nmos_receiver_from_node_server` now take a caller-chosen name (`sender_name` / `receiver_name`) instead of a UUID.
+
+### Activation Changes
+
+- The IS-05 activation callback typedef `nmos_connection_rtp_activation_callback` is now `nmos_connection_activation_callback`, and its signature changed from `(server, id, sdp)` to `(server, side, name, transport_file)`. The matching `NvNmosNodeConfig::rtp_connection_activated` field is now `connection_activated`. The new `NvNmosSide` parameter (`NVNMOS_SIDE_SENDER` / `NVNMOS_SIDE_RECEIVER`) disambiguates a name that may now be shared between a Sender and a Receiver on the same Node — names are scoped per side.
+- `nmos_connection_rtp_activate(server, id, sdp)` is now `nmos_connection_activate(server, side, name, transport_file)`.
+
+### New ID-Accessors
+
+The NMOS resource UUIDs are deterministic pure functions of `(seed, side, name)`. Three pure accessors compute them without a server:
+
+- `nmos_make_node_id(seed, out, out_len)`
+- `nmos_make_sender_id(seed, sender_name, out, out_len)`
+- `nmos_make_receiver_id(seed, receiver_name, out, out_len)`
+
+Three live accessors look them up on a running server:
+
+- `nmos_get_node_id(server, out, out_len)`
+- `nmos_get_sender_id(server, sender_name, out, out_len)`
+- `nmos_get_receiver_id(server, receiver_name, out, out_len)`
+
+All write a null-terminated UUID into a buffer of at least `NVNMOS_ID_LEN` bytes (37, including the terminator). Each returns `bool`.
+
+### MXL Transport File Format
+
+For `NVNMOS_TRANSPORT_MXL` the transport file is an MXL flow definition JSON (the form consumed by the MXL SDK), with NvNmos extensions carried as entries in the standard `tags` property keyed by `urn:x-nvnmos:tag:*` URN strings. See *NvNmos Extensions to the Transport File* above for the full set.
+
+For the full per-field documentation see [`src/nvnmos.h`](src/nvnmos.h).
 
 ## Docker-Based Build
 
@@ -365,7 +402,7 @@ Build the library and application with the following command or manually using t
 cmake --build build --config <Release-or-Debug> --parallel
 ```
 
-### Local `nmos-cpp` checkout (Conan for dependencies only)
+### Local nmos-cpp Checkout (Conan for Dependencies Only)
 
 To build against a clone of [nmos-cpp](https://github.com/sony/nmos-cpp) while using Conan to resolve Boost, cpprestsdk, Avahi or mDNSResponder, and other dependencies:
 
@@ -475,7 +512,7 @@ http://<host-address>:<port>/
 
 ## Troubleshooting
 
-### Address already in use
+### Address Already in Use
 
 When running multiple NMOS Node instances, each process must be configured to use different ports, i.e., with a unique `port` value.
 When the port is already in use, at start-up, the application may show a message like the following:
@@ -484,7 +521,7 @@ When the port is already in use, at start-up, the application may show a message
 asio listen error: system:98 (Address already in use)
 ```
 
-### Apple Bonjour compatibility warnings
+### Apple Bonjour Compatibility Warnings
 
 When using Avahi for DNS-SD, shortly after start-up the following lines may be displayed in the log.
 They do not indicate a problem and can be ignored.
@@ -495,7 +532,7 @@ They do not indicate a problem and can be ignored.
 *** WARNING *** For more information see <http://0pointer.de/blog/projects/avahi-compat.html>
 ```
 
-### DNSServiceRegister and DNSServiceBrowse errors
+### DNSServiceRegister and DNSServiceBrowse Errors
 
 The application may show messages like the following shortly after start-up:
 

--- a/README.md
+++ b/README.md
@@ -69,24 +69,37 @@ Each `NvNmosSenderConfig` and `NvNmosReceiverConfig` includes a `transport` fiel
 
 ### NvNmos extensions to the transport file
 
-NvNmos uses a small set of `x-nvnmos-*` extensions in the transport file to convey configuration that the standard transport file format does not carry. In some cases, the same names are used as an SDP attribute (e.g. `a=x-nvnmos-id:<value>`) for RTP and as a top-level JSON property (e.g. `"x-nvnmos-id": "<value>"`) for MXL flow definitions.
+NvNmos uses a small set of extensions in the transport file to convey configuration that the standard transport file format does not carry. The same conceptual extensions are carried differently in the two transport file formats:
 
-| Extension                  | Where                            | Meaning                                                                                                                |
-| ---                        | ---                              | ---                                                                                                                    |
-| `x-nvnmos-id`              | Senders and Receivers (required) | The application's unique identifier for the Sender or Receiver, used in all NvNmos API callbacks                       |
-| `x-nvnmos-group-hint`      | Senders and Receivers (RTP only) | A group hint tag advertised via `urn:x-nmos:tag:grouphint/v1.0`                                                        |
-| `x-nvnmos-caps`            | Receivers (optional)             | If present, suppress format-derived Receiver Capabilities so the Receiver advertises a more permissive profile         |
-| `x-nvnmos-iface-ip`        | Receivers (RTP only)             | The interface IP address on which the stream is received                                                               |
-| `x-nvnmos-src-port`        | Senders (RTP only)               | The source port from which the stream is transmitted                                                                   |
-| `x-nvnmos-mxl-domain-id`   | Senders and Receivers (MXL only, required) | The MXL domain identity (UUID) for the Sender or Receiver; the IS-05 `mxl_domain_id` transport parameter defaults to `"auto"` and is resolved at activation time from this value |
+- For RTP (SDP), as custom `a=x-nvnmos-*:<value>` attributes.
+- For MXL flow definitions (JSON), as entries in the standard `tags` property keyed by `urn:x-nvnmos:tag:*` URN strings. The tag's value is an array of strings; the first element is used.
 
-For MXL Senders and Receivers, a group hint tag is conveyed using the standard NMOS tag `urn:x-nmos:tag:grouphint/v1.0` in the flow definition's `tags` object (the first entry of the array, if present, is used). The SDP-only `x-nvnmos-group-hint` attribute exists because SDP has no native equivalent.
+| Concept                  | SDP attribute (RTP)        | MXL flow_def tag key (MXL)              | Applies to                                | Description                                                                                                                |
+| ---                      | ---                        | ---                                     | ---                                       | ---                                                                                                                        |
+| Internal id              | `a=x-nvnmos-id:<v>`        | `urn:x-nvnmos:tag:id`                   | Senders and Receivers (required)          | The application's unique identifier for the Sender or Receiver, used in all NvNmos API callbacks                           |
+| Group hint               | `a=x-nvnmos-group-hint:<v>`| standard `urn:x-nmos:tag:grouphint/v1.0`| Senders and Receivers (optional)          | A group hint tag advertised via `urn:x-nmos:tag:grouphint/v1.0` on the NMOS resource                                       |
+| Suppress narrow Receiver Caps | `a=x-nvnmos-caps:<v>` (media-level) | `urn:x-nvnmos:tag:caps` | Receivers (optional) | An empty string value selects a fully-flexible Receiver, with format-derived Capabilities omitted. Non-empty strings are reserved for future capability; today any value is treated the same.                                                                                                                                  |
+| Interface IP             | `a=x-nvnmos-iface-ip:<v>`  | n/a                                     | Receivers (RTP only)                      | The interface IP address on which the stream is received                                                                   |
+| Source port              | `a=x-nvnmos-src-port:<v>`  | n/a                                     | Senders (RTP only)                        | The source port from which the stream is transmitted                                                                       |
+| MXL domain id            | n/a                        | `urn:x-nvnmos:tag:mxl-domain-id`        | Senders and Receivers (MXL only, required)| The MXL domain identity (UUID) for the Sender or Receiver; the IS-05 `mxl_domain_id` transport parameter defaults to `"auto"` and is resolved at activation time from this value |
 
-For MXL Senders, the top-level `id` field of the flow definition (if present, a UUID) is used as the MXL flow identity (i.e. the `mxl_flow_id` IS-05 transport parameter); if absent, the generated NMOS Flow id is used in its place. The NMOS Flow id itself is always derived from the `seed` and `x-nvnmos-id` and is independent of the flow definition's `id` field. For MXL Receivers, the MXL flow identity is supplied dynamically through IS-05 Connection Management, so the `id` field of the flow definition is ignored.
+For an MXL flow definition, the tag entries are stored alongside (and follow the same shape as) the standard `urn:x-nmos:tag:grouphint/v1.0` tag, e.g.:
+
+```json
+"tags": {
+  "urn:x-nmos:tag:grouphint/v1.0": [ "video-sender-1:Video" ],
+  "urn:x-nvnmos:tag:id": [ "video-sender-1" ],
+  "urn:x-nvnmos:tag:mxl-domain-id": [ "1ac254d9-c9be-475a-93a7-f80b9c1063a8" ]
+}
+```
+
+NvNmos also publishes the `urn:x-nvnmos:tag:id` tag on the corresponding NMOS resources (visible to controllers via IS-04), so the URN is shared between the two artifacts.
+
+For MXL Senders, the top-level `id` field of the flow definition (if present, a UUID) is used as the MXL flow identity (i.e. the `mxl_flow_id` IS-05 transport parameter); if absent, the generated NMOS Flow id is used in its place. The NMOS Flow id itself is always derived from the `seed` and the internal id (`urn:x-nvnmos:tag:id` value) and is independent of the flow definition's `id` field. For MXL Receivers, the MXL flow identity is supplied dynamically through IS-05 Connection Management, so the `id` field of the flow definition is ignored.
 
 ### Connection activations
 
-When an IS-05 Connection API activation occurs, the library invokes the application's `connection_activated` callback with the application's `id` and an updated `transport_file` reflecting the new active transport parameters. For an RTP Sender or Receiver, the callback receives an SDP file; for an MXL Sender or Receiver, the callback receives an MXL flow definition (JSON) with the new active `mxl_domain_id` and `mxl_flow_id` spliced in (as `x-nvnmos-mxl-domain-id` and the top-level `id`, respectively). The application is expected to dispatch on `id` to identify the Sender or Receiver and react accordingly (for example, by reconfiguring its data plane). Conversely, if an activation (or deactivation) has already occurred in the application's data plane by some other means, outside the NMOS API, the application calls `nmos_connection_activate` to update the IS-04 and IS-05 model to reflect it. The library does not initiate any activation on the application's behalf.
+When an IS-05 Connection API activation occurs, the library invokes the application's `connection_activated` callback with the application's `id` and an updated `transport_file` reflecting the new active transport parameters. For an RTP Sender or Receiver, the callback receives an SDP file; for an MXL Sender or Receiver, the callback receives an MXL flow definition (JSON) with the new active `mxl_domain_id` and `mxl_flow_id` spliced in (as the `urn:x-nvnmos:tag:mxl-domain-id` tag value and the top-level `id` field, respectively). The application is expected to dispatch on `id` to identify the Sender or Receiver and react accordingly (for example, by reconfiguring its data plane). Conversely, if an activation (or deactivation) has already occurred in the application's data plane by some other means, outside the NMOS API, the application calls `nmos_connection_activate` to update the IS-04 and IS-05 model to reflect it. The library does not initiate any activation on the application's behalf.
 
 ## Docker-Based Build
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,19 @@ The library can automatically discover and register with an NMOS Registry on the
 The library provides callbacks for NMOS events such as [AMWA IS-05](https://specs.amwa.tv/is-05/) Connection API requests from an NMOS Controller.
 These callbacks can be used to update running DeepStream pipelines with new transport parameters, for example.
 
-NvNmos currently supports Senders and Receivers for uncompressed Video and Audio, i.e., SMPTE ST 2110-20 and SMPTE ST 2110-30 streams.
+NvNmos currently supports Senders and Receivers for video, audio, and ancillary data flows over RTP (i.e., SMPTE ST 2110-20, -22, -30, and -40 streams) and over the Media eXchange Layer (MXL).
 
 The NvNmos library supports the following specifications, using the [Sony nmos-cpp](https://github.com/sony/nmos-cpp) implementation internally:
 - [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04/) v1.3
-- [AMWA IS-05 NMOS Device Connection Management Specification](https://specs.amwa.tv/is-05/) v1.1
+- [AMWA IS-05 NMOS Device Connection Management Specification](https://specs.amwa.tv/is-05/) v1.1 and v1.2-dev (for MXL)
 - [AMWA IS-09 NMOS System Parameters Specification](https://specs.amwa.tv/is-09/) v1.0
 - [AMWA BCP-002-01 Natural Grouping of NMOS Resources](https://specs.amwa.tv/bcp-002-01/) v1.0
 - [AMWA BCP-002-02 NMOS Asset Distinguishing Information](https://specs.amwa.tv/bcp-002-02/) v1.0
 - [AMWA BCP-004-01 NMOS Receiver Capabilities](https://specs.amwa.tv/bcp-004-01/) v1.0
 - [AMWA BCP-006-01 NMOS With JPEG XS](https://specs.amwa.tv/bcp-006-01/) v1.0
+- [AMWA BCP-007-03 NMOS With MXL](https://specs.amwa.tv/bcp-007-03/) v1.0-dev
 - Session Description Protocol conforming to SMPTE ST 2110-20, -22, -30, -40, and ST 2022-7
+- MXL flow definition JSON as consumed by the [MXL SDK](https://github.com/dmf-mxl/mxl)
 
 ## Supported Platforms
 
@@ -55,6 +57,36 @@ NvNmos consists of a single shared library (_libnvnmos.so_ on Linux, _nvnmos.dll
 The API is specified by the _nvnmos.h_ header file.
 
 The nvnmos-example application demonstrates use of the library.
+
+### Transports
+
+Each `NvNmosSenderConfig` and `NvNmosReceiverConfig` includes a `transport` field (an `NvNmosTransport` enum) that selects the transport. A zero-initialised configuration defaults to RTP. The `transport_file` field then holds the transport file as the appropriate text:
+
+| `transport`             | `transport_file` format                                              | Reference  |
+| ---                     | ---                                                                  | ---        |
+| `NVNMOS_TRANSPORT_RTP`  | Session Description Protocol (SDP) per SMPTE ST 2110 / IETF RFCs     | RFC 4566   |
+| `NVNMOS_TRANSPORT_MXL`  | MXL flow definition (JSON) as consumed by the MXL SDK                | MXL SDK    |
+
+### NvNmos extensions to the transport file
+
+NvNmos uses a small set of `x-nvnmos-*` extensions in the transport file to convey configuration that the standard transport file format does not carry. In some cases, the same names are used as an SDP attribute (e.g. `a=x-nvnmos-id:<value>`) for RTP and as a top-level JSON property (e.g. `"x-nvnmos-id": "<value>"`) for MXL flow definitions.
+
+| Extension                  | Where                            | Meaning                                                                                                                |
+| ---                        | ---                              | ---                                                                                                                    |
+| `x-nvnmos-id`              | Senders and Receivers (required) | The application's unique identifier for the Sender or Receiver, used in all NvNmos API callbacks                       |
+| `x-nvnmos-group-hint`      | Senders and Receivers (RTP only) | A group hint tag advertised via `urn:x-nmos:tag:grouphint/v1.0`                                                        |
+| `x-nvnmos-caps`            | Receivers (optional)             | If present, suppress format-derived Receiver Capabilities so the Receiver advertises a more permissive profile         |
+| `x-nvnmos-iface-ip`        | Receivers (RTP only)             | The interface IP address on which the stream is received                                                               |
+| `x-nvnmos-src-port`        | Senders (RTP only)               | The source port from which the stream is transmitted                                                                   |
+| `x-nvnmos-mxl-domain-id`   | Senders and Receivers (MXL only, required) | The MXL domain identity (UUID) for the Sender or Receiver; the IS-05 `mxl_domain_id` transport parameter defaults to `"auto"` and is resolved at activation time from this value |
+
+For MXL Senders and Receivers, a group hint tag is conveyed using the standard NMOS tag `urn:x-nmos:tag:grouphint/v1.0` in the flow definition's `tags` object (the first entry of the array, if present, is used). The SDP-only `x-nvnmos-group-hint` attribute exists because SDP has no native equivalent.
+
+For MXL Senders, the top-level `id` field of the flow definition (if present, a UUID) is used as the MXL flow identity (i.e. the `mxl_flow_id` IS-05 transport parameter); if absent, the generated NMOS Flow id is used in its place. The NMOS Flow id itself is always derived from the `seed` and `x-nvnmos-id` and is independent of the flow definition's `id` field. For MXL Receivers, the MXL flow identity is supplied dynamically through IS-05 Connection Management, so the `id` field of the flow definition is ignored.
+
+### Connection activations
+
+When an IS-05 Connection API activation occurs, the library invokes the application's `connection_activated` callback with the application's `id` and an updated `transport_file` reflecting the new active transport parameters. For an RTP Sender or Receiver, the callback receives an SDP file; for an MXL Sender or Receiver, the callback receives an MXL flow definition (JSON) with the new active `mxl_domain_id` and `mxl_flow_id` spliced in (as `x-nvnmos-mxl-domain-id` and the top-level `id`, respectively). The application is expected to dispatch on `id` to identify the Sender or Receiver and react accordingly (for example, by reconfiguring its data plane). Conversely, if an activation (or deactivation) has already occurred in the application's data plane by some other means, outside the NMOS API, the application calls `nmos_connection_activate` to update the IS-04 and IS-05 model to reflect it. The library does not initiate any activation on the application's behalf.
 
 ## Docker-Based Build
 
@@ -417,6 +449,8 @@ Continue ([y]/n)?
 
 If the app runs successfully to completion, the process exits with code 0.
 If any step fails, or the user responds negatively to a prompt, the process exits immediately with code 1.
+
+The example application also creates two MXL Senders and two MXL Receivers (uncompressed `video/v210` and `audio/float32`) and exercises the same add/remove/activate/deactivate cycle for them, alongside the RTP Senders and Receivers.
 
 ### Accessing the NMOS APIs
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NvNmos uses a small set of extensions in the transport file to convey configurat
 
 | Concept                  | SDP attribute (RTP)        | MXL flow_def tag key (MXL)              | Applies to                                | Description                                                                                                                |
 | ---                      | ---                        | ---                                     | ---                                       | ---                                                                                                                        |
-| Internal id              | `a=x-nvnmos-id:<v>`        | `urn:x-nvnmos:tag:id`                   | Senders and Receivers (required)          | The application's unique identifier for the Sender or Receiver, used in all NvNmos API callbacks                           |
+| Name                     | `a=x-nvnmos-name:<v>`      | `urn:x-nvnmos:tag:name`                 | Senders and Receivers (required)          | The application's caller-chosen name for the Sender or Receiver, unique within the Node for the given side (Sender or Receiver). A Sender and a Receiver may share the same name. Used in all NvNmos API callbacks (paired with the `NvNmosSide`) |
 | Group hint               | `a=x-nvnmos-group-hint:<v>`| standard `urn:x-nmos:tag:grouphint/v1.0`| Senders and Receivers (optional)          | A group hint tag advertised via `urn:x-nmos:tag:grouphint/v1.0` on the NMOS resource                                       |
 | Suppress narrow Receiver Caps | `a=x-nvnmos-caps:<v>` (media-level) | `urn:x-nvnmos:tag:caps` | Receivers (optional) | An empty string value selects a fully-flexible Receiver, with format-derived Capabilities omitted. Non-empty strings are reserved for future capability; today any value is treated the same.                                                                                                                                  |
 | Interface IP             | `a=x-nvnmos-iface-ip:<v>`  | n/a                                     | Receivers (RTP only)                      | The interface IP address on which the stream is received                                                                   |
@@ -88,18 +88,18 @@ For an MXL flow definition, the tag entries are stored alongside (and follow the
 ```json
 "tags": {
   "urn:x-nmos:tag:grouphint/v1.0": [ "video-sender-1:Video" ],
-  "urn:x-nvnmos:tag:id": [ "video-sender-1" ],
+  "urn:x-nvnmos:tag:name": [ "video-sender-1" ],
   "urn:x-nvnmos:tag:mxl-domain-id": [ "1ac254d9-c9be-475a-93a7-f80b9c1063a8" ]
 }
 ```
 
-NvNmos also publishes the `urn:x-nvnmos:tag:id` tag on the corresponding NMOS resources (visible to controllers via IS-04), so the URN is shared between the two artifacts.
+NvNmos also publishes the `urn:x-nvnmos:tag:name` tag on the corresponding NMOS resources (visible to controllers via IS-04), so the URN is shared between the two artifacts.
 
-For MXL Senders, the top-level `id` field of the flow definition (if present, a UUID) is used as the MXL flow identity (i.e. the `mxl_flow_id` IS-05 transport parameter); if absent, the generated NMOS Flow id is used in its place. The NMOS Flow id itself is always derived from the `seed` and the internal id (`urn:x-nvnmos:tag:id` value) and is independent of the flow definition's `id` field. For MXL Receivers, the MXL flow identity is supplied dynamically through IS-05 Connection Management, so the `id` field of the flow definition is ignored.
+For MXL Senders, the top-level `id` field of the flow definition (if present, a UUID) is used as the MXL flow identity (i.e. the `mxl_flow_id` IS-05 transport parameter); if absent, the generated NMOS Flow id is used in its place. The NMOS Flow id itself is always derived from the `seed` and the name (`urn:x-nvnmos:tag:name` value) and is independent of the flow definition's `id` field. For MXL Receivers, the MXL flow identity is supplied dynamically through IS-05 Connection Management, so the `id` field of the flow definition is ignored.
 
 ### Connection activations
 
-When an IS-05 Connection API activation occurs, the library invokes the application's `connection_activated` callback with the application's `id` and an updated `transport_file` reflecting the new active transport parameters. For an RTP Sender or Receiver, the callback receives an SDP file; for an MXL Sender or Receiver, the callback receives an MXL flow definition (JSON) with the new active `mxl_domain_id` and `mxl_flow_id` spliced in (as the `urn:x-nvnmos:tag:mxl-domain-id` tag value and the top-level `id` field, respectively). The application is expected to dispatch on `id` to identify the Sender or Receiver and react accordingly (for example, by reconfiguring its data plane). Conversely, if an activation (or deactivation) has already occurred in the application's data plane by some other means, outside the NMOS API, the application calls `nmos_connection_activate` to update the IS-04 and IS-05 model to reflect it. The library does not initiate any activation on the application's behalf.
+When an IS-05 Connection API activation occurs, the library invokes the application's `connection_activated` callback with an `NvNmosSide` (Sender or Receiver), the application's `name`, and an updated `transport_file` reflecting the new active transport parameters. For an RTP Sender or Receiver, the callback receives an SDP file; for an MXL Sender or Receiver, the callback receives an MXL flow definition (JSON) with the new active `mxl_domain_id` and `mxl_flow_id` spliced in (as the `urn:x-nvnmos:tag:mxl-domain-id` tag value and the top-level `id` field, respectively). The application is expected to dispatch on `(side, name)` to identify the Sender or Receiver and react accordingly (for example, by reconfiguring its data plane). Conversely, if an activation (or deactivation) has already occurred in the application's data plane by some other means, outside the NMOS API, the application calls `nmos_connection_activate` (also passing the `side`) to update the IS-04 and IS-05 model to reflect it. The library does not initiate any activation on the application's behalf.
 
 ## Docker-Based Build
 

--- a/src/main.c
+++ b/src/main.c
@@ -266,12 +266,14 @@ static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sende
     int result = snprintf(flow_def,
         flow_def_size,
         "{\n"
-        "  \"x-nvnmos-id\": \"%s\",\n"
-        "  \"x-nvnmos-mxl-domain-id\": \"%s\",\n"
         "  \"id\": \"%s\",\n"
         "  \"label\": \"%s\",\n"
         "  \"description\": \"" MXL_VIDEO_DESCRIPTION "\",\n"
-        "  \"tags\": { \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ] },\n"
+        "  \"tags\": {\n"
+        "    \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ],\n"
+        "    \"urn:x-nvnmos:tag:id\": [ \"%s\" ],\n"
+        "    \"urn:x-nvnmos:tag:mxl-domain-id\": [ \"%s\" ]\n"
+        "  },\n"
         "  \"format\": \"urn:x-nmos:format:video\",\n"
         "  \"media_type\": \"video/v210\",\n"
         "  \"grain_rate\": { \"numerator\": %d, \"denominator\": %d },\n"
@@ -286,11 +288,11 @@ static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sende
         "    { \"name\": \"Cr\", \"width\": %d, \"height\": %d, \"bit_depth\": 10 }\n"
         "  ]\n"
         "}\n",
-        id,
-        mxl_domain_id,
         mxl_flow_id,
         label,
         group_hint,
+        id,
+        mxl_domain_id,
         MXL_VIDEO_GRAIN_RATE_NUM, MXL_VIDEO_GRAIN_RATE_DEN,
         MXL_VIDEO_FRAME_WIDTH, MXL_VIDEO_FRAME_HEIGHT,
         MXL_VIDEO_FRAME_WIDTH, MXL_VIDEO_FRAME_HEIGHT,
@@ -307,23 +309,25 @@ static bool init_audio_flow_def(char* flow_def, size_t flow_def_size, bool sende
     int result = snprintf(flow_def,
         flow_def_size,
         "{\n"
-        "  \"x-nvnmos-id\": \"%s\",\n"
-        "  \"x-nvnmos-mxl-domain-id\": \"%s\",\n"
         "  \"id\": \"%s\",\n"
         "  \"label\": \"%s\",\n"
         "  \"description\": \"" MXL_AUDIO_DESCRIPTION "\",\n"
-        "  \"tags\": { \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ] },\n"
+        "  \"tags\": {\n"
+        "    \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ],\n"
+        "    \"urn:x-nvnmos:tag:id\": [ \"%s\" ],\n"
+        "    \"urn:x-nvnmos:tag:mxl-domain-id\": [ \"%s\" ]\n"
+        "  },\n"
         "  \"format\": \"urn:x-nmos:format:audio\",\n"
         "  \"media_type\": \"audio/float32\",\n"
         "  \"sample_rate\": { \"numerator\": 48000, \"denominator\": 1 },\n"
         "  \"channel_count\": %d,\n"
         "  \"bit_depth\": 32\n"
         "}\n",
-        id,
-        mxl_domain_id,
         mxl_flow_id,
         label,
         group_hint,
+        id,
+        mxl_domain_id,
         MXL_AUDIO_CHANNEL_COUNT
     );
 

--- a/src/main.c
+++ b/src/main.c
@@ -123,16 +123,18 @@ static void handle_log(
 
 static bool handle_connection_activated(
     NvNmosNodeServer *server,
-    const char *id,
+    NvNmosSide side,
+    const char *name,
     const char *transport_file)
 {
-    printf("%s %s\n", id, transport_file ? "activated via NMOS" : "deactivated via NMOS");
+    const char *type = side == NVNMOS_SIDE_SENDER ? "sender" : "receiver";
+    printf("%s %s %s\n", type, name, transport_file ? "activated via NMOS" : "deactivated via NMOS");
     if (server->user_data && transport_file) printf("%s\n", transport_file);
     return true;
 }
 
 // construct example SDP for video sender or receiver
-static bool init_video_sdp(char* sdp, size_t sdp_size, bool sender, const char* id, const char* interface_ip, const char* label, const char* group_hint)
+static bool init_video_sdp(char* sdp, size_t sdp_size, bool sender, const char* name, const char* interface_ip, const char* label, const char* group_hint)
 {
     const char* description = VIDEO_DESCRIPTION;
     const char* encoding = VIDEO_ENCODING_PARAMETERS;
@@ -158,7 +160,7 @@ static bool init_video_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
         "s=%s\r\n"
         "i=%s\r\n" // optional
         "t=0 0\r\n"
-        "a=x-nvnmos-id:%s\r\n"
+        "a=x-nvnmos-name:%s\r\n"
         "a=x-nvnmos-group-hint:%s\r\n" // optional
         "m=video %d RTP/AVP %d\r\n"
         "c=IN IP4 %s/64\r\n"
@@ -175,7 +177,7 @@ static bool init_video_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
         interface_ip,
         label,
         description,
-        id,
+        name,
         group_hint,
         destination_port,
         payload_type,
@@ -196,7 +198,7 @@ static bool init_video_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
 }
 
 // construct example SDP for audio sender or receiver
-static bool init_audio_sdp(char* sdp, size_t sdp_size, bool sender, const char* id, const char* interface_ip, const char* label, const char* group_hint)
+static bool init_audio_sdp(char* sdp, size_t sdp_size, bool sender, const char* name, const char* interface_ip, const char* label, const char* group_hint)
 {
     const char* description = AUDIO_DESCRIPTION;
     const char* encoding = AUDIO_ENCODING_PARAMETERS;
@@ -222,7 +224,7 @@ static bool init_audio_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
         "s=%s\r\n"
         "i=%s\r\n" // optional
         "t=0 0\r\n"
-        "a=x-nvnmos-id:%s\r\n"
+        "a=x-nvnmos-name:%s\r\n"
         "a=x-nvnmos-group-hint:%s\r\n" // optional
         "m=audio %d RTP/AVP %d\r\n"
         "c=IN IP4 %s/64\r\n"
@@ -239,7 +241,7 @@ static bool init_audio_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
         interface_ip,
         label,
         description,
-        id,
+        name,
         group_hint,
         destination_port,
         payload_type,
@@ -261,7 +263,7 @@ static bool init_audio_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
 
 // construct example MXL flow definition JSON for an uncompressed v210 video sender or receiver
 // see AMWA BCP-007-03 and the MXL library examples
-static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sender, const char* id, const char* mxl_domain_id, const char* mxl_flow_id, const char* label, const char* group_hint)
+static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sender, const char* name, const char* mxl_domain_id, const char* mxl_flow_id, const char* label, const char* group_hint)
 {
     int result = snprintf(flow_def,
         flow_def_size,
@@ -271,7 +273,7 @@ static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sende
         "  \"description\": \"" MXL_VIDEO_DESCRIPTION "\",\n"
         "  \"tags\": {\n"
         "    \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ],\n"
-        "    \"urn:x-nvnmos:tag:id\": [ \"%s\" ],\n"
+        "    \"urn:x-nvnmos:tag:name\": [ \"%s\" ],\n"
         "    \"urn:x-nvnmos:tag:mxl-domain-id\": [ \"%s\" ]\n"
         "  },\n"
         "  \"format\": \"urn:x-nmos:format:video\",\n"
@@ -291,7 +293,7 @@ static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sende
         mxl_flow_id,
         label,
         group_hint,
-        id,
+        name,
         mxl_domain_id,
         MXL_VIDEO_GRAIN_RATE_NUM, MXL_VIDEO_GRAIN_RATE_DEN,
         MXL_VIDEO_FRAME_WIDTH, MXL_VIDEO_FRAME_HEIGHT,
@@ -304,7 +306,7 @@ static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sende
 }
 
 // construct example MXL flow definition JSON for an audio/float32 sender or receiver
-static bool init_audio_flow_def(char* flow_def, size_t flow_def_size, bool sender, const char* id, const char* mxl_domain_id, const char* mxl_flow_id, const char* label, const char* group_hint)
+static bool init_audio_flow_def(char* flow_def, size_t flow_def_size, bool sender, const char* name, const char* mxl_domain_id, const char* mxl_flow_id, const char* label, const char* group_hint)
 {
     int result = snprintf(flow_def,
         flow_def_size,
@@ -314,7 +316,7 @@ static bool init_audio_flow_def(char* flow_def, size_t flow_def_size, bool sende
         "  \"description\": \"" MXL_AUDIO_DESCRIPTION "\",\n"
         "  \"tags\": {\n"
         "    \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ],\n"
-        "    \"urn:x-nvnmos:tag:id\": [ \"%s\" ],\n"
+        "    \"urn:x-nvnmos:tag:name\": [ \"%s\" ],\n"
         "    \"urn:x-nvnmos:tag:mxl-domain-id\": [ \"%s\" ]\n"
         "  },\n"
         "  \"format\": \"urn:x-nmos:format:audio\",\n"
@@ -326,7 +328,7 @@ static bool init_audio_flow_def(char* flow_def, size_t flow_def_size, bool sende
         mxl_flow_id,
         label,
         group_hint,
-        id,
+        name,
         mxl_domain_id,
         MXL_AUDIO_CHANNEL_COUNT
     );
@@ -344,13 +346,13 @@ static bool get_continue(void)
     return result;
 }
 
-static inline void print_id(const char *type, const char *internal_id, const char *value)
+static inline void print_id(const char *type, const char *name, const char *value)
 {
-    printf("  %-8s  %-12s  %s\n", type, internal_id, value);
+    printf("  %-8s  %-12s  %s\n", type, name, value);
 }
 
 // demonstrate the seed-only ID accessors: pure functions of the
-// node seed string and (for sender/receiver) the internal id; useful
+// node seed string and (for sender/receiver) the name; useful
 // for tooling that wants the NMOS IDs without standing up a server
 static void print_expected_ids(const char *seed)
 {
@@ -363,22 +365,22 @@ static void print_expected_ids(const char *seed)
         print_id("node", "", success ? id : "<error>");
     }
 
-    static const char *const sender_internal_ids[] = {
+    static const char *const sender_names[] = {
         "sink-0", "sink-1", "mxl-sink-0", "mxl-sink-1"
     };
-    for (size_t i = 0; i < sizeof sender_internal_ids / sizeof sender_internal_ids[0]; ++i)
+    for (size_t i = 0; i < sizeof sender_names / sizeof sender_names[0]; ++i)
     {
-        const bool success = nmos_make_sender_id(seed, sender_internal_ids[i], id, sizeof id);
-        print_id("sender", sender_internal_ids[i], success ? id : "<error>");
+        const bool success = nmos_make_sender_id(seed, sender_names[i], id, sizeof id);
+        print_id("sender", sender_names[i], success ? id : "<error>");
     }
 
-    static const char *const receiver_internal_ids[] = {
+    static const char *const receiver_names[] = {
         "source-0", "source-1", "mxl-source-0", "mxl-source-1"
     };
-    for (size_t i = 0; i < sizeof receiver_internal_ids / sizeof receiver_internal_ids[0]; ++i)
+    for (size_t i = 0; i < sizeof receiver_names / sizeof receiver_names[0]; ++i)
     {
-        const bool success = nmos_make_receiver_id(seed, receiver_internal_ids[i], id, sizeof id);
-        print_id("receiver", receiver_internal_ids[i], success ? id : "<error>");
+        const bool success = nmos_make_receiver_id(seed, receiver_names[i], id, sizeof id);
+        print_id("receiver", receiver_names[i], success ? id : "<error>");
     }
 }
 
@@ -396,22 +398,22 @@ static void print_actual_ids(const NvNmosNodeServer *server)
         print_id("node", "", success ? id : "<error>");
     }
 
-    static const char *const sender_internal_ids[] = {
+    static const char *const sender_names[] = {
         "sink-0", "sink-1", "mxl-sink-0", "mxl-sink-1"
     };
-    for (size_t i = 0; i < sizeof sender_internal_ids / sizeof sender_internal_ids[0]; ++i)
+    for (size_t i = 0; i < sizeof sender_names / sizeof sender_names[0]; ++i)
     {
-        const bool success = nmos_get_sender_id(server, sender_internal_ids[i], id, sizeof id);
-        print_id("sender", sender_internal_ids[i], success ? id : "<missing>");
+        const bool success = nmos_get_sender_id(server, sender_names[i], id, sizeof id);
+        print_id("sender", sender_names[i], success ? id : "<missing>");
     }
 
-    static const char *const receiver_internal_ids[] = {
+    static const char *const receiver_names[] = {
         "source-0", "source-1", "mxl-source-0", "mxl-source-1"
     };
-    for (size_t i = 0; i < sizeof receiver_internal_ids / sizeof receiver_internal_ids[0]; ++i)
+    for (size_t i = 0; i < sizeof receiver_names / sizeof receiver_names[0]; ++i)
     {
-        const bool success = nmos_get_receiver_id(server, receiver_internal_ids[i], id, sizeof id);
-        print_id("receiver", receiver_internal_ids[i], success ? id : "<missing>");
+        const bool success = nmos_get_receiver_id(server, receiver_names[i], id, sizeof id);
+        print_id("receiver", receiver_names[i], success ? id : "<missing>");
     }
 }
 
@@ -531,24 +533,24 @@ int main(int argc, char *argv[])
     if (!add_nmos_sender_to_node_server(&node_server, &sink_config[3])) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Activating senders and receivers...\n");
-    if (!nmos_connection_activate(&node_server, "source-0", source_config[0].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "source-1", source_config[1].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "sink-0", sink_config[0].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "sink-1", sink_config[1].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-source-0", source_config[2].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-source-1", source_config[3].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-sink-0", sink_config[2].transport_file)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-sink-1", sink_config[3].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "source-0", source_config[0].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "source-1", source_config[1].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "sink-0", sink_config[0].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "sink-1", sink_config[1].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "mxl-source-0", source_config[2].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "mxl-source-1", source_config[3].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "mxl-sink-0", sink_config[2].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "mxl-sink-1", sink_config[3].transport_file)) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Deactivating senders and receivers...\n");
-    if (!nmos_connection_activate(&node_server, "source-0", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "source-1", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "sink-0", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "sink-1", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-source-0", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-source-1", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-sink-0", 0)) goto cleanup;
-    if (!nmos_connection_activate(&node_server, "mxl-sink-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "source-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "source-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "sink-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "sink-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "mxl-source-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_RECEIVER, "mxl-source-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "mxl-sink-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, NVNMOS_SIDE_SENDER, "mxl-sink-1", 0)) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Destroying NvNmos server...\n");
     if (!destroy_nmos_node_server(&node_server)) return 1;

--- a/src/main.c
+++ b/src/main.c
@@ -340,6 +340,77 @@ static bool get_continue(void)
     return result;
 }
 
+static inline void print_id(const char *type, const char *internal_id, const char *value)
+{
+    printf("  %-8s  %-12s  %s\n", type, internal_id, value);
+}
+
+// demonstrate the seed-only ID accessors: pure functions of the
+// node seed string and (for sender/receiver) the internal id; useful
+// for tooling that wants the NMOS IDs without standing up a server
+static void print_expected_ids(const char *seed)
+{
+    char id[NVNMOS_ID_LEN];
+
+    printf("Expected NMOS IDs (computed from seed):\n");
+
+    {
+        const bool success = nmos_make_node_id(seed, id, sizeof id);
+        print_id("node", "", success ? id : "<error>");
+    }
+
+    static const char *const sender_internal_ids[] = {
+        "sink-0", "sink-1", "mxl-sink-0", "mxl-sink-1"
+    };
+    for (size_t i = 0; i < sizeof sender_internal_ids / sizeof sender_internal_ids[0]; ++i)
+    {
+        const bool success = nmos_make_sender_id(seed, sender_internal_ids[i], id, sizeof id);
+        print_id("sender", sender_internal_ids[i], success ? id : "<error>");
+    }
+
+    static const char *const receiver_internal_ids[] = {
+        "source-0", "source-1", "mxl-source-0", "mxl-source-1"
+    };
+    for (size_t i = 0; i < sizeof receiver_internal_ids / sizeof receiver_internal_ids[0]; ++i)
+    {
+        const bool success = nmos_make_receiver_id(seed, receiver_internal_ids[i], id, sizeof id);
+        print_id("receiver", receiver_internal_ids[i], success ? id : "<error>");
+    }
+}
+
+// demonstrate the server-based ID accessors: read what the running
+// node server actually advertises; sender/receiver lookups also act
+// as an existence check, so removed resources return false
+static void print_actual_ids(const NvNmosNodeServer *server)
+{
+    char id[NVNMOS_ID_LEN];
+
+    printf("Actual NMOS IDs (queried from server):\n");
+
+    {
+        const bool success = nmos_get_node_id(server, id, sizeof id);
+        print_id("node", "", success ? id : "<error>");
+    }
+
+    static const char *const sender_internal_ids[] = {
+        "sink-0", "sink-1", "mxl-sink-0", "mxl-sink-1"
+    };
+    for (size_t i = 0; i < sizeof sender_internal_ids / sizeof sender_internal_ids[0]; ++i)
+    {
+        const bool success = nmos_get_sender_id(server, sender_internal_ids[i], id, sizeof id);
+        print_id("sender", sender_internal_ids[i], success ? id : "<missing>");
+    }
+
+    static const char *const receiver_internal_ids[] = {
+        "source-0", "source-1", "mxl-source-0", "mxl-source-1"
+    };
+    for (size_t i = 0; i < sizeof receiver_internal_ids / sizeof receiver_internal_ids[0]; ++i)
+    {
+        const bool success = nmos_get_receiver_id(server, receiver_internal_ids[i], id, sizeof id);
+        print_id("receiver", receiver_internal_ids[i], success ? id : "<missing>");
+    }
+}
+
 int main(int argc, char *argv[])
 {
     if (argc < 4)
@@ -432,14 +503,22 @@ int main(int argc, char *argv[])
     // as an example, use user_data to make handle_connection_activated print the transport file
     node_server.user_data = (void*)1;
 
+    print_expected_ids(seed);
+
     printf("Creating NvNmos server...\n");
     if (!create_nmos_node_server(&node_config, &node_server)) return 1;
+
+    print_actual_ids(&node_server);
+
     if (!get_continue()) goto cleanup;
     printf("Removing some senders and receivers...\n");
     if (!remove_nmos_receiver_from_node_server(&node_server, "source-0")) goto cleanup;
     if (!remove_nmos_sender_from_node_server(&node_server, "sink-1")) goto cleanup;
     if (!remove_nmos_receiver_from_node_server(&node_server, "mxl-source-0")) goto cleanup;
     if (!remove_nmos_sender_from_node_server(&node_server, "mxl-sink-1")) goto cleanup;
+
+    print_actual_ids(&node_server);
+
     if (!get_continue()) goto cleanup;
     printf("Adding back some senders and receivers...\n");
     if (!add_nmos_receiver_to_node_server(&node_server, &source_config[0])) goto cleanup;

--- a/src/main.c
+++ b/src/main.c
@@ -64,6 +64,50 @@
 #define AUDIO_FORMAT_SPECIFIC_PARAMETERS "channel-order=SMPTE2110.(ST); "
 #endif
 
+// example MXL video flow definition parameters
+// video/v210 (YCbCr-4:2:2, 10 bit, progressive) is hard-coded
+#ifndef MXL_VIDEO_FLOW_ID
+#define MXL_VIDEO_FLOW_ID "5ede7baf-9dcf-4b80-9e44-bc0f615633b4"
+#endif
+#ifndef MXL_VIDEO_DESCRIPTION
+#define MXL_VIDEO_DESCRIPTION "YCbCr-4:2:2, 10 bit, 1920 x 1080, progressive, 59.94 Hz"
+#endif
+#ifndef MXL_VIDEO_GRAIN_RATE_NUM
+#define MXL_VIDEO_GRAIN_RATE_NUM 60000
+#endif
+#ifndef MXL_VIDEO_GRAIN_RATE_DEN
+#define MXL_VIDEO_GRAIN_RATE_DEN 1001
+#endif
+#ifndef MXL_VIDEO_FRAME_WIDTH
+#define MXL_VIDEO_FRAME_WIDTH 1920
+#endif
+#ifndef MXL_VIDEO_FRAME_HEIGHT
+#define MXL_VIDEO_FRAME_HEIGHT 1080
+#endif
+#ifndef MXL_VIDEO_COLORSPACE
+#define MXL_VIDEO_COLORSPACE "BT709"
+#endif
+#ifndef MXL_VIDEO_TRANSFER_CHARACTERISTIC
+#define MXL_VIDEO_TRANSFER_CHARACTERISTIC "SDR"
+#endif
+
+// example MXL audio flow definition parameters
+// audio/float32 at 48 kHz is hard-coded
+#ifndef MXL_AUDIO_FLOW_ID
+#define MXL_AUDIO_FLOW_ID "92029e8a-fb63-46d7-b2f4-abe2f8dbf083"
+#endif
+#ifndef MXL_AUDIO_DESCRIPTION
+#define MXL_AUDIO_DESCRIPTION "2 ch, 48 kHz, 32 bit"
+#endif
+#ifndef MXL_AUDIO_CHANNEL_COUNT
+#define MXL_AUDIO_CHANNEL_COUNT 2
+#endif
+
+// example MXL domain id (UUIDv4); see AMWA BCP-007-03
+#ifndef MXL_DOMAIN_ID
+#define MXL_DOMAIN_ID "212ba127-f746-43c5-87d4-3962ec7ff284"
+#endif
+
 #ifndef CLK_PTP
 #define CLK_PTP true
 #endif
@@ -77,13 +121,13 @@ static void handle_log(
     printf("%s [%d:%s]\n", message, level, categories);
 }
 
-static bool handle_rtp_connection_activated(
+static bool handle_connection_activated(
     NvNmosNodeServer *server,
     const char *id,
-    const char *sdp)
+    const char *transport_file)
 {
-    printf("%s %s\n", id, sdp ? "activated via NMOS" : "deactivated via NMOS");
-    if (server->user_data && sdp) printf("%s\n", sdp);
+    printf("%s %s\n", id, transport_file ? "activated via NMOS" : "deactivated via NMOS");
+    if (server->user_data && transport_file) printf("%s\n", transport_file);
     return true;
 }
 
@@ -215,6 +259,77 @@ static bool init_audio_sdp(char* sdp, size_t sdp_size, bool sender, const char* 
     return 0 < result && (size_t)result < sdp_size;
 }
 
+// construct example MXL flow definition JSON for an uncompressed v210 video sender or receiver
+// see AMWA BCP-007-03 and the MXL library examples
+static bool init_video_flow_def(char* flow_def, size_t flow_def_size, bool sender, const char* id, const char* mxl_domain_id, const char* mxl_flow_id, const char* label, const char* group_hint)
+{
+    int result = snprintf(flow_def,
+        flow_def_size,
+        "{\n"
+        "  \"x-nvnmos-id\": \"%s\",\n"
+        "  \"x-nvnmos-mxl-domain-id\": \"%s\",\n"
+        "  \"id\": \"%s\",\n"
+        "  \"label\": \"%s\",\n"
+        "  \"description\": \"" MXL_VIDEO_DESCRIPTION "\",\n"
+        "  \"tags\": { \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ] },\n"
+        "  \"format\": \"urn:x-nmos:format:video\",\n"
+        "  \"media_type\": \"video/v210\",\n"
+        "  \"grain_rate\": { \"numerator\": %d, \"denominator\": %d },\n"
+        "  \"frame_width\": %d,\n"
+        "  \"frame_height\": %d,\n"
+        "  \"interlace_mode\": \"progressive\",\n"
+        "  \"colorspace\": \"" MXL_VIDEO_COLORSPACE "\",\n"
+        "  \"transfer_characteristic\": \"" MXL_VIDEO_TRANSFER_CHARACTERISTIC "\",\n"
+        "  \"components\": [\n"
+        "    { \"name\": \"Y\",  \"width\": %d, \"height\": %d, \"bit_depth\": 10 },\n"
+        "    { \"name\": \"Cb\", \"width\": %d, \"height\": %d, \"bit_depth\": 10 },\n"
+        "    { \"name\": \"Cr\", \"width\": %d, \"height\": %d, \"bit_depth\": 10 }\n"
+        "  ]\n"
+        "}\n",
+        id,
+        mxl_domain_id,
+        mxl_flow_id,
+        label,
+        group_hint,
+        MXL_VIDEO_GRAIN_RATE_NUM, MXL_VIDEO_GRAIN_RATE_DEN,
+        MXL_VIDEO_FRAME_WIDTH, MXL_VIDEO_FRAME_HEIGHT,
+        MXL_VIDEO_FRAME_WIDTH, MXL_VIDEO_FRAME_HEIGHT,
+        MXL_VIDEO_FRAME_WIDTH / 2, MXL_VIDEO_FRAME_HEIGHT,
+        MXL_VIDEO_FRAME_WIDTH / 2, MXL_VIDEO_FRAME_HEIGHT
+    );
+
+    return 0 < result && (size_t)result < flow_def_size;
+}
+
+// construct example MXL flow definition JSON for an audio/float32 sender or receiver
+static bool init_audio_flow_def(char* flow_def, size_t flow_def_size, bool sender, const char* id, const char* mxl_domain_id, const char* mxl_flow_id, const char* label, const char* group_hint)
+{
+    int result = snprintf(flow_def,
+        flow_def_size,
+        "{\n"
+        "  \"x-nvnmos-id\": \"%s\",\n"
+        "  \"x-nvnmos-mxl-domain-id\": \"%s\",\n"
+        "  \"id\": \"%s\",\n"
+        "  \"label\": \"%s\",\n"
+        "  \"description\": \"" MXL_AUDIO_DESCRIPTION "\",\n"
+        "  \"tags\": { \"urn:x-nmos:tag:grouphint/v1.0\": [ \"%s\" ] },\n"
+        "  \"format\": \"urn:x-nmos:format:audio\",\n"
+        "  \"media_type\": \"audio/float32\",\n"
+        "  \"sample_rate\": { \"numerator\": 48000, \"denominator\": 1 },\n"
+        "  \"channel_count\": %d,\n"
+        "  \"bit_depth\": 32\n"
+        "}\n",
+        id,
+        mxl_domain_id,
+        mxl_flow_id,
+        label,
+        group_hint,
+        MXL_AUDIO_CHANNEL_COUNT
+    );
+
+    return 0 < result && (size_t)result < flow_def_size;
+}
+
 static bool get_continue(void)
 {
     printf("Continue ([y]/n)?\n");
@@ -269,29 +384,52 @@ int main(int argc, char *argv[])
     if (!init_video_sdp(sink_sdp[0], sizeof sink_sdp[0], true, "sink-0", interface_ip, "NvNmos Video Sender", "tx-0:video")) return 1;
     if (!init_audio_sdp(sink_sdp[1], sizeof sink_sdp[1], true, "sink-1", interface_ip, "NvNmos Audio Sender", "tx-0:audio")) return 1;
 
-    NvNmosReceiverConfig source_config[2] = { 0 };
+    // example MXL domain and per-flow ids (just hard-coded UUIDs for this example)
+    const char* mxl_domain_id = MXL_DOMAIN_ID;
 
-    source_config[0].sdp = source_sdp[0];
-    source_config[1].sdp = source_sdp[1];
+    char source_mxl[2][2048] = { 0 };
+    if (!init_video_flow_def(source_mxl[0], sizeof source_mxl[0], false, "mxl-source-0", mxl_domain_id, MXL_VIDEO_FLOW_ID, "NvNmos MXL Video Receiver", "rx-mxl-0:video")) return 1;
+    if (!init_audio_flow_def(source_mxl[1], sizeof source_mxl[1], false, "mxl-source-1", mxl_domain_id, MXL_AUDIO_FLOW_ID, "NvNmos MXL Audio Receiver", "rx-mxl-0:audio")) return 1;
+
+    char sink_mxl[2][2048] = { 0 };
+    if (!init_video_flow_def(sink_mxl[0], sizeof sink_mxl[0], true, "mxl-sink-0", mxl_domain_id, MXL_VIDEO_FLOW_ID, "NvNmos MXL Video Sender", "tx-mxl-0:video")) return 1;
+    if (!init_audio_flow_def(sink_mxl[1], sizeof sink_mxl[1], true, "mxl-sink-1", mxl_domain_id, MXL_AUDIO_FLOW_ID, "NvNmos MXL Audio Sender", "tx-mxl-0:audio")) return 1;
+
+    NvNmosReceiverConfig source_config[4] = { 0 };
+
+    source_config[0].transport = NVNMOS_TRANSPORT_RTP;
+    source_config[0].transport_file = source_sdp[0];
+    source_config[1].transport = NVNMOS_TRANSPORT_RTP;
+    source_config[1].transport_file = source_sdp[1];
+    source_config[2].transport = NVNMOS_TRANSPORT_MXL;
+    source_config[2].transport_file = source_mxl[0];
+    source_config[3].transport = NVNMOS_TRANSPORT_MXL;
+    source_config[3].transport_file = source_mxl[1];
 
     node_config.receivers = &source_config[0];
-    node_config.num_receivers = 2;
+    node_config.num_receivers = 4;
 
-    NvNmosSenderConfig sink_config[2] = { 0 };
+    NvNmosSenderConfig sink_config[4] = { 0 };
 
-    sink_config[0].sdp = sink_sdp[0];
-    sink_config[1].sdp = sink_sdp[1];
+    sink_config[0].transport = NVNMOS_TRANSPORT_RTP;
+    sink_config[0].transport_file = sink_sdp[0];
+    sink_config[1].transport = NVNMOS_TRANSPORT_RTP;
+    sink_config[1].transport_file = sink_sdp[1];
+    sink_config[2].transport = NVNMOS_TRANSPORT_MXL;
+    sink_config[2].transport_file = sink_mxl[0];
+    sink_config[3].transport = NVNMOS_TRANSPORT_MXL;
+    sink_config[3].transport_file = sink_mxl[1];
 
     node_config.senders = &sink_config[0];
-    node_config.num_senders = 2;
+    node_config.num_senders = 4;
 
-    node_config.rtp_connection_activated = &handle_rtp_connection_activated;
+    node_config.connection_activated = &handle_connection_activated;
 
     node_config.log_callback = &handle_log;
     node_config.log_level = argc > 4 ? atoi(argv[4]) : NVNMOS_LOG_ERROR;
 
     NvNmosNodeServer node_server = { 0 };
-    // as an example, use user_data to make handle_rtp_connection_activated print the SDP data
+    // as an example, use user_data to make handle_connection_activated print the transport file
     node_server.user_data = (void*)1;
 
     printf("Creating NvNmos server...\n");
@@ -300,22 +438,34 @@ int main(int argc, char *argv[])
     printf("Removing some senders and receivers...\n");
     if (!remove_nmos_receiver_from_node_server(&node_server, "source-0")) goto cleanup;
     if (!remove_nmos_sender_from_node_server(&node_server, "sink-1")) goto cleanup;
+    if (!remove_nmos_receiver_from_node_server(&node_server, "mxl-source-0")) goto cleanup;
+    if (!remove_nmos_sender_from_node_server(&node_server, "mxl-sink-1")) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Adding back some senders and receivers...\n");
     if (!add_nmos_receiver_to_node_server(&node_server, &source_config[0])) goto cleanup;
     if (!add_nmos_sender_to_node_server(&node_server, &sink_config[1])) goto cleanup;
+    if (!add_nmos_receiver_to_node_server(&node_server, &source_config[2])) goto cleanup;
+    if (!add_nmos_sender_to_node_server(&node_server, &sink_config[3])) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Activating senders and receivers...\n");
-    if (!nmos_connection_rtp_activate(&node_server, "source-0", source_config[0].sdp)) goto cleanup;
-    if (!nmos_connection_rtp_activate(&node_server, "source-1", source_config[1].sdp)) goto cleanup;
-    if (!nmos_connection_rtp_activate(&node_server, "sink-0", sink_config[0].sdp)) goto cleanup;
-    if (!nmos_connection_rtp_activate(&node_server, "sink-1", sink_config[1].sdp)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "source-0", source_config[0].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "source-1", source_config[1].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "sink-0", sink_config[0].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "sink-1", sink_config[1].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-source-0", source_config[2].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-source-1", source_config[3].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-sink-0", sink_config[2].transport_file)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-sink-1", sink_config[3].transport_file)) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Deactivating senders and receivers...\n");
-    if (!nmos_connection_rtp_activate(&node_server, "source-0", 0)) goto cleanup;
-    if (!nmos_connection_rtp_activate(&node_server, "source-1", 0)) goto cleanup;
-    if (!nmos_connection_rtp_activate(&node_server, "sink-0", 0)) goto cleanup;
-    if (!nmos_connection_rtp_activate(&node_server, "sink-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "source-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "source-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "sink-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "sink-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-source-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-source-1", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-sink-0", 0)) goto cleanup;
+    if (!nmos_connection_activate(&node_server, "mxl-sink-1", 0)) goto cleanup;
     if (!get_continue()) goto cleanup;
     printf("Destroying NvNmos server...\n");
     if (!destroy_nmos_node_server(&node_server)) return 1;

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -25,6 +25,7 @@
 
 #include "nvnmos.h"
 
+#include <cstring>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/iterator_range_core.hpp>
@@ -91,6 +92,10 @@ namespace nvnmos
         void remove_sender(const std::string& id);
 
         void activate_connection(const std::string& id, const std::string& transport_file);
+
+        nmos::id node_id() const;
+        nmos::id sender_id(const std::string& internal_id) const;
+        nmos::id receiver_id(const std::string& internal_id) const;
 
     private:
         static nmos::transport to_transport(NvNmosTransport transport);
@@ -481,6 +486,28 @@ namespace nvnmos
             throw;
         }
     }
+
+    nmos::id server::node_id() const
+    {
+        auto lock = node_model.read_lock();
+        return impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::node);
+    }
+
+    nmos::id server::sender_id(const std::string& internal_id) const
+    {
+        auto lock = node_model.read_lock();
+        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::sender, utility::s2us(internal_id.c_str()));
+        if (node_model.node_resources.end() == nmos::find_resource(node_model.node_resources, { candidate, nmos::types::sender })) return {};
+        return candidate;
+    }
+
+    nmos::id server::receiver_id(const std::string& internal_id) const
+    {
+        auto lock = node_model.read_lock();
+        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::receiver, utility::s2us(internal_id.c_str()));
+        if (node_model.node_resources.end() == nmos::find_resource(node_model.node_resources, { candidate, nmos::types::receiver })) return {};
+        return candidate;
+    }
 }
 
 NVNMOS_API
@@ -614,6 +641,135 @@ bool nmos_connection_activate(
     {
         impl->activate_connection(id, transport_file);
         return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+namespace nvnmos
+{
+    inline bool copy_id_to_buffer(const nmos::id& id, char* out, size_t out_len)
+    {
+        if (!out || out_len < NVNMOS_ID_LEN) return false;
+        if (id.empty()) return false;
+        const auto narrow = utility::us2s(id);
+        if (narrow.size() + 1 > out_len) return false;
+        std::memcpy(out, narrow.data(), narrow.size());
+        out[narrow.size()] = '\0';
+        return true;
+    }
+}
+
+NVNMOS_API
+bool nmos_make_node_id(
+    const char* seed,
+    char* out,
+    size_t out_len)
+{
+    if (!seed) return false;
+    try
+    {
+        const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::node), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_make_sender_id(
+    const char* seed,
+    const char* internal_id,
+    char* out,
+    size_t out_len)
+{
+    if (!seed || !internal_id) return false;
+    try
+    {
+        const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::sender, utility::s2us(internal_id)), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_make_receiver_id(
+    const char* seed,
+    const char* internal_id,
+    char* out,
+    size_t out_len)
+{
+    if (!seed || !internal_id) return false;
+    try
+    {
+        const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::receiver, utility::s2us(internal_id)), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_get_node_id(
+    const NvNmosNodeServer* server,
+    char* out,
+    size_t out_len)
+{
+    if (!server) return false;
+    auto impl = (nvnmos::server*)server->impl;
+    if (!impl) return false;
+    try
+    {
+        return nvnmos::copy_id_to_buffer(impl->node_id(), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_get_sender_id(
+    const NvNmosNodeServer* server,
+    const char* internal_id,
+    char* out,
+    size_t out_len)
+{
+    if (!server || !internal_id) return false;
+    auto impl = (nvnmos::server*)server->impl;
+    if (!impl) return false;
+    try
+    {
+        return nvnmos::copy_id_to_buffer(impl->sender_id(internal_id), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_get_receiver_id(
+    const NvNmosNodeServer* server,
+    const char* internal_id,
+    char* out,
+    size_t out_len)
+{
+    if (!server || !internal_id) return false;
+    auto impl = (nvnmos::server*)server->impl;
+    if (!impl) return false;
+    try
+    {
+        return nvnmos::copy_id_to_buffer(impl->receiver_id(internal_id), out, out_len);
     }
     catch (...)
     {

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -180,6 +180,11 @@ namespace nvnmos
 
             node_implementation_init(node_model, gate);
 
+            {
+                const auto urls = impl::make_api_base_urls(node_model.settings);
+                slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(node_id(), nmos::types::node) << ": " << urls.first << " " << urls.second;
+            }
+
             for (auto& receiver : boost::make_iterator_range_n(config.receivers, config.num_receivers))
             {
                 if (!receiver.transport_file) throw std::logic_error("invalid receiver config");
@@ -220,6 +225,12 @@ namespace nvnmos
         {
             log_current_exception();
         }
+
+        try
+        {
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Destroyed " << std::make_pair(node_id(), nmos::types::node);
+        }
+        catch (...) {}
 
         slog::log<slog::severities::info>(gate, SLOG_FLF) << "Stopping NvNmos node";
     }

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -313,6 +313,7 @@ namespace nvnmos
         web::json::insert(settings, std::make_pair(nmos::fields::events_port, -1));
         web::json::insert(settings, std::make_pair(nmos::fields::events_ws_port, -1));
         web::json::insert(settings, std::make_pair(nmos::fields::channelmapping_port, -1));
+        web::json::insert(settings, std::make_pair(nmos::fields::control_protocol_ws_port, -1));
 
         if (0 != config.asset_tags)
         {

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -80,6 +80,23 @@ namespace nvnmos
         nmos::experimental::log_model& model;
     };
 
+    inline nmos::type parse_side(NvNmosSide side)
+    {
+        switch (side)
+        {
+        case NVNMOS_SIDE_SENDER: return nmos::types::sender;
+        case NVNMOS_SIDE_RECEIVER: return nmos::types::receiver;
+        }
+        throw std::logic_error("invalid NvNmosSide");
+    }
+
+    inline NvNmosSide make_side(const nmos::type& type)
+    {
+        if (nmos::types::sender == type) return NVNMOS_SIDE_SENDER;
+        if (nmos::types::receiver == type) return NVNMOS_SIDE_RECEIVER;
+        throw std::logic_error("nmos::type is neither sender nor receiver");
+    }
+
     class server
     {
     public:
@@ -87,15 +104,15 @@ namespace nvnmos
         ~server();
 
         void add_receiver(const NvNmosReceiverConfig& config);
-        void remove_receiver(const std::string& id);
+        void remove_receiver(const std::string& receiver_name);
         void add_sender(const NvNmosSenderConfig& config);
-        void remove_sender(const std::string& id);
+        void remove_sender(const std::string& sender_name);
 
-        void activate_connection(const std::string& id, const std::string& transport_file);
+        void activate_connection(const nmos::type& type, const std::string& name, const std::string& transport_file);
 
         nmos::id node_id() const;
-        nmos::id sender_id(const std::string& internal_id) const;
-        nmos::id receiver_id(const std::string& internal_id) const;
+        nmos::id sender_id(const std::string& sender_name) const;
+        nmos::id receiver_id(const std::string& receiver_name) const;
 
     private:
         static nmos::transport to_transport(NvNmosTransport transport);
@@ -136,13 +153,14 @@ namespace nvnmos
 
             const auto& activated = config.connection_activated;
             auto& gate_ = gate;
-            auto connection_activated = [activated, server, &gate_](const std::string& id, const std::string& transport_file)
+            auto connection_activated = [activated, server, &gate_](const nmos::type& type, const std::string& name, const std::string& transport_file)
             {
                 if (!activated) return;
-                const bool success = activated(server, id.c_str(), !transport_file.empty() ? transport_file.c_str() : 0);
+                const auto side = nvnmos::make_side(type);
+                const bool success = activated(server, side, name.c_str(), !transport_file.empty() ? transport_file.c_str() : 0);
                 if (!success)
                 {
-                    slog::log<slog::severities::warning>(gate_, SLOG_FLF) << "Activation failed for internal id: " << id;
+                    slog::log<slog::severities::warning>(gate_, SLOG_FLF) << "Activation failed for " << type.name << ": " << name;
                 }
             };
             node_implementation = make_node_implementation(node_model, connection_activated, gate);
@@ -432,11 +450,11 @@ namespace nvnmos
         }
     }
 
-    void server::remove_receiver(const std::string& id)
+    void server::remove_receiver(const std::string& receiver_name)
     {
         try
         {
-            node_implementation_remove_receiver(node_model, utility::s2us(id), gate);
+            node_implementation_remove_receiver(node_model, utility::s2us(receiver_name), gate);
         }
         catch (...)
         {
@@ -461,11 +479,11 @@ namespace nvnmos
         }
     }
 
-    void server::remove_sender(const std::string& id)
+    void server::remove_sender(const std::string& sender_name)
     {
         try
         {
-            node_implementation_remove_sender(node_model, utility::s2us(id), gate);
+            node_implementation_remove_sender(node_model, utility::s2us(sender_name), gate);
         }
         catch (...)
         {
@@ -474,11 +492,11 @@ namespace nvnmos
         }
     }
 
-    void server::activate_connection(const std::string& id, const std::string& transport_file)
+    void server::activate_connection(const nmos::type& type, const std::string& name, const std::string& transport_file)
     {
         try
         {
-            node_implementation_activate_connection(node_model, utility::s2us(id), transport_file, gate);
+            node_implementation_activate_connection(node_model, type, utility::s2us(name), transport_file, gate);
         }
         catch (...)
         {
@@ -493,18 +511,18 @@ namespace nvnmos
         return impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::node);
     }
 
-    nmos::id server::sender_id(const std::string& internal_id) const
+    nmos::id server::sender_id(const std::string& sender_name) const
     {
         auto lock = node_model.read_lock();
-        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::sender, utility::s2us(internal_id.c_str()));
+        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::sender, utility::s2us(sender_name.c_str()));
         if (node_model.node_resources.end() == nmos::find_resource(node_model.node_resources, { candidate, nmos::types::sender })) return {};
         return candidate;
     }
 
-    nmos::id server::receiver_id(const std::string& internal_id) const
+    nmos::id server::receiver_id(const std::string& receiver_name) const
     {
         auto lock = node_model.read_lock();
-        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::receiver, utility::s2us(internal_id.c_str()));
+        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::receiver, utility::s2us(receiver_name.c_str()));
         if (node_model.node_resources.end() == nmos::find_resource(node_model.node_resources, { candidate, nmos::types::receiver })) return {};
         return candidate;
     }
@@ -565,16 +583,16 @@ bool add_nmos_receiver_to_node_server(
 NVNMOS_API
 bool remove_nmos_receiver_from_node_server(
     NvNmosNodeServer* server,
-    const char* id)
+    const char* receiver_name)
 {
     if (!server) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
-    if (!id) return false;
+    if (!receiver_name) return false;
 
     try
     {
-        impl->remove_receiver(id);
+        impl->remove_receiver(receiver_name);
         return true;
     }
     catch (...)
@@ -607,16 +625,16 @@ bool add_nmos_sender_to_node_server(
 NVNMOS_API
 bool remove_nmos_sender_from_node_server(
     NvNmosNodeServer* server,
-    const char* id)
+    const char* sender_name)
 {
     if (!server) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
-    if (!id) return false;
+    if (!sender_name) return false;
 
     try
     {
-        impl->remove_sender(id);
+        impl->remove_sender(sender_name);
         return true;
     }
     catch (...)
@@ -628,18 +646,20 @@ bool remove_nmos_sender_from_node_server(
 NVNMOS_API
 bool nmos_connection_activate(
     NvNmosNodeServer* server,
-    const char* id,
+    NvNmosSide side,
+    const char* name,
     const char* transport_file)
 {
     if (!server) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
-    if (!id) return false;
+    if (!name) return false;
     if (!transport_file) transport_file = "";
 
     try
     {
-        impl->activate_connection(id, transport_file);
+        const auto type = nvnmos::parse_side(side);
+        impl->activate_connection(type, name, transport_file);
         return true;
     }
     catch (...)
@@ -683,15 +703,15 @@ bool nmos_make_node_id(
 NVNMOS_API
 bool nmos_make_sender_id(
     const char* seed,
-    const char* internal_id,
+    const char* sender_name,
     char* out,
     size_t out_len)
 {
-    if (!seed || !internal_id) return false;
+    if (!seed || !sender_name) return false;
     try
     {
         const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
-        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::sender, utility::s2us(internal_id)), out, out_len);
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::sender, utility::s2us(sender_name)), out, out_len);
     }
     catch (...)
     {
@@ -702,15 +722,15 @@ bool nmos_make_sender_id(
 NVNMOS_API
 bool nmos_make_receiver_id(
     const char* seed,
-    const char* internal_id,
+    const char* receiver_name,
     char* out,
     size_t out_len)
 {
-    if (!seed || !internal_id) return false;
+    if (!seed || !receiver_name) return false;
     try
     {
         const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
-        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::receiver, utility::s2us(internal_id)), out, out_len);
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::receiver, utility::s2us(receiver_name)), out, out_len);
     }
     catch (...)
     {
@@ -740,16 +760,16 @@ bool nmos_get_node_id(
 NVNMOS_API
 bool nmos_get_sender_id(
     const NvNmosNodeServer* server,
-    const char* internal_id,
+    const char* sender_name,
     char* out,
     size_t out_len)
 {
-    if (!server || !internal_id) return false;
+    if (!server || !sender_name) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
     try
     {
-        return nvnmos::copy_id_to_buffer(impl->sender_id(internal_id), out, out_len);
+        return nvnmos::copy_id_to_buffer(impl->sender_id(sender_name), out, out_len);
     }
     catch (...)
     {
@@ -760,16 +780,16 @@ bool nmos_get_sender_id(
 NVNMOS_API
 bool nmos_get_receiver_id(
     const NvNmosNodeServer* server,
-    const char* internal_id,
+    const char* receiver_name,
     char* out,
     size_t out_len)
 {
-    if (!server || !internal_id) return false;
+    if (!server || !receiver_name) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
     try
     {
-        return nvnmos::copy_id_to_buffer(impl->receiver_id(internal_id), out, out_len);
+        return nvnmos::copy_id_to_buffer(impl->receiver_id(receiver_name), out, out_len);
     }
     catch (...)
     {

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -90,9 +90,10 @@ namespace nvnmos
         void add_sender(const NvNmosSenderConfig& config);
         void remove_sender(const std::string& id);
 
-        void activate_rtp_connection(const std::string& id, const std::string& sdp);
+        void activate_connection(const std::string& id, const std::string& transport_file);
 
     private:
+        static nmos::transport to_transport(NvNmosTransport transport);
         static nmos::settings make_settings(const NvNmosNodeConfig& config);
         void log_current_exception();
 
@@ -128,18 +129,18 @@ namespace nvnmos
 
             // Set up the callbacks between the node server and the underlying implementation
 
-            const auto& activated = config.rtp_connection_activated;
+            const auto& activated = config.connection_activated;
             auto& gate_ = gate;
-            auto rtp_connection_activated = [activated, server, &gate_](const std::string& id, const std::string& sdp)
+            auto connection_activated = [activated, server, &gate_](const std::string& id, const std::string& transport_file)
             {
                 if (!activated) return;
-                const bool success = activated(server, id.c_str(), !sdp.empty() ? sdp.c_str() : 0);
+                const bool success = activated(server, id.c_str(), !transport_file.empty() ? transport_file.c_str() : 0);
                 if (!success)
                 {
                     slog::log<slog::severities::warning>(gate_, SLOG_FLF) << "Activation failed for internal id: " << id;
                 }
             };
-            node_implementation = make_node_implementation(node_model, rtp_connection_activated, gate);
+            node_implementation = make_node_implementation(node_model, connection_activated, gate);
 
             // Set up the node server
 
@@ -158,14 +159,14 @@ namespace nvnmos
 
             for (auto& receiver : boost::make_iterator_range_n(config.receivers, config.num_receivers))
             {
-                if (!receiver.sdp) throw std::logic_error("invalid receiver config");
-                node_implementation_add_receiver(node_model, receiver.sdp, gate);
+                if (!receiver.transport_file) throw std::logic_error("invalid receiver config");
+                node_implementation_add_receiver(node_model, to_transport(receiver.transport), receiver.transport_file, gate);
             }
 
             for (auto& sender : boost::make_iterator_range_n(config.senders, config.num_senders))
             {
-                if (!sender.sdp) throw std::logic_error("invalid sender config");
-                node_implementation_add_sender(node_model, sender.sdp, gate);
+                if (!sender.transport_file) throw std::logic_error("invalid sender config");
+                node_implementation_add_sender(node_model, to_transport(sender.transport), sender.transport_file, gate);
             }
 
             // Open the API ports and start up node operation (including the DNS-SD advertisements)
@@ -400,14 +401,24 @@ namespace nvnmos
         }
     }
 
+    nmos::transport server::to_transport(NvNmosTransport transport)
+    {
+        switch (transport)
+        {
+        case NVNMOS_TRANSPORT_RTP: return nmos::transports::rtp;
+        case NVNMOS_TRANSPORT_MXL: return nmos::transports::mxl;
+        }
+        throw std::logic_error("invalid NvNmosTransport");
+    }
+
     void server::add_receiver(const NvNmosReceiverConfig& config)
     {
         using web::json::value_of;
 
         try
         {
-            if (!config.sdp) throw std::logic_error("invalid receiver config");
-            node_implementation_add_receiver(node_model, config.sdp, gate);
+            if (!config.transport_file) throw std::logic_error("invalid receiver config");
+            node_implementation_add_receiver(node_model, to_transport(config.transport), config.transport_file, gate);
         }
         catch (...)
         {
@@ -435,8 +446,8 @@ namespace nvnmos
 
         try
         {
-            if (!config.sdp) throw std::logic_error("invalid sender config");
-            node_implementation_add_sender(node_model, config.sdp, gate);
+            if (!config.transport_file) throw std::logic_error("invalid sender config");
+            node_implementation_add_sender(node_model, to_transport(config.transport), config.transport_file, gate);
         }
         catch (...)
         {
@@ -458,11 +469,11 @@ namespace nvnmos
         }
     }
 
-    void server::activate_rtp_connection(const std::string& id, const std::string& sdp)
+    void server::activate_connection(const std::string& id, const std::string& transport_file)
     {
         try
         {
-            node_implementation_activate_rtp_connection(node_model, utility::s2us(id), sdp, gate);
+            node_implementation_activate_connection(node_model, utility::s2us(id), transport_file, gate);
         }
         catch (...)
         {
@@ -588,20 +599,20 @@ bool remove_nmos_sender_from_node_server(
 }
 
 NVNMOS_API
-bool nmos_connection_rtp_activate(
+bool nmos_connection_activate(
     NvNmosNodeServer* server,
     const char* id,
-    const char* sdp)
+    const char* transport_file)
 {
     if (!server) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
     if (!id) return false;
-    if (!sdp) sdp = "";
+    if (!transport_file) transport_file = "";
 
     try
     {
-        impl->activate_rtp_connection(id, sdp);
+        impl->activate_connection(id, transport_file);
         return true;
     }
     catch (...)

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -39,18 +39,20 @@
  * used to update running DeepStream pipelines with new transport parameters,
  * for example.
  *
- * NvNmos currently supports Senders and Receivers for uncompressed Video
- * and Audio, i.e., SMPTE ST 2110-20 and SMPTE ST 2110-30 streams.
+ * NvNmos currently supports Senders and Receivers for video, audio, and ancillary data flows over RTP
+ * (i.e., SMPTE ST 2110-20, -22, -30, and -40 streams) and over the Media eXchange Layer (MXL).
  *
  * The NvNmos library supports the following specifications, using the <a href="https://github.com/sony/nmos-cpp">Sony nmos-cpp</a> implementation:
  * - <a href="https://specs.amwa.tv/is-04/">AMWA IS-04 NMOS Discovery and Registration Specification</a> v1.3
- * - <a href="https://specs.amwa.tv/is-05/">AMWA IS-05 NMOS Device Connection Management Specification</a> v1.1
+ * - <a href="https://specs.amwa.tv/is-05/">AMWA IS-05 NMOS Device Connection Management Specification</a> v1.1 and v1.2-dev (for MXL)
  * - <a href="https://specs.amwa.tv/is-09/">AMWA IS-09 NMOS System Parameters Specification</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-002-01/">AMWA BCP-002-01 Natural Grouping of NMOS Resources</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-002-02/">AMWA BCP-002-02 NMOS Asset Distinguishing Information</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-004-01/">AMWA BCP-004-01 NMOS Receiver Capabilities</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-006-01/">AMWA BCP-006-01 NMOS With JPEG XS</a> v1.0
+ * - <a href="https://specs.amwa.tv/bcp-007-03/">AMWA BCP-007-03 NMOS With MXL</a> v1.0-dev
  * - Session Description Protocol conforming to SMPTE ST 2110-20, -22, -30, -40, and ST 2022-7
+ * - MXL flow definition JSON as consumed by the <a href="https://github.com/dmf-mxl/mxl">MXL SDK</a>
  *
  * @ingroup NvNmosApi
  * @{
@@ -95,34 +97,66 @@ extern "C"
 typedef struct _NvNmosNodeServer NvNmosNodeServer;
 
 /**
+ * Identifies the transport used by an NvNmos Sender or Receiver. Stored in
+ * @ref NvNmosSenderConfig::transport and @ref NvNmosReceiverConfig::transport,
+ * it corresponds to the base URN of the transport of the NMOS Sender or
+ * Receiver resource.
+ */
+typedef enum _NvNmosTransport
+{
+    /** RTP, as used by SMPTE ST 2110.
+        The associated transport file is a Session Description Protocol
+        (SDP) file. This is the default for a zero-initialised configuration. */
+    NVNMOS_TRANSPORT_RTP = 0,
+    /** The Media eXchange Layer (MXL).
+        The associated transport file is an MXL flow definition (JSON)
+        of the form consumed by the MXL SDK. */
+    NVNMOS_TRANSPORT_MXL = 1
+} NvNmosTransport;
+
+/**
  * Type for a callback from NvNmos library when an IS-05 Connection API
  * activation occurs.
  *
- * @param[in] server A pointer to the server issuing the callback.
- * @param[in] id     The unique identifier for the sender or receiver
- *                   to be activated or deactivated.
- * @param[in] sdp    The updated Session Description Protocol data
- *                   for the sender or receiver, or a null pointer when
- *                   the sender or receiver is being deactivated.
- *                   The new data only updates the transport parameters
- *                   of the sender or receiver, not the media format.
- *                   The 'inactive' media-level attribute is used to
- *                   indicate a disabled leg.
- *                   The 'x-nvnmos-id' session-level attribute specifies
- *                   the unique identifier for the sender or receiver,
- *                   @p id.
- *                   For a receiver, the 'x-nvnmos-iface-ip' media-level
- *                   attribute is used to specify the interface IP
- *                   address on which the stream is received.
- *                   For a sender, the 'x-nvnmos-src-port' media-level
- *                   attribute is used to specify the source port
- *                   from which the stream is transmitted.
+ * @param[in] server         A pointer to the server issuing the callback.
+ * @param[in] id             The unique identifier for the sender or receiver
+ *                           to be activated or deactivated. This is the
+ *                           same id specified in the configuration's
+ *                           'x-nvnmos-id' attribute or property.
+ * @param[in] transport_file The updated transport file data for the
+ *                           sender or receiver, or a null pointer when
+ *                           the sender or receiver is being deactivated.
+ *
+ *                           For an RTP sender or receiver this is an SDP
+ *                           file. The 'inactive' media-level attribute is
+ *                           used to indicate a disabled leg. The
+ *                           'x-nvnmos-id' session-level attribute specifies
+ *                           the unique identifier for the sender or
+ *                           receiver, @p id. For a receiver, the
+ *                           'x-nvnmos-iface-ip' media-level attribute is
+ *                           used to specify the interface IP address on
+ *                           which the stream is received. For a sender,
+ *                           the 'x-nvnmos-src-port' media-level attribute
+ *                           is used to specify the source port from which
+ *                           the stream is transmitted.
+ *
+ *                           For an MXL sender or receiver this is an MXL
+ *                           flow definition (JSON), with the
+ *                           'x-nvnmos-id' property specifying the unique
+ *                           identifier for the sender or receiver, @p id,
+ *                           and the 'mxl_domain_id' and 'mxl_flow_id'
+ *                           IS-05 transport parameters reflected as the
+ *                           'x-nvnmos-mxl-domain-id' key and the JSON
+ *                           document's 'id' field respectively.
+ *                           The application is expected to dispatch on
+ *                           @p id (which it specified) to determine the
+ *                           transport, if needed.
  * @return Whether the activation could be applied.
  */
-typedef bool (* nmos_connection_rtp_activation_callback)(
+typedef bool (* nmos_connection_activation_callback)(
     NvNmosNodeServer *server,
     const char *id,
-    const char *sdp);
+    const char *transport_file);
 
 /**
  * Defines some common severity/logging levels for log messages from
@@ -215,7 +249,7 @@ typedef struct _NvNmosNodeConfig
 
     /** Holds the callback for handling an IS-05 Connection API activation.
         May be null. */
-    nmos_connection_rtp_activation_callback rtp_connection_activated;
+    nmos_connection_activation_callback connection_activated;
 
     /** Holds the callback for handling log messages. May be null. */
     nmos_logging_callback log_callback;
@@ -259,17 +293,44 @@ typedef struct _NvNmosAssetConfig
  */
 typedef struct _NvNmosReceiverConfig
 {
-    /** Holds the Session Description Protocol data used to configure
-        the receiver. Must not be null. The SDP data must be valid
-        as per the relevant IETF RFC and SMPTE standards for the
-        media format and transport.
+    /** Holds the transport used by the receiver. Determines the type
+        of the @ref transport_file. Defaults to ::NVNMOS_TRANSPORT_RTP
+        for a zero-initialised configuration. */
+    NvNmosTransport transport;
+    /** Holds the transport file data used to configure the receiver.
+        Must not be null.
+
+        For ::NVNMOS_TRANSPORT_RTP, this is Session Description Protocol
+        (SDP) data, which must be valid as per the relevant IETF RFC
+        and SMPTE standards for the media format and transport.
         The 'x-nvnmos-id' session-level attribute specifies the unique
         identifier for the receiver.
         The 'x-nvnmos-group-hint' session-level attribute may be used to
         specify a group hint tag for the receiver.
         The 'x-nvnmos-iface-ip' media-level attribute is used to specify
-        the interface IP address on which the stream is received. */
-    const char *sdp;
+        the interface IP address on which the stream is received.
+        The 'x-nvnmos-caps' media-level attribute may be used to indicate
+        that the receiver should be advertised with the format-derived
+        capabilities omitted (i.e. a more permissive receiver).
+        The connection address and source filter are not used by the
+        receiver itself (since the transport parameters are set
+        dynamically by IS-05).
+
+        For ::NVNMOS_TRANSPORT_MXL, this is an MXL flow definition (JSON)
+        of the form consumed by the MXL library, with NvNmos extensions.
+        The 'x-nvnmos-id' top-level property specifies the unique
+        identifier for the receiver.
+        A group hint tag may be specified via the 'tags' property.
+        The 'x-nvnmos-caps' top-level property may be used to indicate
+        that the receiver should be advertised with the format-derived
+        capabilities omitted.
+        The 'x-nvnmos-mxl-domain-id' top-level property (UUID string)
+        is required and specifies the MXL domain for the receiver;
+        the IS-05 transport parameter defaults to 'auto' and is
+        resolved at activation time from this value.
+        The flow definition's 'id' field is not used by the receiver
+        itself (since the MXL flow id is set dynamically by IS-05). */
+    const char *transport_file;
 } NvNmosReceiverConfig;
 
 /**
@@ -278,18 +339,39 @@ typedef struct _NvNmosReceiverConfig
  */
 typedef struct _NvNmosSenderConfig
 {
-    /** Holds the Session Description Protocol data used to configure
-        the sender. Must not be null. The SDP data must be valid
-        as per the relevant IETF RFC and SMPTE standards for the
-        media format and transport.
+    /** Holds the transport used by the sender. Determines the format
+        of @ref transport_file. Defaults to ::NVNMOS_TRANSPORT_RTP for
+        a zero-initialised configuration. */
+    NvNmosTransport transport;
+    /** Holds the transport file data used to configure the sender.
+        Must not be null.
+
+        For ::NVNMOS_TRANSPORT_RTP, this is Session Description Protocol
+        (SDP) data, which must be valid as per the relevant IETF RFC
+        and SMPTE standards for the media format and transport.
         The 'ts-refclk' attributes are used to specify the node clock.
         The 'x-nvnmos-id' session-level attribute specifies the unique
         identifier for the sender.
         The 'x-nvnmos-group-hint' session-level attribute may be used to
         specify a group hint tag for the sender.
         The 'x-nvnmos-src-port' media-level attribute is used to specify
-        the source port from which the stream is transmitted. */
-    const char *sdp;
+        the source port from which the stream is transmitted.
+
+        For ::NVNMOS_TRANSPORT_MXL, this is an MXL flow definition (JSON)
+        of the form consumed by the MXL library, with NvNmos extensions.
+        The 'x-nvnmos-id' top-level property specifies the unique
+        identifier for the sender.
+        A group hint tag may be specified via the 'tags' property.
+        The 'x-nvnmos-mxl-domain-id' top-level property (UUID string)
+        is required and specifies the MXL domain for the sender;
+        the IS-05 transport parameter defaults to 'auto' and is
+        resolved at activation time from this value.
+        The flow definition's 'id' field (UUID string), if present, is
+        used as the MXL flow identity for the sender's IS-05 transport
+        parameter 'mxl_flow_id'; if absent, the NMOS Flow id (derived
+        from @ref NvNmosNodeConfig::seed and the 'x-nvnmos-id') is used
+        in its place. */
+    const char *transport_file;
 } NvNmosSenderConfig;
 
 /**
@@ -437,36 +519,42 @@ bool remove_nmos_sender_from_node_server(
     const char* id);
 
 /**
- * Update the configuration settings of a sender or receiver.
+ * Report that a sender or receiver has been activated or deactivated
+ * out of band.
  *
- * @param[in] server A pointer to the server to be updated.
- * @param[in] id     The unique identifier for the sender or receiver
- *                   to be activated or deactivated.
- * @param[in] sdp    The updated Session Description Protocol data
- *                   for the sender or receiver, or a null pointer when
- *                   the sender or receiver is being deactivated.
- *                   The new data only updates the transport parameters
- *                   of the sender or receiver, not the media format.
- *                   The 'inactive' media-level attribute is used to
- *                   indicate a disabled leg.
- *                   For a sender, the 'ts-refclk' attributes are used
- *                   to specify the node clock.
- *                   The 'x-nvnmos-id' session-level attribute specifies
- *                   the unique identifier for the sender or receiver,
- *                   @p id.
- *                   For a receiver, the 'x-nvnmos-iface-ip' media-level
- *                   attribute is used to specify the interface IP
- *                   address on which the stream is received.
- *                   For a sender, the 'x-nvnmos-src-port' media-level
- *                   attribute is used to specify the source port
- *                   from which the stream is transmitted.
+ * Used when the application's data plane has activated (or deactivated)
+ * a sender or receiver by some means other than an IS-05 Connection API
+ * patch, so that the IS-04 Node API and IS-05 Connection API model can
+ * be updated to reflect the new state. The library does not initiate
+ * any activation on the application's behalf.
+ *
+ * The application's @ref nmos_connection_activation_callback is not
+ * invoked as a result of this call.
+ *
+ * @param[in] server         A pointer to the server to be updated.
+ * @param[in] id             The unique identifier for the sender or
+ *                           receiver whose state has changed. The
+ *                           transport is inferred from the existing
+ *                           sender or receiver with this id.
+ * @param[in] transport_file The new transport file data reflecting the
+ *                           active state of the sender or receiver, or
+ *                           a null pointer when the sender or receiver
+ *                           has been deactivated. The new data only
+ *                           updates the transport parameters of the
+ *                           sender or receiver, not the media format.
+ *                           See
+ *                           @ref NvNmosSenderConfig::transport_file and
+ *                           @ref NvNmosReceiverConfig::transport_file
+ *                           for the recognised format (SDP for RTP,
+ *                           MXL flow definition JSON for MXL) and the
+ *                           supported 'x-nvnmos-' extensions.
  * @return Whether the update has been successfully applied.
  */
 NVNMOS_API
-bool nmos_connection_rtp_activate(
+bool nmos_connection_activate(
     NvNmosNodeServer *server,
     const char *id,
-    const char *sdp);
+    const char *transport_file);
 
 #ifdef __cplusplus
 }

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -124,16 +124,36 @@ typedef enum _NvNmosTransport
 } NvNmosTransport;
 
 /**
+ * Identifies a resource as either a Sender or a Receiver. Used by
+ * @ref nmos_connection_activate and @ref nmos_connection_activation_callback
+ * to disambiguate a name that may be shared between a Sender and a
+ * Receiver on the same Node (caller-chosen names are unique within a
+ * given side on a Node, but a Sender and a Receiver are permitted to
+ * use the same name).
+ */
+typedef enum _NvNmosSide
+{
+    /** An NMOS Sender. */
+    NVNMOS_SIDE_SENDER = 0,
+    /** An NMOS Receiver. */
+    NVNMOS_SIDE_RECEIVER = 1
+} NvNmosSide;
+
+/**
  * Type for a callback from NvNmos library when an IS-05 Connection API
  * activation occurs.
  *
  * @param[in] server         A pointer to the server issuing the callback.
- * @param[in] id             The unique identifier for the sender or receiver
- *                           to be activated or deactivated. This is the
- *                           same id originally supplied via the
- *                           configuration's transport file (see
+ * @param[in] side           Whether the activation is for a Sender or a
+ *                           Receiver.
+ * @param[in] name           The caller-chosen name for the sender or
+ *                           receiver to be activated or deactivated.
+ *                           This is the same name originally supplied
+ *                           via the configuration's transport file (see
  *                           @ref NvNmosSenderConfig::transport_file and
  *                           @ref NvNmosReceiverConfig::transport_file).
+ *                           Unique for the given @p side on the
+ *                           Node.
  * @param[in] transport_file The updated transport file data for the
  *                           sender or receiver, or a null pointer when
  *                           the sender or receiver is being deactivated.
@@ -141,33 +161,34 @@ typedef enum _NvNmosTransport
  *                           For an RTP sender or receiver this is an SDP
  *                           file. The 'inactive' media-level attribute is
  *                           used to indicate a disabled leg. The
- *                           'x-nvnmos-id' session-level attribute specifies
- *                           the unique identifier for the sender or
- *                           receiver, @p id. For a receiver, the
- *                           'x-nvnmos-iface-ip' media-level attribute is
- *                           used to specify the interface IP address on
- *                           which the stream is received. For a sender,
- *                           the 'x-nvnmos-src-port' media-level attribute
- *                           is used to specify the source port from which
- *                           the stream is transmitted.
+ *                           'x-nvnmos-name' session-level attribute specifies
+ *                           the name of the sender or receiver, @p name.
+ *                           For a receiver, the 'x-nvnmos-iface-ip'
+ *                           media-level attribute is used to specify the
+ *                           interface IP address on which the stream is
+ *                           received. For a sender, the 'x-nvnmos-src-port'
+ *                           media-level attribute is used to specify the
+ *                           source port from which the stream is
+ *                           transmitted.
  *
  *                           For an MXL sender or receiver this is an MXL
- *                           flow definition (JSON). The 'urn:x-nvnmos:tag:id'
- *                           tag in the 'tags' property specifies the unique
- *                           identifier for the sender or receiver, @p id;
+ *                           flow definition (JSON). The 'urn:x-nvnmos:tag:name'
+ *                           tag in the 'tags' property specifies the name
+ *                           of the sender or receiver, @p name;
  *                           the 'mxl_domain_id' and 'mxl_flow_id' IS-05
  *                           transport parameters are reflected in the
  *                           'urn:x-nvnmos:tag:mxl-domain-id' tag (also in
  *                           'tags') and the JSON document's top-level 'id'
  *                           field respectively.
  *                           The application is expected to dispatch on
- *                           @p id (which it specified) to determine the
- *                           transport, if needed.
+ *                           (@p side, @p name) (both of which it specified)
+ *                           to determine the transport, if needed.
  * @return Whether the activation could be applied.
  */
 typedef bool (* nmos_connection_activation_callback)(
     NvNmosNodeServer *server,
-    const char *id,
+    NvNmosSide side,
+    const char *name,
     const char *transport_file);
 
 /**
@@ -315,8 +336,8 @@ typedef struct _NvNmosReceiverConfig
         For ::NVNMOS_TRANSPORT_RTP, this is Session Description Protocol
         (SDP) data, which must be valid as per the relevant IETF RFC
         and SMPTE standards for the media format and transport.
-        The 'x-nvnmos-id' session-level attribute specifies the unique
-        identifier for the receiver.
+        The 'x-nvnmos-name' session-level attribute specifies the
+        caller-chosen name for the receiver, unique within the Node.
         The 'x-nvnmos-group-hint' session-level attribute may be used to
         specify a group hint tag for the receiver.
         The 'x-nvnmos-iface-ip' media-level attribute is used to specify
@@ -331,8 +352,9 @@ typedef struct _NvNmosReceiverConfig
         For ::NVNMOS_TRANSPORT_MXL, this is an MXL flow definition (JSON)
         of the form consumed by the MXL library, with NvNmos extensions
         carried as entries in the 'tags' property.
-        The 'urn:x-nvnmos:tag:id' tag (single-string array, required)
-        specifies the unique identifier for the receiver.
+        The 'urn:x-nvnmos:tag:name' tag (single-string array, required)
+        specifies the caller-chosen name for the receiver, unique within
+        the Node.
         A group hint tag may be specified via the standard
         'urn:x-nmos:tag:grouphint/v1.0' tag.
         The 'urn:x-nvnmos:tag:caps' tag may be used (presence-only) to
@@ -365,8 +387,8 @@ typedef struct _NvNmosSenderConfig
         (SDP) data, which must be valid as per the relevant IETF RFC
         and SMPTE standards for the media format and transport.
         The 'ts-refclk' attributes are used to specify the node clock.
-        The 'x-nvnmos-id' session-level attribute specifies the unique
-        identifier for the sender.
+        The 'x-nvnmos-name' session-level attribute specifies the
+        caller-chosen name for the sender, unique within the Node.
         The 'x-nvnmos-group-hint' session-level attribute may be used to
         specify a group hint tag for the sender.
         The 'x-nvnmos-src-port' media-level attribute is used to specify
@@ -376,8 +398,9 @@ typedef struct _NvNmosSenderConfig
         of the form consumed by the MXL library, with NvNmos extensions
         carried as entries in the 'tags' property (following the same
         URN convention as the standard 'urn:x-nmos:tag:grouphint/v1.0').
-        The 'urn:x-nvnmos:tag:id' tag (single-string array, required)
-        specifies the unique identifier for the sender.
+        The 'urn:x-nvnmos:tag:name' tag (single-string array, required)
+        specifies the caller-chosen name for the sender, unique within
+        the Node.
         A group hint tag may be specified via the standard
         'urn:x-nmos:tag:grouphint/v1.0' tag.
         The 'urn:x-nvnmos:tag:mxl-domain-id' tag (single-string array of
@@ -388,7 +411,7 @@ typedef struct _NvNmosSenderConfig
         if present, is used as the MXL flow identity for the sender's
         IS-05 transport parameter 'mxl_flow_id'; if absent, the NMOS
         Flow id (derived from @ref NvNmosNodeConfig::seed and the
-        'urn:x-nvnmos:tag:id' value) is used in its place. */
+        'urn:x-nvnmos:tag:name' value) is used in its place. */
     const char *transport_file;
 } NvNmosSenderConfig;
 
@@ -497,14 +520,15 @@ bool add_nmos_receiver_to_node_server(
  * The receiver may have been adding using @ref create_nmos_node_server
  * or @ref add_nmos_receiver_to_node_server.
  *
- * @param[in] server Pointer to the server to update.
- * @param[in] id     The unique identifier for the receiver to be removed.
+ * @param[in] server        Pointer to the server to update.
+ * @param[in] receiver_name The caller-chosen name of the receiver to be
+ *                          removed (see @ref NvNmosReceiverConfig::transport_file).
  * @return Whether the receiver has been successfully removed.
  */
 NVNMOS_API
 bool remove_nmos_receiver_from_node_server(
     NvNmosNodeServer *server,
-    const char* id);
+    const char* receiver_name);
 
 /**
  * Add an NMOS Sender to an NMOS Node server according to the
@@ -527,14 +551,15 @@ bool add_nmos_sender_to_node_server(
  * The sender may have been adding using @ref create_nmos_node_server
  * or @ref add_nmos_sender_to_node_server.
  *
- * @param[in] server Pointer to the server to update.
- * @param[in] id     The unique identifier for the sender to be removed.
- * @return Whether the receiver has been successfully removed.
+ * @param[in] server        Pointer to the server to update.
+ * @param[in] sender_name   The caller-chosen name of the sender to be
+ *                          removed (see @ref NvNmosSenderConfig::transport_file).
+ * @return Whether the sender has been successfully removed.
  */
 NVNMOS_API
 bool remove_nmos_sender_from_node_server(
     NvNmosNodeServer *server,
-    const char* id);
+    const char* sender_name);
 
 /**
  * Report that a sender or receiver has been activated or deactivated
@@ -550,10 +575,12 @@ bool remove_nmos_sender_from_node_server(
  * invoked as a result of this call.
  *
  * @param[in] server         A pointer to the server to be updated.
- * @param[in] id             The unique identifier for the sender or
+ * @param[in] side           Whether the sender or receiver is a Sender
+ *                           or a Receiver.
+ * @param[in] name           The caller-chosen name of the sender or
  *                           receiver whose state has changed. The
  *                           transport is inferred from the existing
- *                           sender or receiver with this id.
+ *                           sender or receiver of @p side with this name.
  * @param[in] transport_file The new transport file data reflecting the
  *                           active state of the sender or receiver, or
  *                           a null pointer when the sender or receiver
@@ -571,7 +598,8 @@ bool remove_nmos_sender_from_node_server(
 NVNMOS_API
 bool nmos_connection_activate(
     NvNmosNodeServer *server,
-    const char *id,
+    NvNmosSide side,
+    const char *name,
     const char *transport_file);
 
 /**
@@ -601,13 +629,13 @@ bool nmos_make_node_id(
 /**
  * Compute the NMOS Sender resource id that an
  * @ref NvNmosNodeServer created with the given @p seed will use for
- * the sender identified by the given @p internal_id.
+ * the sender with the given @p sender_name.
  *
- * Pure function of (@p seed, @p internal_id). See
+ * Pure function of (@p seed, @p sender_name). See
  * @ref nmos_make_node_id for the contract; the same notes apply.
  *
  * @param[in]  seed        Seed string. Must not be null.
- * @param[in]  internal_id The internal id of the sender (see
+ * @param[in]  sender_name The caller-chosen name of the sender (see
  *                         @ref NvNmosSenderConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
@@ -617,30 +645,30 @@ bool nmos_make_node_id(
 NVNMOS_API
 bool nmos_make_sender_id(
     const char *seed,
-    const char *internal_id,
+    const char *sender_name,
     char *out,
     size_t out_len);
 
 /**
  * Compute the NMOS Receiver resource id that an
  * @ref NvNmosNodeServer created with the given @p seed will use for
- * the receiver identified by the given @p internal_id.
+ * the receiver with the given @p receiver_name.
  *
- * Pure function of (@p seed, @p internal_id). See
+ * Pure function of (@p seed, @p receiver_name). See
  * @ref nmos_make_node_id for the contract.
  *
- * @param[in]  seed        Seed string. Must not be null.
- * @param[in]  internal_id The internal id of the receiver (see
- *                         @ref NvNmosReceiverConfig::transport_file).
- *                         Must not be null.
- * @param[out] out         Buffer to receive the id.
- * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @param[in]  seed          Seed string. Must not be null.
+ * @param[in]  receiver_name The caller-chosen name of the receiver (see
+ *                           @ref NvNmosReceiverConfig::transport_file).
+ *                           Must not be null.
+ * @param[out] out           Buffer to receive the id.
+ * @param[in]  out_len       Size of @p out, at least @ref NVNMOS_ID_LEN.
  * @return Whether the id has been written to @p out.
  */
 NVNMOS_API
 bool nmos_make_receiver_id(
     const char *seed,
-    const char *internal_id,
+    const char *receiver_name,
     char *out,
     size_t out_len);
 
@@ -664,12 +692,12 @@ bool nmos_get_node_id(
  * Get the NMOS Sender resource id of a sender currently registered
  * with the specified server.
  *
- * Looks the sender up by its internal id. Returns false (without
- * writing to @p out) if no sender with the given @p internal_id has
- * been added to the server.
+ * Looks the sender up by its name. Returns false (without writing to
+ * @p out) if no sender with the given @p sender_name has been added
+ * to the server.
  *
  * @param[in]  server      Pointer to the server.
- * @param[in]  internal_id The internal id of the sender (see
+ * @param[in]  sender_name The caller-chosen name of the sender (see
  *                         @ref NvNmosSenderConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
@@ -679,7 +707,7 @@ bool nmos_get_node_id(
 NVNMOS_API
 bool nmos_get_sender_id(
     const NvNmosNodeServer *server,
-    const char *internal_id,
+    const char *sender_name,
     char *out,
     size_t out_len);
 
@@ -687,22 +715,22 @@ bool nmos_get_sender_id(
  * Get the NMOS Receiver resource id of a receiver currently
  * registered with the specified server.
  *
- * Looks the receiver up by its internal id. Returns false (without
- * writing to @p out) if no receiver with the given @p internal_id
- * has been added to the server.
+ * Looks the receiver up by its name. Returns false (without writing
+ * to @p out) if no receiver with the given @p receiver_name has been
+ * added to the server.
  *
- * @param[in]  server      Pointer to the server.
- * @param[in]  internal_id The internal id of the receiver (see
- *                         @ref NvNmosReceiverConfig::transport_file).
- *                         Must not be null.
- * @param[out] out         Buffer to receive the id.
- * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @param[in]  server        Pointer to the server.
+ * @param[in]  receiver_name The caller-chosen name of the receiver (see
+ *                           @ref NvNmosReceiverConfig::transport_file).
+ *                           Must not be null.
+ * @param[out] out           Buffer to receive the id.
+ * @param[in]  out_len       Size of @p out, at least @ref NVNMOS_ID_LEN.
  * @return Whether the id has been written to @p out.
  */
 NVNMOS_API
 bool nmos_get_receiver_id(
     const NvNmosNodeServer *server,
-    const char *internal_id,
+    const char *receiver_name,
     char *out,
     size_t out_len);
 

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -39,8 +39,9 @@
  * used to update running DeepStream pipelines with new transport parameters,
  * for example.
  *
- * NvNmos currently supports Senders and Receivers for video, audio, and ancillary data flows over RTP
- * (i.e., SMPTE ST 2110-20, -22, -30, and -40 streams) and over the Media eXchange Layer (MXL).
+ * NvNmos currently supports Senders and Receivers for video, audio, and
+ * ancillary data flows over RTP (i.e., SMPTE ST 2110-20, -22, -30, and -40
+ * streams) and over the Media eXchange Layer (MXL).
  *
  * The NvNmos library supports the following specifications, using the <a href="https://github.com/sony/nmos-cpp">Sony nmos-cpp</a> implementation:
  * - <a href="https://specs.amwa.tv/is-04/">AMWA IS-04 NMOS Discovery and Registration Specification</a> v1.3

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -130,8 +130,10 @@ typedef enum _NvNmosTransport
  * @param[in] server         A pointer to the server issuing the callback.
  * @param[in] id             The unique identifier for the sender or receiver
  *                           to be activated or deactivated. This is the
- *                           same id specified in the configuration's
- *                           'x-nvnmos-id' attribute or property.
+ *                           same id originally supplied via the
+ *                           configuration's transport file (see
+ *                           @ref NvNmosSenderConfig::transport_file and
+ *                           @ref NvNmosReceiverConfig::transport_file).
  * @param[in] transport_file The updated transport file data for the
  *                           sender or receiver, or a null pointer when
  *                           the sender or receiver is being deactivated.
@@ -150,13 +152,14 @@ typedef enum _NvNmosTransport
  *                           the stream is transmitted.
  *
  *                           For an MXL sender or receiver this is an MXL
- *                           flow definition (JSON), with the
- *                           'x-nvnmos-id' property specifying the unique
- *                           identifier for the sender or receiver, @p id,
- *                           and the 'mxl_domain_id' and 'mxl_flow_id'
- *                           IS-05 transport parameters reflected as the
- *                           'x-nvnmos-mxl-domain-id' key and the JSON
- *                           document's 'id' field respectively.
+ *                           flow definition (JSON). The 'urn:x-nvnmos:tag:id'
+ *                           tag in the 'tags' property specifies the unique
+ *                           identifier for the sender or receiver, @p id;
+ *                           the 'mxl_domain_id' and 'mxl_flow_id' IS-05
+ *                           transport parameters are reflected in the
+ *                           'urn:x-nvnmos:tag:mxl-domain-id' tag (also in
+ *                           'tags') and the JSON document's top-level 'id'
+ *                           field respectively.
  *                           The application is expected to dispatch on
  *                           @p id (which it specified) to determine the
  *                           transport, if needed.
@@ -326,19 +329,22 @@ typedef struct _NvNmosReceiverConfig
         dynamically by IS-05).
 
         For ::NVNMOS_TRANSPORT_MXL, this is an MXL flow definition (JSON)
-        of the form consumed by the MXL library, with NvNmos extensions.
-        The 'x-nvnmos-id' top-level property specifies the unique
-        identifier for the receiver.
-        A group hint tag may be specified via the 'tags' property.
-        The 'x-nvnmos-caps' top-level property may be used to indicate
-        that the receiver should be advertised with the format-derived
-        capabilities omitted.
-        The 'x-nvnmos-mxl-domain-id' top-level property (UUID string)
-        is required and specifies the MXL domain for the receiver;
+        of the form consumed by the MXL library, with NvNmos extensions
+        carried as entries in the 'tags' property.
+        The 'urn:x-nvnmos:tag:id' tag (single-string array, required)
+        specifies the unique identifier for the receiver.
+        A group hint tag may be specified via the standard
+        'urn:x-nmos:tag:grouphint/v1.0' tag.
+        The 'urn:x-nvnmos:tag:caps' tag may be used (presence-only) to
+        indicate that the receiver should be advertised with the
+        format-derived capabilities omitted.
+        The 'urn:x-nvnmos:tag:mxl-domain-id' tag (single-string array of
+        a UUID, required) specifies the MXL domain for the receiver;
         the IS-05 transport parameter defaults to 'auto' and is
         resolved at activation time from this value.
-        The flow definition's 'id' field is not used by the receiver
-        itself (since the MXL flow id is set dynamically by IS-05). */
+        The flow definition's top-level 'id' field is not used by the
+        receiver itself (since the MXL flow id is set dynamically by
+        IS-05). */
     const char *transport_file;
 } NvNmosReceiverConfig;
 
@@ -367,19 +373,22 @@ typedef struct _NvNmosSenderConfig
         the source port from which the stream is transmitted.
 
         For ::NVNMOS_TRANSPORT_MXL, this is an MXL flow definition (JSON)
-        of the form consumed by the MXL library, with NvNmos extensions.
-        The 'x-nvnmos-id' top-level property specifies the unique
-        identifier for the sender.
-        A group hint tag may be specified via the 'tags' property.
-        The 'x-nvnmos-mxl-domain-id' top-level property (UUID string)
-        is required and specifies the MXL domain for the sender;
+        of the form consumed by the MXL library, with NvNmos extensions
+        carried as entries in the 'tags' property (following the same
+        URN convention as the standard 'urn:x-nmos:tag:grouphint/v1.0').
+        The 'urn:x-nvnmos:tag:id' tag (single-string array, required)
+        specifies the unique identifier for the sender.
+        A group hint tag may be specified via the standard
+        'urn:x-nmos:tag:grouphint/v1.0' tag.
+        The 'urn:x-nvnmos:tag:mxl-domain-id' tag (single-string array of
+        a UUID, required) specifies the MXL domain for the sender;
         the IS-05 transport parameter defaults to 'auto' and is
         resolved at activation time from this value.
-        The flow definition's 'id' field (UUID string), if present, is
-        used as the MXL flow identity for the sender's IS-05 transport
-        parameter 'mxl_flow_id'; if absent, the NMOS Flow id (derived
-        from @ref NvNmosNodeConfig::seed and the 'x-nvnmos-id') is used
-        in its place. */
+        The flow definition's top-level 'id' field (UUID string),
+        if present, is used as the MXL flow identity for the sender's
+        IS-05 transport parameter 'mxl_flow_id'; if absent, the NMOS
+        Flow id (derived from @ref NvNmosNodeConfig::seed and the
+        'urn:x-nvnmos:tag:id' value) is used in its place. */
     const char *transport_file;
 } NvNmosSenderConfig;
 
@@ -556,7 +565,7 @@ bool remove_nmos_sender_from_node_server(
  *                           @ref NvNmosReceiverConfig::transport_file
  *                           for the recognised format (SDP for RTP,
  *                           MXL flow definition JSON for MXL) and the
- *                           supported 'x-nvnmos-' extensions.
+ *                           supported NvNmos extensions.
  * @return Whether the update has been successfully applied.
  */
 NVNMOS_API
@@ -598,7 +607,8 @@ bool nmos_make_node_id(
  * @ref nmos_make_node_id for the contract; the same notes apply.
  *
  * @param[in]  seed        Seed string. Must not be null.
- * @param[in]  internal_id The 'x-nvnmos-id' value of the sender.
+ * @param[in]  internal_id The internal id of the sender (see
+ *                         @ref NvNmosSenderConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
  * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
@@ -620,7 +630,8 @@ bool nmos_make_sender_id(
  * @ref nmos_make_node_id for the contract.
  *
  * @param[in]  seed        Seed string. Must not be null.
- * @param[in]  internal_id The 'x-nvnmos-id' value of the receiver.
+ * @param[in]  internal_id The internal id of the receiver (see
+ *                         @ref NvNmosReceiverConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
  * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
@@ -658,7 +669,8 @@ bool nmos_get_node_id(
  * been added to the server.
  *
  * @param[in]  server      Pointer to the server.
- * @param[in]  internal_id The 'x-nvnmos-id' of the sender.
+ * @param[in]  internal_id The internal id of the sender (see
+ *                         @ref NvNmosSenderConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
  * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
@@ -680,7 +692,8 @@ bool nmos_get_sender_id(
  * has been added to the server.
  *
  * @param[in]  server      Pointer to the server.
- * @param[in]  internal_id The 'x-nvnmos-id' of the receiver.
+ * @param[in]  internal_id The internal id of the receiver (see
+ *                         @ref NvNmosReceiverConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
  * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -88,11 +88,20 @@
 #endif
 
 #include <stdbool.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
+
+/**
+ * Buffer size, in bytes, that is always sufficient to hold an NMOS
+ * resource id (a UUID in canonical 8-4-4-4-12 hex form) including the
+ * terminating null character. Callers may pass buffers of this size
+ * or larger to the id accessor functions defined below.
+ */
+#define NVNMOS_ID_LEN 37
 
 typedef struct _NvNmosNodeServer NvNmosNodeServer;
 
@@ -555,6 +564,134 @@ bool nmos_connection_activate(
     NvNmosNodeServer *server,
     const char *id,
     const char *transport_file);
+
+/**
+ * Compute the NMOS Node resource id (the '/self' UUID) that an
+ * @ref NvNmosNodeServer created with the given @p seed will use.
+ *
+ * Pure function of @p seed. The id is generated deterministically by
+ * the library, so calling this before @ref create_nmos_node_server
+ * yields the same value as @ref nmos_get_node_id on the resulting
+ * server. Useful for tooling that needs to pre-compute an id without
+ * standing up a server.
+ *
+ * @param[in]  seed    Seed string. Must not be null. The same string
+ *                     used in @ref NvNmosNodeConfig::seed.
+ * @param[out] out     Buffer to receive the id as a null-terminated
+ *                     ASCII string in canonical UUID form.
+ * @param[in]  out_len Size of @p out in bytes. Must be at least
+ *                     @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_make_node_id(
+    const char *seed,
+    char *out,
+    size_t out_len);
+
+/**
+ * Compute the NMOS Sender resource id that an
+ * @ref NvNmosNodeServer created with the given @p seed will use for
+ * the sender identified by the given @p internal_id.
+ *
+ * Pure function of (@p seed, @p internal_id). See
+ * @ref nmos_make_node_id for the contract; the same notes apply.
+ *
+ * @param[in]  seed        Seed string. Must not be null.
+ * @param[in]  internal_id The 'x-nvnmos-id' value of the sender.
+ *                         Must not be null.
+ * @param[out] out         Buffer to receive the id.
+ * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_make_sender_id(
+    const char *seed,
+    const char *internal_id,
+    char *out,
+    size_t out_len);
+
+/**
+ * Compute the NMOS Receiver resource id that an
+ * @ref NvNmosNodeServer created with the given @p seed will use for
+ * the receiver identified by the given @p internal_id.
+ *
+ * Pure function of (@p seed, @p internal_id). See
+ * @ref nmos_make_node_id for the contract.
+ *
+ * @param[in]  seed        Seed string. Must not be null.
+ * @param[in]  internal_id The 'x-nvnmos-id' value of the receiver.
+ *                         Must not be null.
+ * @param[out] out         Buffer to receive the id.
+ * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_make_receiver_id(
+    const char *seed,
+    const char *internal_id,
+    char *out,
+    size_t out_len);
+
+/**
+ * Get the NMOS Node resource id (the '/self' UUID) of a running
+ * @ref NvNmosNodeServer.
+ *
+ * @param[in]  server  Pointer to a server previously initialised by
+ *                     @ref create_nmos_node_server.
+ * @param[out] out     Buffer to receive the id.
+ * @param[in]  out_len Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_get_node_id(
+    const NvNmosNodeServer *server,
+    char *out,
+    size_t out_len);
+
+/**
+ * Get the NMOS Sender resource id of a sender currently registered
+ * with the specified server.
+ *
+ * Looks the sender up by its internal id. Returns false (without
+ * writing to @p out) if no sender with the given @p internal_id has
+ * been added to the server.
+ *
+ * @param[in]  server      Pointer to the server.
+ * @param[in]  internal_id The 'x-nvnmos-id' of the sender.
+ *                         Must not be null.
+ * @param[out] out         Buffer to receive the id.
+ * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_get_sender_id(
+    const NvNmosNodeServer *server,
+    const char *internal_id,
+    char *out,
+    size_t out_len);
+
+/**
+ * Get the NMOS Receiver resource id of a receiver currently
+ * registered with the specified server.
+ *
+ * Looks the receiver up by its internal id. Returns false (without
+ * writing to @p out) if no receiver with the given @p internal_id
+ * has been added to the server.
+ *
+ * @param[in]  server      Pointer to the server.
+ * @param[in]  internal_id The 'x-nvnmos-id' of the receiver.
+ *                         Must not be null.
+ * @param[out] out         Buffer to receive the id.
+ * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_get_receiver_id(
+    const NvNmosNodeServer *server,
+    const char *internal_id,
+    char *out,
+    size_t out_len);
 
 #ifdef __cplusplus
 }

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -98,7 +98,7 @@ namespace nvnmos
         // with support for the custom SDP attributes in nvnmos::attributes for senders as well as receivers
         web::json::value get_session_description_transport_params(const nmos::type& type, const web::json::value& session_description);
 
-        // get the internal id from the custom attribute
+        // get the (required) internal id from the custom attribute; throws std::invalid_argument if absent or empty
         utility::string_t get_session_description_internal_id(const web::json::value& session_description);
 
         // get the optional group hint from the custom attribute
@@ -150,6 +150,28 @@ namespace nvnmos
     // forward declarations
     nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver();
 
+    namespace impl
+    {
+        // parse an MXL flow definition (JSON) including nvnmos extensions
+        // (x-nvnmos-* top-level properties); propagates web::json::json_exception on parse error
+        web::json::value parse_mxl_flow_def(const std::string& flow_def);
+        // extract the (required) internal id from the x-nvnmos-id top-level property;
+        // throws std::invalid_argument if absent or empty
+        utility::string_t get_mxl_flow_def_internal_id(const web::json::value& flow_def);
+        // extract an optional group hint from the tags property (or empty)
+        utility::string_t get_mxl_flow_def_group_hint(const web::json::value& flow_def);
+        // returns true if the x-nvnmos-caps top-level property is present
+        bool has_mxl_flow_def_caps(const web::json::value& flow_def);
+        // extract the (required) MXL domain id from the x-nvnmos-mxl-domain-id top-level property;
+        // throws std::invalid_argument if absent or empty (the IS-05 transport parameter defaults
+        // to "auto" and is resolved at activation time from this value)
+        utility::string_t get_mxl_flow_def_domain_id(const web::json::value& flow_def);
+        // extract the top-level 'id' property (or empty)
+        utility::string_t get_mxl_flow_def_id(const web::json::value& flow_def);
+        // produce a flow definition JSON string with the active MXL transport parameters spliced in
+        std::string make_mxl_flow_def(web::json::value flow_def, const utility::string_t& mxl_domain_id, const utility::string_t& mxl_flow_id);
+    }
+
     void node_implementation_init_(nmos::resources& node_resources, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
     {
         using web::json::value;
@@ -187,7 +209,7 @@ namespace nvnmos
         settings[nvnmos::fields::receivers] = value::object();
     }
 
-    void node_implementation_add_sender_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& sdp_, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
+    void node_implementation_add_rtp_sender_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& sdp_, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
     {
         using web::json::value;
         using web::json::value_of;
@@ -382,11 +404,11 @@ namespace nvnmos
         // insert into settings
 
         nvnmos::fields::senders(settings)[sender_id] = value_of({
-            { nvnmos::fields::sdp, utility::s2us(sdp_) }
+            { nvnmos::fields::transport_file, utility::s2us(sdp_) }
         });
     }
 
-    void node_implementation_add_receiver_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& sdp_, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
+    void node_implementation_add_rtp_receiver_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& sdp_, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
     {
         using web::json::value;
         using web::json::value_of;
@@ -559,7 +581,261 @@ namespace nvnmos
         // insert into settings
 
         nvnmos::fields::receivers(settings)[receiver_id] = value_of({
-            { nvnmos::fields::sdp, utility::s2us(sdp_) }
+            { nvnmos::fields::transport_file, utility::s2us(sdp_) }
+        });
+    }
+
+    void node_implementation_add_mxl_sender_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& flow_def_, nmos::settings& settings, slog::base_gate& gate)
+    {
+        using web::json::value;
+        using web::json::value_of;
+
+        const auto flow_def = impl::parse_mxl_flow_def(flow_def_);
+        const auto internal_id = impl::get_mxl_flow_def_internal_id(flow_def);
+        const auto group_hint = impl::get_mxl_flow_def_group_hint(flow_def);
+        const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(flow_def);
+
+        const auto seed_id = nmos::experimental::fields::seed_id(settings);
+        const auto node_id = impl::make_id(seed_id, nmos::types::node);
+        const auto device_id = impl::make_id(seed_id, nmos::types::device);
+        const auto source_id = impl::make_id(seed_id, nmos::types::source, internal_id);
+        const auto flow_id = impl::make_id(seed_id, nmos::types::flow, internal_id);
+        const auto sender_id = impl::make_id(seed_id, nmos::types::sender, internal_id);
+
+        // the NMOS Flow id is always generated (flow_id, above); the MXL flow id is taken from the flow
+        // definition's 'id' property if present, otherwise it falls back to the NMOS Flow id
+        const auto explicit_mxl_flow_id = impl::get_mxl_flow_def_id(flow_def);
+        const auto mxl_flow_id = !explicit_mxl_flow_id.empty() ? explicit_mxl_flow_id : flow_id;
+
+        // for now, only manage a single clock (internal); MXL has no equivalent to RTP ts-refclk,
+        // that will require a new nvnmos extension property
+        const auto clock = nmos::clock_names::clk0;
+
+        const nmos::media_type media_type{ nmos::fields::media_type(flow_def) };
+        const auto format = impl::get_format(media_type);
+
+        nmos::resource source;
+        nmos::resource flow;
+
+        if (impl::format::video == format)
+        {
+            // assuming an MXL flow definition follows IS-04 v1.3 once an MXL SDK schema lands,
+            // the structural properties (grain_rate, frame_width, frame_height, colorspace) are
+            // required; let nmos::fields::* propagate json_exception if absent
+            const auto grain_rate = nmos::parse_rational(nmos::fields::grain_rate(flow_def));
+            const auto frame_width = nmos::fields::frame_width(flow_def);
+            const auto frame_height = nmos::fields::frame_height(flow_def);
+            const auto colorspace = nmos::colorspace{ nmos::fields::colorspace(flow_def) };
+            // interlace_mode and transfer_characteristic have defaults; absent in MXL flow_def
+            // maps to absent in NMOS Flow
+            const auto interlace_mode = nmos::interlace_mode{ nmos::fields::interlace_mode(flow_def) };
+            const auto transfer_characteristic = nmos::transfer_characteristic{ nmos::fields::transfer_characteristic(flow_def) };
+
+            // components is required (carries sampling and bit depth); use nmos-cpp's helper
+            // to classify the sampling and let it throw on unsupported components
+            const auto& components = nmos::fields::components(flow_def);
+            const auto sampling = nmos::details::make_sampling(components);
+            const auto bit_depth = nmos::fields::bit_depth(components.at(0));
+
+            source = nmos::make_video_source(source_id, device_id, clock, grain_rate, settings);
+            flow = nmos::make_coded_video_flow(
+                flow_id, source_id, device_id,
+                grain_rate, frame_width, frame_height, interlace_mode,
+                colorspace, transfer_characteristic, sampling, bit_depth,
+                media_type,
+                settings
+            );
+        }
+        else if (impl::format::audio == format)
+        {
+            // sample_rate, channel_count and bit_depth are required; let the accessors propagate
+            // json_exception if absent
+            const auto sample_rate = nmos::parse_rational(nmos::fields::sample_rate(flow_def));
+            const auto channel_count = nvnmos::fields::channel_count(flow_def);
+            const auto bit_depth = nmos::fields::bit_depth(flow_def);
+
+            const auto channels = boost::copy_range<std::vector<nmos::channel>>(
+                boost::irange(0, channel_count) | boost::adaptors::transformed([&](const int& index)
+            {
+                return nmos::channel{ U(""), nmos::channel_symbols::Undefined(1 + index) };
+            }));
+
+            source = nmos::make_audio_source(source_id, device_id, clock, sample_rate, channels, settings);
+            flow = nmos::make_raw_audio_flow(flow_id, source_id, device_id, sample_rate, bit_depth, settings);
+            flow.data[nmos::fields::media_type] = value::string(media_type.name);
+        }
+        else if (impl::format::data == format)
+        {
+            const auto grain_rate = nmos::parse_rational(nmos::fields::grain_rate(flow_def));
+
+            source = nmos::make_data_source(source_id, device_id, clock, grain_rate, settings);
+            flow = nmos::make_sdianc_data_flow(flow_id, source_id, device_id, {}, settings);
+            flow.data[nmos::fields::grain_rate] = nmos::make_rational(grain_rate);
+        }
+        else
+        {
+            slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unsupported MXL media type for sender: " << media_type.name;
+            throw node_implementation_exception();
+        }
+
+        // MXL sender: no manifest_href (no /transportfile), no interface_bindings
+        auto sender = nmos::make_sender(sender_id, flow_id, nmos::transports::mxl, device_id, {}, {}, settings);
+
+        auto connection_sender = nmos::make_connection_mxl_sender(sender_id, mxl_domain_id, mxl_flow_id);
+
+        const auto resolve_auto = make_node_implementation_auto_resolver();
+        resolve_auto(sender, connection_sender, connection_sender.data[nmos::fields::endpoint_active][nmos::fields::transport_params]);
+
+        // label and description are required (per IS-04 v1.3); let the accessors propagate
+        // json_exception if absent
+        sender.data[nmos::fields::label] = value::string(nmos::fields::label(flow_def));
+        sender.data[nmos::fields::description] = value::string(nmos::fields::description(flow_def));
+        impl::set_internal_id(sender, internal_id);
+        if (!group_hint.empty()) impl::set_group_hint(sender, group_hint);
+
+        if (!insert_resource(node_resources, std::move(source)).second) throw node_implementation_exception();
+        if (!insert_resource(node_resources, std::move(flow)).second) throw node_implementation_exception();
+        if (!insert_resource(node_resources, std::move(sender)).second) throw node_implementation_exception();
+        if (!insert_resource(connection_resources, std::move(connection_sender)).second) throw node_implementation_exception();
+
+        // update device's deprecated senders array
+
+        nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
+        {
+            device.data[nmos::fields::version] = value::string(nmos::make_version());
+            web::json::push_back(nmos::fields::senders(device.data), sender_id);
+        });
+
+        // insert into settings
+
+        nvnmos::fields::senders(settings)[sender_id] = value_of({
+            { nvnmos::fields::transport_file, utility::s2us(flow_def_) }
+        });
+    }
+
+    void node_implementation_add_mxl_receiver_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& flow_def_, nmos::settings& settings, slog::base_gate& gate)
+    {
+        using web::json::value;
+        using web::json::value_of;
+
+        const auto flow_def = impl::parse_mxl_flow_def(flow_def_);
+        const auto internal_id = impl::get_mxl_flow_def_internal_id(flow_def);
+        const auto group_hint = impl::get_mxl_flow_def_group_hint(flow_def);
+        const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(flow_def);
+        const auto want_caps = !impl::has_mxl_flow_def_caps(flow_def);
+
+        const auto seed_id = nmos::experimental::fields::seed_id(settings);
+        const auto device_id = impl::make_id(seed_id, nmos::types::device);
+        const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, internal_id);
+
+        const nmos::media_type media_type{ nmos::fields::media_type(flow_def) };
+        const auto format = impl::get_format(media_type);
+
+        nmos::resource receiver;
+
+        if (impl::format::video == format)
+        {
+            receiver = nmos::make_receiver(receiver_id, device_id, nmos::transports::mxl, {}, nmos::formats::video, { media_type }, settings);
+
+            if (want_caps)
+            {
+                // structural properties are required; let nmos::fields::* throw if absent
+                const auto grain_rate = nmos::parse_rational(nmos::fields::grain_rate(flow_def));
+                const auto frame_width = nmos::fields::frame_width(flow_def);
+                const auto frame_height = nmos::fields::frame_height(flow_def);
+                const auto& components = nmos::fields::components(flow_def);
+                const auto sampling = nmos::details::make_sampling(components);
+                const auto interlace_mode_name = nmos::fields::interlace_mode(flow_def);
+                const auto interlace_modes = nmos::interlace_modes::progressive.name == interlace_mode_name
+                    ? std::vector<utility::string_t>{ nmos::interlace_modes::progressive.name }
+                    : std::vector<utility::string_t>{ nmos::interlace_modes::interlaced_bff.name, nmos::interlace_modes::interlaced_tff.name, nmos::interlace_modes::interlaced_psf.name };
+
+                receiver.data[nmos::fields::caps][nmos::fields::constraint_sets] = value_of({
+                    value_of({
+                        { nmos::caps::format::media_type, nmos::make_caps_string_constraint({ media_type.name }) },
+                        { nmos::caps::format::grain_rate, nmos::make_caps_rational_constraint({ grain_rate }) },
+                        { nmos::caps::format::frame_width, nmos::make_caps_integer_constraint({ frame_width }) },
+                        { nmos::caps::format::frame_height, nmos::make_caps_integer_constraint({ frame_height }) },
+                        { !interlace_mode_name.empty() ? nmos::caps::format::interlace_mode.key : U(""), nmos::make_caps_string_constraint(interlace_modes) },
+                        { nmos::caps::format::color_sampling, nmos::make_caps_string_constraint({ sampling.name }) }
+                    })
+                });
+                receiver.data[nmos::fields::version] = receiver.data[nmos::fields::caps][nmos::fields::version] = value(nmos::make_version());
+            }
+        }
+        else if (impl::format::audio == format)
+        {
+            // sample_rate, channel_count and bit_depth are required; let nmos::fields::* throw if absent
+            const auto sample_rate = nmos::parse_rational(nmos::fields::sample_rate(flow_def));
+            const auto channel_count = nvnmos::fields::channel_count(flow_def);
+            const auto bit_depth = nmos::fields::bit_depth(flow_def);
+
+            receiver = nmos::make_receiver(receiver_id, device_id, nmos::transports::mxl, {}, nmos::formats::audio, { media_type }, settings);
+
+            if (want_caps)
+            {
+                receiver.data[nmos::fields::caps][nmos::fields::constraint_sets] = value_of({
+                    value_of({
+                        { nmos::caps::format::media_type, nmos::make_caps_string_constraint({ media_type.name }) },
+                        { nmos::caps::format::channel_count, nmos::make_caps_integer_constraint({ channel_count }) },
+                        { nmos::caps::format::sample_rate, nmos::make_caps_rational_constraint({ sample_rate }) },
+                        { nmos::caps::format::sample_depth, nmos::make_caps_integer_constraint({ bit_depth }) }
+                    })
+                });
+                receiver.data[nmos::fields::version] = receiver.data[nmos::fields::caps][nmos::fields::version] = value(nmos::make_version());
+            }
+        }
+        else if (impl::format::data == format)
+        {
+            receiver = nmos::make_sdianc_data_receiver(receiver_id, device_id, nmos::transports::mxl, {}, settings);
+
+            if (want_caps)
+            {
+                if (flow_def.has_field(nmos::fields::grain_rate))
+                {
+                    const auto grain_rate = nmos::parse_rational(nmos::fields::grain_rate(flow_def));
+                    receiver.data[nmos::fields::caps][nmos::fields::constraint_sets] = value_of({
+                        value_of({
+                            { nmos::caps::format::grain_rate, nmos::make_caps_rational_constraint({ grain_rate }) }
+                        })
+                    });
+                    receiver.data[nmos::fields::version] = receiver.data[nmos::fields::caps][nmos::fields::version] = value(nmos::make_version());
+                }
+            }
+        }
+        else
+        {
+            slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unsupported MXL media type for receiver: " << media_type.name;
+            throw node_implementation_exception();
+        }
+
+        auto connection_receiver = nmos::make_connection_mxl_receiver(receiver_id, mxl_domain_id);
+
+        const auto resolve_auto = make_node_implementation_auto_resolver();
+        resolve_auto(receiver, connection_receiver, connection_receiver.data[nmos::fields::endpoint_active][nmos::fields::transport_params]);
+
+        // label and description are required (per IS-04 v1.3); let the accessors propagate
+        // json_exception if absent
+        receiver.data[nmos::fields::label] = value::string(nmos::fields::label(flow_def));
+        receiver.data[nmos::fields::description] = value::string(nmos::fields::description(flow_def));
+        impl::set_internal_id(receiver, internal_id);
+        if (!group_hint.empty()) impl::set_group_hint(receiver, group_hint);
+
+        if (!insert_resource(node_resources, std::move(receiver)).second) throw node_implementation_exception();
+        if (!insert_resource(connection_resources, std::move(connection_receiver)).second) throw node_implementation_exception();
+
+        // update device's deprecated receivers array
+
+        nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
+        {
+            device.data[nmos::fields::version] = value::string(nmos::make_version());
+            web::json::push_back(nmos::fields::receivers(device.data), receiver_id);
+        });
+
+        // insert into settings
+
+        nvnmos::fields::receivers(settings)[receiver_id] = value_of({
+            { nvnmos::fields::transport_file, utility::s2us(flow_def_) }
         });
     }
 
@@ -653,26 +929,50 @@ namespace nvnmos
         model.notify();
     }
 
-    // This constructs and inserts sources/flows/senders into the model, based on the specified SDP file.
-    void node_implementation_add_sender(nmos::node_model& model, const std::string& sdp, slog::base_gate& gate)
+    // This constructs and inserts sources/flows/senders into the model, based on the specified transport file.
+    void node_implementation_add_sender(nmos::node_model& model, const nmos::transport& transport, const std::string& transport_file, slog::base_gate& gate)
     {
         auto lock = model.write_lock(); // in order to update the resources
 
         const auto host_interfaces = web::hosts::experimental::host_interfaces();
 
-        node_implementation_add_sender_(model.node_resources, model.connection_resources, sdp, host_interfaces, model.settings, gate);
+        if (nmos::transports::rtp == nmos::transport_base(transport))
+        {
+            node_implementation_add_rtp_sender_(model.node_resources, model.connection_resources, transport_file, host_interfaces, model.settings, gate);
+        }
+        else if (nmos::transports::mxl == nmos::transport_base(transport))
+        {
+            node_implementation_add_mxl_sender_(model.node_resources, model.connection_resources, transport_file, model.settings, gate);
+        }
+        else
+        {
+            slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unsupported transport: " << transport.name;
+            throw node_implementation_exception();
+        }
 
         model.notify();
     }
 
-    // This constructs and inserts a receiver into the model, based on the specified SDP file.
-    void node_implementation_add_receiver(nmos::node_model& model, const std::string& sdp, slog::base_gate& gate)
+    // This constructs and inserts a receiver into the model, based on the specified transport file.
+    void node_implementation_add_receiver(nmos::node_model& model, const nmos::transport& transport, const std::string& transport_file, slog::base_gate& gate)
     {
         auto lock = model.write_lock(); // in order to update the resources
 
         const auto host_interfaces = web::hosts::experimental::host_interfaces();
 
-        node_implementation_add_receiver_(model.node_resources, model.connection_resources, sdp, host_interfaces, model.settings, gate);
+        if (nmos::transports::rtp == nmos::transport_base(transport))
+        {
+            node_implementation_add_rtp_receiver_(model.node_resources, model.connection_resources, transport_file, host_interfaces, model.settings, gate);
+        }
+        else if (nmos::transports::mxl == nmos::transport_base(transport))
+        {
+            node_implementation_add_mxl_receiver_(model.node_resources, model.connection_resources, transport_file, model.settings, gate);
+        }
+        else
+        {
+            slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Unsupported transport: " << transport.name;
+            throw node_implementation_exception();
+        }
 
         model.notify();
     }
@@ -785,7 +1085,9 @@ namespace nvnmos
             // this code relies on the specific constraints added by node_implementation_init
             const auto& constraints = nmos::fields::endpoint_constraints(connection_resource.data);
 
-            const auto is_rtp = nmos::transports::rtp == nmos::transport_base(nmos::transport{ nmos::fields::transport(resource.data) });
+            const auto transport_base = nmos::transport_base(nmos::transport{ nmos::fields::transport(resource.data) });
+            const auto is_rtp = nmos::transports::rtp == transport_base;
+            const auto is_mxl = nmos::transports::mxl == transport_base;
 
             // "In some cases the behaviour is more complex, and may be determined by the vendor."
             // See https://specs.amwa.tv/is-05/releases/v1.0.0/docs/2.2._APIs_-_Server_Side_Implementation.html#use-of-auto
@@ -808,6 +1110,17 @@ namespace nvnmos
                 // lastly, apply the specification defaults for any properties not handled above
                 nmos::resolve_rtp_auto(id_type.second, transport_params);
             }
+            else if (nmos::types::sender == id_type.second && is_mxl)
+            {
+                // BCP-007-03: MXL has a single transport leg per sender
+                nmos::details::resolve_auto(transport_params[0], nmos::fields::mxl_domain_id, [&] { return web::json::front(nmos::fields::constraint_enum(constraints.at(0).at(nmos::fields::mxl_domain_id))); });
+                nmos::details::resolve_auto(transport_params[0], nmos::fields::mxl_flow_id, [&] { return web::json::front(nmos::fields::constraint_enum(constraints.at(0).at(nmos::fields::mxl_flow_id))); });
+            }
+            else if (nmos::types::receiver == id_type.second && is_mxl)
+            {
+                // BCP-007-03: MXL has a single transport leg per receiver, and mxl_flow_id does not use "auto" (UUID or null only)
+                nmos::details::resolve_auto(transport_params[0], nmos::fields::mxl_domain_id, [&] { return web::json::front(nmos::fields::constraint_enum(constraints.at(0).at(nmos::fields::mxl_domain_id))); });
+            }
         };
     }
 
@@ -826,7 +1139,7 @@ namespace nvnmos
 
             if (configs.as_object().end() != config && is_rtp)
             {
-                const auto& sdp_data = nvnmos::fields::sdp(config->second);
+                const auto& sdp_data = nvnmos::fields::transport_file(config->second);
 
                 const auto parsed_sdp = sdp::parse_session_description(utility::us2s(sdp_data));
 
@@ -872,12 +1185,12 @@ namespace nvnmos
     }
 
     // Connection API activation callback to perform application-specific operations to complete activation
-    nmos::connection_activation_handler make_node_implementation_connection_activation_handler(rtp_connection_activation_handler rtp_connection_activated, nmos::settings& settings, slog::base_gate& gate)
+    nmos::connection_activation_handler make_node_implementation_connection_activation_handler(connection_activation_handler connection_activated, nmos::settings& settings, slog::base_gate& gate)
     {
         using web::json::value;
         using web::json::value_from_elements;
 
-        return [&settings, rtp_connection_activated, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
+        return [&settings, connection_activated, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
         {
             const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
             slog::log<slog::severities::info>(gate, SLOG_FLF) << "Activating " << id_type;
@@ -885,18 +1198,24 @@ namespace nvnmos
             auto& configs = nmos::types::sender == resource.type ? nvnmos::fields::senders(settings) : nvnmos::fields::receivers(settings);
             auto config = configs.as_object().find(resource.id);
 
-            const auto is_rtp = nmos::transports::rtp == nmos::transport_base(nmos::transport{ nmos::fields::transport(resource.data) });
+            if (configs.as_object().end() == config) return;
 
-            if (configs.as_object().end() != config && is_rtp)
+            const auto transport_base = nmos::transport_base(nmos::transport{ nmos::fields::transport(resource.data) });
+            const auto is_rtp = nmos::transports::rtp == transport_base;
+            const auto is_mxl = nmos::transports::mxl == transport_base;
+
+            if (!is_rtp && !is_mxl) return;
+
+            const auto internal_id = impl::get_internal_id(resource);
+
+            const auto& endpoint_active = nmos::fields::endpoint_active(connection_resource.data);
+
+            // determine the new state of the sender or receiver
+            const bool active = nmos::fields::master_enable(endpoint_active);
+
+            if (active)
             {
-                const auto internal_id = impl::get_internal_id(resource);
-
-                const auto& endpoint_active = nmos::fields::endpoint_active(connection_resource.data);
-
-                // determine the new state of the sender or receiver
-                const bool active = nmos::fields::master_enable(endpoint_active);
-
-                if (active)
+                if (is_rtp)
                 {
                     // get the active transport file from the sender's /transportfile endpoint or receiver's /active transport_file object
                     auto& transportfile = nmos::types::sender == id_type.second
@@ -908,7 +1227,7 @@ namespace nvnmos
                     // based on the original SDP data used to configure the receiver or sender
                     const auto& transportfile_data = !transportfile_data_or_null.is_null() && !transportfile_data_or_null.as_string().empty()
                         ? transportfile_data_or_null.as_string()
-                        : nvnmos::fields::sdp(config->second);
+                        : nvnmos::fields::transport_file(config->second);
 
                     // activate the sender or receiver with the effective SDP file for the /active transport_params
 
@@ -952,29 +1271,178 @@ namespace nvnmos
                     const auto merged_sdp = impl::make_session_description(id_type.second, internal_id, group_hint, session_info, sdp_params, transport_params);
                     const auto sdp_data = sdp::make_session_description(merged_sdp);
 
-                    rtp_connection_activated(utility::us2s(internal_id), sdp_data);
+                    connection_activated(utility::us2s(internal_id), sdp_data);
                 }
-                else
+                else if (is_mxl)
                 {
-                    // deactivate sender or receiver
+                    // BCP-007-03: MXL transport_params is a single-leg array
+                    const auto& active_leg = nmos::fields::transport_params(endpoint_active).at(0);
+                    const auto& mxl_flow_id_or_null = nmos::fields::mxl_flow_id(active_leg);
 
-                    rtp_connection_activated(utility::us2s(internal_id), {});
+                    // for receivers, mxl_flow_id may be null even when master_enable is true.
+                    // unlike RTP's rtp_enabled=false (where the other transport params may still
+                    // be useful), there's nothing actionable for the application without a
+                    // concrete flow id, so translate this to a deactivation callback.
+                    if (mxl_flow_id_or_null.is_null())
+                    {
+                        connection_activated(utility::us2s(internal_id), {});
+                        return;
+                    }
+
+                    // hmm, we do not have access to the MXL flow definition of the flow here;
+                    // for now, splice the active mxl_domain_id, mxl_flow_id transport parameters
+                    // into the original MXL flow definition JSON
+                    const auto& mxl_domain_id = nmos::fields::mxl_domain_id(active_leg).as_string();
+                    const auto& mxl_flow_id = mxl_flow_id_or_null.as_string();
+
+                    const auto& config_flow_def_data = nvnmos::fields::transport_file(config->second);
+                    auto config_flow_def = web::json::value::parse(config_flow_def_data);
+                    const auto flow_def_data = impl::make_mxl_flow_def(std::move(config_flow_def), mxl_domain_id, mxl_flow_id);
+
+                    connection_activated(utility::us2s(internal_id), flow_def_data);
                 }
+            }
+            else
+            {
+                // deactivate sender or receiver
+                connection_activated(utility::us2s(internal_id), {});
             }
         };
     }
 
-    void node_implementation_activate_rtp_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const utility::string_t& internal_id, const std::string& sdp, nmos::settings& settings, slog::base_gate& gate)
+    void node_implementation_activate_rtp_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const nmos::resource& resource, const std::string& sdp, nmos::settings& settings, slog::base_gate& gate)
     {
         using web::json::value;
         using web::json::value_of;
 
         const auto set_transportfile = make_node_implementation_transportfile_setter(node_resources, settings);
 
-        // find sender or receiver with specified internal id
+        const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto node_id = impl::make_id(seed_id, nmos::types::node);
+
+        if (nmos::types::sender == id_type.second && !sdp.empty())
+        {
+            auto source = impl::find_source_for_sender(node_resources, resource);
+            if (node_resources.end() == source) throw node_implementation_exception();
+            auto& clock_or_null = nmos::fields::clock_name(source->data);
+            if (clock_or_null.is_null()) throw node_implementation_exception();
+            const auto clock = nmos::clock_name(clock_or_null.as_string());
+
+            // hmm, the IS-05 update already calls sdp::parse_session_description(sdp) twice...
+            const auto parsed_sdp = sdp::parse_session_description(sdp);
+            const auto ts_refclks = impl::get_session_description_ts_refclks(parsed_sdp);
+
+            auto& clock_settings = nvnmos::fields::clocks(settings)[clock.name];
+            auto ptp_domain = nmos::fields::ptp_domain_number(clock_settings);
+            impl::update_node_clock(node_resources, node_id, impl::make_node_clock(clock, ts_refclks, ptp_domain));
+
+            clock_settings[nmos::fields::ptp_domain_number] = ptp_domain;
+        }
+
+        const auto activation_time = nmos::tai_now();
+
+        nmos::modify_resource(connection_resources, id_type.first, [&](nmos::resource& connection_resource)
+        {
+            const auto at = value::string(nmos::make_version(activation_time));
+
+            connection_resource.data[nmos::fields::version] = at;
+
+            // Update the IS-05 resource's /active endpoint
+
+            auto& active = connection_resource.data[nmos::fields::endpoint_active];
+
+            active[nmos::types::sender == connection_resource.type ? nmos::fields::receiver_id : nmos::fields::sender_id] = value::null();
+            active[nmos::fields::master_enable] = value::boolean(!sdp.empty());
+            active[nmos::fields::activation] = nmos::make_activation();
+
+            if (!sdp.empty())
+            {
+                if (nmos::types::receiver == connection_resource.type)
+                {
+                    active[nmos::fields::transport_file] = value_of({
+                        { nmos::fields::data, utility::s2us(sdp) },
+                        { nmos::fields::type, nmos::media_types::application_sdp.name }
+                    });
+                }
+
+                active[nmos::fields::transport_params] = impl::get_session_description_transport_params(connection_resource.type, sdp::parse_session_description(sdp));
+            }
+
+            // Update an IS-05 sender's /transportfile endpoint
+
+            if (nmos::types::sender == id_type.second)
+            {
+                set_transportfile(resource, connection_resource, connection_resource.data[nmos::fields::endpoint_transportfile]);
+            }
+        });
+
+        nmos::modify_resource(node_resources, id_type.first, [&](nmos::resource& res)
+        {
+            nmos::set_resource_subscription(res, !sdp.empty(), {}, activation_time);
+        });
+    }
+
+    void node_implementation_activate_mxl_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const nmos::resource& resource, const std::string& flow_def, nmos::settings& settings, slog::base_gate& gate)
+    {
+        using web::json::value;
+        using web::json::value_of;
+
+        const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
+
+        const auto activation_time = nmos::tai_now();
+
+        // BCP-007-03: MXL connections do not have a transport file in the IS-05 sense;
+        // the supplied flow_def is the application's MXL flow definition for the new active state.
+        // From it, derive the active mxl_domain_id and mxl_flow_id transport parameters.
+        const auto parsed_flow_def = flow_def.empty() ? web::json::value{} : web::json::value::parse(flow_def);
+
+        nmos::modify_resource(connection_resources, id_type.first, [&](nmos::resource& connection_resource)
+        {
+            const auto at = value::string(nmos::make_version(activation_time));
+
+            connection_resource.data[nmos::fields::version] = at;
+
+            auto& active = connection_resource.data[nmos::fields::endpoint_active];
+
+            active[nmos::types::sender == connection_resource.type ? nmos::fields::receiver_id : nmos::fields::sender_id] = value::null();
+            active[nmos::fields::master_enable] = value::boolean(!flow_def.empty());
+            active[nmos::fields::activation] = nmos::make_activation();
+
+            if (!flow_def.empty())
+            {
+                // MXL connections have no transport file in the IS-05 sense; for receivers,
+                // endpoint_active.transport_file is initialised to { data: null, type: null }
+                // at resource creation and stays that way; for senders, there is no /transportfile
+
+                const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(parsed_flow_def);
+                const auto mxl_flow_id = impl::get_mxl_flow_def_id(parsed_flow_def);
+                // nvnmos always associates an NMOS flow with every sender, and requires receivers
+                // to bind to a concrete MXL flow at activation time; to unbind, the application
+                // should deactivate (pass an empty transport_file) instead
+                if (mxl_flow_id.empty()) throw std::invalid_argument("Missing 'id' property in MXL flow definition for activation");
+
+                active[nmos::fields::transport_params] = value_of({
+                    value_of({
+                        { nmos::fields::mxl_domain_id, mxl_domain_id },
+                        { nmos::fields::mxl_flow_id, mxl_flow_id }
+                    })
+                });
+            }
+        });
+
+        nmos::modify_resource(node_resources, id_type.first, [&](nmos::resource& res)
+        {
+            nmos::set_resource_subscription(res, !flow_def.empty(), {}, activation_time);
+        });
+    }
+
+    void node_implementation_activate_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const utility::string_t& internal_id, const std::string& transport_file, nmos::settings& settings, slog::base_gate& gate)
+    {
+        // find sender or receiver with specified internal id
+
+        const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto sender_id = impl::make_id(seed_id, nmos::types::sender, internal_id);
         const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, internal_id);
 
@@ -984,89 +1452,43 @@ namespace nvnmos
             resource = nmos::find_resource(node_resources, { receiver_id, nmos::types::receiver });
         }
 
-        if (node_resources.end() != resource)
+        if (node_resources.end() == resource)
         {
-            // hmm, consider how to handle this 'internal' activation
-            // * for now, setting /active endpoint directly, cf. nmos::connection_activation_thread
-            // * alternatively, by setting or patching /staged with an immediate or scheduled activation
+            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Could not find sender or receiver with internal id: " << internal_id;
+            return;
+        }
 
-            const std::pair<nmos::id, nmos::type> id_type{ resource->id, resource->type };
-            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Updating " << id_type << " with internal id: " << internal_id;
+        // hmm, consider how to handle this 'internal' activation
+        // * for now, setting /active endpoint directly, cf. nmos::connection_activation_thread
+        // * alternatively, by setting or patching /staged with an immediate or scheduled activation
 
-            if (nmos::types::sender == id_type.second && !sdp.empty())
-            {
-                auto source = impl::find_source_for_sender(node_resources, *resource);
-                if (node_resources.end() == source) throw node_implementation_exception();
-                auto& clock_or_null = nmos::fields::clock_name(source->data);
-                if (clock_or_null.is_null()) throw node_implementation_exception();
-                const auto clock = nmos::clock_name(clock_or_null.as_string());
+        const std::pair<nmos::id, nmos::type> id_type{ resource->id, resource->type };
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Updating " << id_type << " with internal id: " << internal_id;
 
-                // hmm, the IS-05 update already calls sdp::parse_session_description(sdp) twice...
-                const auto parsed_sdp = sdp::parse_session_description(sdp);
-                const auto ts_refclks = impl::get_session_description_ts_refclks(parsed_sdp);
+        const auto transport_base = nmos::transport_base(nmos::transport{ nmos::fields::transport(resource->data) });
 
-                auto& clock_settings = nvnmos::fields::clocks(settings)[clock.name];
-                auto ptp_domain = nmos::fields::ptp_domain_number(clock_settings);
-                impl::update_node_clock(node_resources, node_id, impl::make_node_clock(clock, ts_refclks, ptp_domain));
-
-                clock_settings[nmos::fields::ptp_domain_number] = ptp_domain;
-            }
-
-            const auto activation_time = nmos::tai_now();
-
-            nmos::modify_resource(connection_resources, id_type.first, [&](nmos::resource& connection_resource)
-            {
-                const auto at = value::string(nmos::make_version(activation_time));
-
-                connection_resource.data[nmos::fields::version] = at;
-
-                // Update the IS-05 resource's /active endpoint
-
-                auto& active = connection_resource.data[nmos::fields::endpoint_active];
-
-                active[nmos::types::sender == connection_resource.type ? nmos::fields::receiver_id : nmos::fields::sender_id] = value::null();
-                active[nmos::fields::master_enable] = value::boolean(!sdp.empty());
-                active[nmos::fields::activation] = nmos::make_activation();
-
-                if (!sdp.empty())
-                {
-                    if (nmos::types::receiver == connection_resource.type)
-                    {
-                        active[nmos::fields::transport_file] = value_of({
-                            { nmos::fields::data, utility::s2us(sdp) },
-                            { nmos::fields::type, nmos::media_types::application_sdp.name }
-                        });
-                    }
-
-                    active[nmos::fields::transport_params] = impl::get_session_description_transport_params(connection_resource.type, sdp::parse_session_description(sdp));
-                }
-
-                // Update an IS-05 sender's /transportfile endpoint
-
-                if (nmos::types::sender == id_type.second)
-                {
-                    set_transportfile(*resource, connection_resource, connection_resource.data[nmos::fields::endpoint_transportfile]);
-                }
-            });
-
-            nmos::modify_resource(node_resources, id_type.first, [&](nmos::resource& resource)
-            {
-                nmos::set_resource_subscription(resource, !sdp.empty(), {}, activation_time);
-            });
+        if (nmos::transports::rtp == transport_base)
+        {
+            node_implementation_activate_rtp_connection_(node_resources, connection_resources, *resource, transport_file, settings, gate);
+        }
+        else if (nmos::transports::mxl == transport_base)
+        {
+            node_implementation_activate_mxl_connection_(node_resources, connection_resources, *resource, transport_file, settings, gate);
         }
         else
         {
-            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Could not find sender or receiver with internal id: " << internal_id;
+            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Unsupported transport for activate: " << transport_base.name;
         }
     }
 
-    // This updates the transport parameters and transport file for the specified sender or receiver based on the specified SDP file.
-    // For now, the SDP file is not validated against the existing sender or receiver capabilities and constraints.
-    void node_implementation_activate_rtp_connection(nmos::node_model& model, const utility::string_t& internal_id, const std::string& sdp, slog::base_gate& gate)
+    // This updates the transport parameters and transport file for the specified sender or receiver based on the specified transport file.
+    // The transport is inferred from the existing sender or receiver with the specified internal id.
+    // For now, the transport file is not validated against the existing sender or receiver capabilities and constraints.
+    void node_implementation_activate_connection(nmos::node_model& model, const utility::string_t& internal_id, const std::string& transport_file, slog::base_gate& gate)
     {
         auto lock = model.write_lock(); // in order to update the resources
 
-        node_implementation_activate_rtp_connection_(model.node_resources, model.connection_resources, internal_id, sdp, model.settings, gate);
+        node_implementation_activate_connection_(model.node_resources, model.connection_resources, internal_id, transport_file, model.settings, gate);
 
         model.notify();
     }
@@ -1234,7 +1656,7 @@ namespace nvnmos
             return transport_params;
         }
 
-        // get the internal id from the custom attribute
+        // get the (required) internal id from the custom attribute; throws std::invalid_argument if absent or empty
         utility::string_t get_session_description_internal_id(const web::json::value& session_description)
         {
             const auto& session_attributes = sdp::fields::attributes(session_description);
@@ -1244,11 +1666,12 @@ namespace nvnmos
                 auto internal_id = sdp::find_name(sa, nvnmos::attributes::internal_id);
                 if (sa.end() != internal_id)
                 {
-                    return sdp::fields::value(*internal_id).as_string();
+                    const auto& value = sdp::fields::value(*internal_id).as_string();
+                    if (!value.empty()) return value;
                 }
             }
 
-            return U("");
+            throw std::invalid_argument("Missing or empty x-nvnmos-id attribute in SDP");
         }
 
         // get the optional group hint from the custom attribute
@@ -1285,7 +1708,7 @@ namespace nvnmos
 
             const auto& media_descriptions = sdp::fields::media_descriptions(session_description);
             // hm, for simplicity, read caps only from the first media description
-            if (0 == media_descriptions.size()) return false;
+            if (web::json::empty(media_descriptions)) return false;
             const auto& media_description = media_descriptions.at(0);
             const auto& media_attributes = sdp::fields::attributes(media_description);
             {
@@ -1330,12 +1753,17 @@ namespace nvnmos
         // identify supported format from media type
         format get_format(const nmos::media_type& media_type)
         {
+            // ST 2110 media types
             if (nmos::media_types::video_raw == media_type) return format::video;
             if (nmos::media_types::video_jxsv == media_type) return format::video;
             if (nmos::media_types::audio_L(24) == media_type) return format::audio;
             if (nmos::media_types::audio_L(16) == media_type) return format::audio;
             if (nmos::media_types::video_smpte291 == media_type) return format::data;
             if (nmos::media_types::video_SMPTE2022_6 == media_type) return format::mux;
+            // MXL media types
+            if (nmos::media_type{ U("video/v210") } == media_type) return format::video;
+            if (nmos::media_type{ U("video/v210a") } == media_type) return format::video;
+            if (nmos::media_type{ U("audio/float32") } == media_type) return format::audio;
             throw node_implementation_exception{};
         }
 
@@ -1393,9 +1821,9 @@ namespace nvnmos
         utility::string_t get_internal_id(const nmos::resource& resource)
         {
             const auto& tags = resource.data.at(nmos::fields::tags);
-            const auto& internal_ids = nvnmos::fields::internal_id_tag(tags);
-            return 0 != internal_ids.as_array().size()
-                ? internal_ids.as_array().begin()->as_string()
+            const auto& internal_ids = nvnmos::fields::internal_id_tag(tags).as_array();
+            return !web::json::empty(internal_ids)
+                ? web::json::front(internal_ids).as_string()
                 : U("");
         }
 
@@ -1411,9 +1839,9 @@ namespace nvnmos
         utility::string_t get_group_hint(const nmos::resource& resource)
         {
             const auto& tags = resource.data.at(nmos::fields::tags);
-            const auto& group_hints = nmos::fields::group_hint(tags);
-            return 0 != group_hints.as_array().size()
-                ? group_hints.as_array().begin()->as_string()
+            const auto& group_hints = nmos::fields::group_hint(tags).as_array();
+            return !web::json::empty(group_hints)
+                ? web::json::front(group_hints).as_string()
                 : U("");
         }
 
@@ -1560,10 +1988,85 @@ namespace nvnmos
                 });
             }
         }
+
+        // parse an MXL flow definition (JSON) including nvnmos extensions
+        // (x-nvnmos-* top-level properties); propagates web::json::json_exception on parse error
+        web::json::value parse_mxl_flow_def(const std::string& flow_def)
+        {
+            return web::json::value::parse(utility::s2us(flow_def));
+        }
+
+        // extract the (required) internal id from the x-nvnmos-id top-level property;
+        // throws std::invalid_argument if absent or empty
+        utility::string_t get_mxl_flow_def_internal_id(const web::json::value& flow_def)
+        {
+            if (flow_def.has_string_field(nvnmos::fields::internal_id))
+            {
+                const auto& value = nvnmos::fields::internal_id(flow_def);
+                if (!value.empty()) return value;
+            }
+            throw std::invalid_argument("Missing or empty x-nvnmos-id property in MXL flow definition");
+        }
+
+        // extract an optional group hint from the tags property (or empty)
+        utility::string_t get_mxl_flow_def_group_hint(const web::json::value& flow_def)
+        {
+            if (flow_def.has_object_field(nmos::fields::tags))
+            {
+                const auto& tags = flow_def.at(nmos::fields::tags);
+                if (tags.has_array_field(nmos::fields::group_hint))
+                {
+                    const auto& group_hints = nmos::fields::group_hint(tags).as_array();
+                    if (!web::json::empty(group_hints) && web::json::front(group_hints).is_string())
+                    {
+                        return web::json::front(group_hints).as_string();
+                    }
+                }
+            }
+            return utility::string_t{};
+        }
+
+        // returns true if the x-nvnmos-caps top-level property is present
+        bool has_mxl_flow_def_caps(const web::json::value& flow_def)
+        {
+            return flow_def.has_field(nvnmos::fields::caps);
+        }
+
+        // extract the (required) MXL domain id from the x-nvnmos-mxl-domain-id top-level property;
+        // throws std::invalid_argument if absent or empty (the IS-05 transport parameter defaults
+        // to "auto" and is resolved at activation time from this value)
+        utility::string_t get_mxl_flow_def_domain_id(const web::json::value& flow_def)
+        {
+            if (flow_def.has_string_field(nvnmos::fields::mxl_domain_id))
+            {
+                const auto& value = nvnmos::fields::mxl_domain_id(flow_def);
+                if (!value.empty()) return value;
+            }
+            throw std::invalid_argument("Missing or empty x-nvnmos-mxl-domain-id property in MXL flow definition");
+        }
+
+        // extract the top-level 'id' property (or empty)
+        utility::string_t get_mxl_flow_def_id(const web::json::value& flow_def)
+        {
+            return flow_def.has_string_field(nmos::fields::id)
+                ? nmos::fields::id(flow_def)
+                : utility::string_t{};
+        }
+
+        // produce a flow definition JSON string with the active MXL transport parameters spliced in
+        std::string make_mxl_flow_def(web::json::value flow_def, const utility::string_t& mxl_domain_id, const utility::string_t& mxl_flow_id)
+        {
+            using web::json::value;
+
+            flow_def[nvnmos::fields::mxl_domain_id] = value::string(mxl_domain_id);
+            flow_def[nmos::fields::id] = value::string(mxl_flow_id);
+
+            return utility::us2s(flow_def.serialize());
+        }
     }
 
     // This constructs all the callbacks used to integrate the application into the server instance for the NMOS Node.
-    nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, rtp_connection_activation_handler rtp_connection_activated, slog::base_gate& gate)
+    nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, connection_activation_handler connection_activated, slog::base_gate& gate)
     {
         return nmos::experimental::node_implementation()
             .on_load_server_certificates(nmos::make_load_server_certificates_handler(model.settings, gate))
@@ -1575,6 +2078,6 @@ namespace nvnmos
             .on_validate_connection_resource_patch(make_node_implementation_patch_validator()) // may be omitted if not required
             .on_resolve_auto(make_node_implementation_auto_resolver())
             .on_set_transportfile(make_node_implementation_transportfile_setter(model.node_resources, model.settings))
-            .on_connection_activated(make_node_implementation_connection_activation_handler(std::move(rtp_connection_activated), model.settings, gate));
+            .on_connection_activated(make_node_implementation_connection_activation_handler(std::move(connection_activated), model.settings, gate));
     }
 }

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -222,7 +222,7 @@ namespace nvnmos
         const auto ts_refclks = impl::get_session_description_ts_refclks(sdp);
         const auto transport_params = impl::get_session_description_transport_params(nmos::types::sender, sdp);
         const auto name = impl::get_session_description_resource_name(sdp);
-        // hm, could check the name is unique across all senders and receivers
+        // hm, could check the name is unique across all senders
         const auto group_hint = impl::get_session_description_group_hint(sdp);
         const auto session_info = impl::get_session_description_session_info(sdp);
 
@@ -425,7 +425,7 @@ namespace nvnmos
         const auto sdp_params = nmos::get_session_description_sdp_parameters(sdp);
         const auto transport_params = impl::get_session_description_transport_params(nmos::types::receiver, sdp);
         const auto name = impl::get_session_description_resource_name(sdp);
-        // hm, could check the name is unique across all senders and receivers
+        // hm, could check the name is unique across all receivers
         const auto group_hint = impl::get_session_description_group_hint(sdp);
         const auto session_info = impl::get_session_description_session_info(sdp);
 
@@ -605,6 +605,7 @@ namespace nvnmos
 
         const auto flow_def = impl::parse_mxl_flow_def(flow_def_);
         const auto name = impl::get_mxl_flow_def_name(flow_def);
+        // hm, could check the name is unique across all senders
         const auto group_hint = impl::get_mxl_flow_def_group_hint(flow_def);
         const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(flow_def);
 
@@ -738,6 +739,7 @@ namespace nvnmos
 
         const auto flow_def = impl::parse_mxl_flow_def(flow_def_);
         const auto name = impl::get_mxl_flow_def_name(flow_def);
+        // hm, could check the name is unique across all receivers
         const auto group_hint = impl::get_mxl_flow_def_group_hint(flow_def);
         const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(flow_def);
         const auto want_caps = !impl::has_mxl_flow_def_caps(flow_def);

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -34,8 +34,10 @@
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/irange.hpp>
 #include "cpprest/host_utils.h"
+#include "cpprest/uri_builder.h"
 #include "nmos/activation_mode.h"
 #include "nmos/activation_utils.h"
+#include "nmos/api_utils.h"
 #include "nmos/capabilities.h"
 #include "nmos/channels.h"
 #include "nmos/clock_name.h"
@@ -45,6 +47,8 @@
 #include "nmos/format.h"
 #include "nmos/group_hint.h"
 #include "nmos/interlace_mode.h"
+#include "nmos/is04_versions.h"
+#include "nmos/is05_versions.h"
 #include "nmos/media_type.h"
 #include "nmos/model.h"
 #include "nmos/node_interfaces.h"
@@ -114,6 +118,9 @@ namespace nvnmos
 
         // generate a repeatable source-specific multicast address for each leg of a sender
         utility::string_t make_source_specific_multicast_address_v4(const nmos::id& id, int leg);
+
+        // generate URLs for a sender or receiver in the Node API and Connection API
+        std::pair<utility::string_t, utility::string_t> make_resource_api_urls(const nmos::settings& settings, const nmos::id& id, const nmos::type& type);
 
         // set the name for the sender or receiver as a resource tag
         void set_name(nmos::resource& resource, const utility::string_t& name);
@@ -377,6 +384,11 @@ namespace nvnmos
         if (!insert_resource(node_resources, std::move(sender)).second) throw node_implementation_exception();
         if (!insert_resource(connection_resources, std::move(connection_sender)).second) throw node_implementation_exception();
 
+        {
+            const auto urls = impl::make_resource_api_urls(settings, sender_id, nmos::types::sender);
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(sender_id, nmos::types::sender) << ": " << urls.first << " " << urls.second;
+        }
+
         // update device's deprecated senders array
 
         nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
@@ -562,6 +574,11 @@ namespace nvnmos
         if (!insert_resource(node_resources, std::move(receiver)).second) throw node_implementation_exception();
         if (!insert_resource(connection_resources, std::move(connection_receiver)).second) throw node_implementation_exception();
 
+        {
+            const auto urls = impl::make_resource_api_urls(settings, receiver_id, nmos::types::receiver);
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(receiver_id, nmos::types::receiver) << ": " << urls.first << " " << urls.second;
+        }
+
         // update device's deprecated receivers array
 
         nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
@@ -694,6 +711,11 @@ namespace nvnmos
         if (!insert_resource(node_resources, std::move(sender)).second) throw node_implementation_exception();
         if (!insert_resource(connection_resources, std::move(connection_sender)).second) throw node_implementation_exception();
 
+        {
+            const auto urls = impl::make_resource_api_urls(settings, sender_id, nmos::types::sender);
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(sender_id, nmos::types::sender) << ": " << urls.first << " " << urls.second;
+        }
+
         // update device's deprecated senders array
 
         nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
@@ -820,6 +842,11 @@ namespace nvnmos
         if (!insert_resource(node_resources, std::move(receiver)).second) throw node_implementation_exception();
         if (!insert_resource(connection_resources, std::move(connection_receiver)).second) throw node_implementation_exception();
 
+        {
+            const auto urls = impl::make_resource_api_urls(settings, receiver_id, nmos::types::receiver);
+            slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(receiver_id, nmos::types::receiver) << ": " << urls.first << " " << urls.second;
+        }
+
         // update device's deprecated receivers array
 
         nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
@@ -905,6 +932,9 @@ namespace nvnmos
             {
                 configs.erase(id);
             }
+
+            slog::log<slog::severities::info>(gate, SLOG_FLF)
+                << "Destroyed " << std::make_pair(id, type);
         }
         else
         {
@@ -1788,6 +1818,33 @@ namespace nvnmos
         nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& name)
         {
             return nmos::make_repeatable_id(seed_id, U("/x-nmos/node/") + type.name + U('/') + name);
+        }
+
+        // generate URLs for the Node API and Connection API
+        std::pair<utility::string_t, utility::string_t> make_api_base_urls(const nmos::settings& settings)
+        {
+            auto build = [&](int port, const utility::string_t& api, const nmos::api_version& version)
+            {
+                return web::uri_builder()
+                    .set_scheme(nmos::http_scheme(settings))
+                    .set_host(nmos::get_host(settings))
+                    .set_port(port)
+                    .set_path(U("/x-nmos/") + api + U('/') + nmos::make_api_version(version))
+                    .to_uri()
+                    .to_string();
+            };
+            return {
+                build(nmos::fields::node_port(settings), U("node"), *nmos::is04_versions::from_settings(settings).rbegin()),
+                build(nmos::fields::connection_port(settings), U("connection"), *nmos::is05_versions::from_settings(settings).rbegin())
+            };
+        }
+
+        // generate URLs for a sender or receiver in the Node API and Connection API
+        std::pair<utility::string_t, utility::string_t> make_resource_api_urls(const nmos::settings& settings, const nmos::id& id, const nmos::type& type)
+        {
+            const auto urls = make_api_base_urls(settings);
+            const auto path = U('/') + type.name + U("s/") + id;
+            return { urls.first + path, urls.second + U("/single") + path };
         }
 
         // generate a repeatable source-specific multicast address for each leg of a sender

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -61,11 +61,6 @@
 
 namespace nvnmos
 {
-    namespace fields
-    {
-        const web::json::field_as_value_or internal_id_tag{ U("urn:x-nvnmos:id"), web::json::value::array() };
-    }
-
     // node implementation details
     namespace impl
     {
@@ -149,18 +144,23 @@ namespace nvnmos
     namespace impl
     {
         // parse an MXL flow definition (JSON) including nvnmos extensions
-        // (x-nvnmos-* top-level properties); propagates web::json::json_exception on parse error
+        // (urn:x-nvnmos:tag:* entries inside the `tags` property);
+        // propagates web::json::json_exception on parse error
         web::json::value parse_mxl_flow_def(const std::string& flow_def);
-        // extract the (required) internal id from the x-nvnmos-id top-level property;
+        // extract the first string from the named tag in the flow definition's
+        // `tags` property (or empty if absent)
+        utility::string_t get_mxl_flow_def_tag(const web::json::value& flow_def, const web::json::field_as_value_or& tag_field);
+        // extract the (required) internal id from the urn:x-nvnmos:tag:id tag;
         // throws std::invalid_argument if absent or empty
         utility::string_t get_mxl_flow_def_internal_id(const web::json::value& flow_def);
-        // extract an optional group hint from the tags property (or empty)
+        // extract an optional group hint from the urn:x-nmos:tag:grouphint/v1.0 tag (or empty)
         utility::string_t get_mxl_flow_def_group_hint(const web::json::value& flow_def);
-        // returns true if the x-nvnmos-caps top-level property is present
+        // returns true if the urn:x-nvnmos:tag:caps tag asks for a fully-flexible
+        // receiver (format-derived capabilities omitted)
         bool has_mxl_flow_def_caps(const web::json::value& flow_def);
-        // extract the (required) MXL domain id from the x-nvnmos-mxl-domain-id top-level property;
-        // throws std::invalid_argument if absent or empty (the IS-05 transport parameter defaults
-        // to "auto" and is resolved at activation time from this value)
+        // extract the (required) MXL domain id from the urn:x-nvnmos:tag:mxl-domain-id tag;
+        // throws std::invalid_argument if absent or empty (the IS-05 transport parameter
+        // defaults to "auto" and is resolved at activation time from this value)
         utility::string_t get_mxl_flow_def_domain_id(const web::json::value& flow_def);
         // extract the top-level 'id' property (or empty)
         utility::string_t get_mxl_flow_def_id(const web::json::value& flow_def);
@@ -1813,14 +1813,13 @@ namespace nvnmos
         {
             using web::json::value_of;
 
-            resource.data[nmos::fields::tags][nvnmos::fields::internal_id_tag] = value_of({ internal_id });
+            resource.data[nmos::fields::tags][nvnmos::fields::internal_id] = value_of({ internal_id });
         }
 
         // get the internal id for the sender or receiver from a resource tag
         utility::string_t get_internal_id(const nmos::resource& resource)
         {
-            const auto& tags = resource.data.at(nmos::fields::tags);
-            const auto& internal_ids = nvnmos::fields::internal_id_tag(tags).as_array();
+            const auto& internal_ids = nvnmos::fields::internal_id(resource.data.at(nmos::fields::tags)).as_array();
             return !web::json::empty(internal_ids)
                 ? web::json::front(internal_ids).as_string()
                 : U("");
@@ -1989,59 +1988,54 @@ namespace nvnmos
         }
 
         // parse an MXL flow definition (JSON) including nvnmos extensions
-        // (x-nvnmos-* top-level properties); propagates web::json::json_exception on parse error
+        // (urn:x-nvnmos:tag:* entries inside the `tags` property);
+        // propagates web::json::json_exception on parse error
         web::json::value parse_mxl_flow_def(const std::string& flow_def)
         {
             return web::json::value::parse(utility::s2us(flow_def));
         }
 
-        // extract the (required) internal id from the x-nvnmos-id top-level property;
+        // extract the first string from the named tag in the flow definition's
+        // `tags` property (or empty if absent)
+        utility::string_t get_mxl_flow_def_tag(const web::json::value& flow_def, const web::json::field_as_value_or& tag_field)
+        {
+            if (!flow_def.has_object_field(nmos::fields::tags)) return {};
+            const auto& values = tag_field(flow_def.at(nmos::fields::tags)).as_array();
+            if (web::json::empty(values) || !web::json::front(values).is_string()) return {};
+            return web::json::front(values).as_string();
+        }
+
+        // extract the (required) internal id from the urn:x-nvnmos:tag:id tag;
         // throws std::invalid_argument if absent or empty
         utility::string_t get_mxl_flow_def_internal_id(const web::json::value& flow_def)
         {
-            if (flow_def.has_string_field(nvnmos::fields::internal_id))
-            {
-                const auto& value = nvnmos::fields::internal_id(flow_def);
-                if (!value.empty()) return value;
-            }
-            throw std::invalid_argument("Missing or empty x-nvnmos-id property in MXL flow definition");
+            const auto value = get_mxl_flow_def_tag(flow_def, nvnmos::fields::internal_id);
+            if (value.empty()) throw std::invalid_argument("Missing or empty urn:x-nvnmos:tag:id tag in MXL flow definition");
+            return value;
         }
 
-        // extract an optional group hint from the tags property (or empty)
+        // extract an optional group hint from the urn:x-nmos:tag:grouphint/v1.0 tag (or empty)
         utility::string_t get_mxl_flow_def_group_hint(const web::json::value& flow_def)
         {
-            if (flow_def.has_object_field(nmos::fields::tags))
-            {
-                const auto& tags = flow_def.at(nmos::fields::tags);
-                if (tags.has_array_field(nmos::fields::group_hint))
-                {
-                    const auto& group_hints = nmos::fields::group_hint(tags).as_array();
-                    if (!web::json::empty(group_hints) && web::json::front(group_hints).is_string())
-                    {
-                        return web::json::front(group_hints).as_string();
-                    }
-                }
-            }
-            return utility::string_t{};
+            return get_mxl_flow_def_tag(flow_def, nmos::fields::group_hint);
         }
 
-        // returns true if the x-nvnmos-caps top-level property is present
+        // returns true if the urn:x-nvnmos:tag:caps tag asks for a fully-flexible
+        // receiver (format-derived capabilities omitted)
         bool has_mxl_flow_def_caps(const web::json::value& flow_def)
         {
-            return flow_def.has_field(nvnmos::fields::caps);
+            if (!flow_def.has_object_field(nmos::fields::tags)) return false;
+            return !web::json::empty(nvnmos::fields::caps(flow_def.at(nmos::fields::tags)).as_array());
         }
 
-        // extract the (required) MXL domain id from the x-nvnmos-mxl-domain-id top-level property;
-        // throws std::invalid_argument if absent or empty (the IS-05 transport parameter defaults
-        // to "auto" and is resolved at activation time from this value)
+        // extract the (required) MXL domain id from the urn:x-nvnmos:tag:mxl-domain-id tag;
+        // throws std::invalid_argument if absent or empty (the IS-05 transport parameter
+        // defaults to "auto" and is resolved at activation time from this value)
         utility::string_t get_mxl_flow_def_domain_id(const web::json::value& flow_def)
         {
-            if (flow_def.has_string_field(nvnmos::fields::mxl_domain_id))
-            {
-                const auto& value = nvnmos::fields::mxl_domain_id(flow_def);
-                if (!value.empty()) return value;
-            }
-            throw std::invalid_argument("Missing or empty x-nvnmos-mxl-domain-id property in MXL flow definition");
+            const auto value = get_mxl_flow_def_tag(flow_def, nvnmos::fields::mxl_domain_id);
+            if (value.empty()) throw std::invalid_argument("Missing or empty urn:x-nvnmos:tag:mxl-domain-id tag in MXL flow definition");
+            return value;
         }
 
         // extract the top-level 'id' property (or empty)
@@ -2056,8 +2050,14 @@ namespace nvnmos
         std::string make_mxl_flow_def(web::json::value flow_def, const utility::string_t& mxl_domain_id, const utility::string_t& mxl_flow_id)
         {
             using web::json::value;
+            using web::json::value_of;
 
-            flow_def[nvnmos::fields::mxl_domain_id] = value::string(mxl_domain_id);
+            if (!flow_def.has_object_field(nmos::fields::tags))
+            {
+                flow_def[nmos::fields::tags] = value::object();
+            }
+            flow_def[nmos::fields::tags][nvnmos::fields::mxl_domain_id]
+                = value_of({ value::string(mxl_domain_id) });
             flow_def[nmos::fields::id] = value::string(mxl_flow_id);
 
             return utility::us2s(flow_def.serialize());

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -56,7 +56,6 @@
 #include "nmos/st2110_21_sender_type.h"
 #include "nmos/system_resources.h"
 #include "nmos/transfer_characteristic.h"
-#include "nmos/transport.h"
 #include "nmos/video_jxsv.h"
 #include "sdp/sdp.h"
 
@@ -117,9 +116,6 @@ namespace nvnmos
 
         // find interface with the specified address
         std::vector<web::hosts::experimental::host_interface>::const_iterator find_interface(const std::vector<web::hosts::experimental::host_interface>& interfaces, const utility::string_t& address);
-
-        // generate repeatable ids for the node's resources
-        nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& internal_id = {});
 
         // generate a repeatable source-specific multicast address for each leg of a sender
         utility::string_t make_source_specific_multicast_address_v4(const nmos::id& id, int leg);

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -82,7 +82,7 @@ namespace nvnmos
 
         // like nmos::make_session_description for 'internal' use
         // with support for the custom SDP attributes in nvnmos::attributes for senders as well as receivers
-        web::json::value make_session_description(const nmos::type& type, const utility::string_t& internal_id, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params);
+        web::json::value make_session_description(const nmos::type& type, const utility::string_t& name, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params);
 
         // like nmos::get_session_description_sdp_parameters
         // with support for multiple ts-refclk attributes in each media description
@@ -92,8 +92,8 @@ namespace nvnmos
         // with support for the custom SDP attributes in nvnmos::attributes for senders as well as receivers
         web::json::value get_session_description_transport_params(const nmos::type& type, const web::json::value& session_description);
 
-        // get the (required) internal id from the custom attribute; throws std::invalid_argument if absent or empty
-        utility::string_t get_session_description_internal_id(const web::json::value& session_description);
+        // get the (required) NvNmos resource name from the `x-nvnmos-name` custom attribute (not the SDP `s=` session-name line); throws std::invalid_argument if absent or empty
+        utility::string_t get_session_description_resource_name(const web::json::value& session_description);
 
         // get the optional group hint from the custom attribute
         utility::string_t get_session_description_group_hint(const web::json::value& session_description);
@@ -115,10 +115,10 @@ namespace nvnmos
         // generate a repeatable source-specific multicast address for each leg of a sender
         utility::string_t make_source_specific_multicast_address_v4(const nmos::id& id, int leg);
 
-        // set the internal id for the sender or receiver as a resource tag
-        void set_internal_id(nmos::resource& resource, const utility::string_t& internal_id);
-        // get the internal id for the sender or receiver from a resource tag
-        utility::string_t get_internal_id(const nmos::resource& resource);
+        // set the name for the sender or receiver as a resource tag
+        void set_name(nmos::resource& resource, const utility::string_t& name);
+        // get the name for the sender or receiver from a resource tag
+        utility::string_t get_name(const nmos::resource& resource);
 
         // set the group hint for the sender or receiver as a resource tag
         void set_group_hint(nmos::resource& resource, const utility::string_t& group_hint);
@@ -150,9 +150,9 @@ namespace nvnmos
         // extract the first string from the named tag in the flow definition's
         // `tags` property (or empty if absent)
         utility::string_t get_mxl_flow_def_tag(const web::json::value& flow_def, const web::json::field_as_value_or& tag_field);
-        // extract the (required) internal id from the urn:x-nvnmos:tag:id tag;
+        // extract the (required) name from the urn:x-nvnmos:tag:name tag;
         // throws std::invalid_argument if absent or empty
-        utility::string_t get_mxl_flow_def_internal_id(const web::json::value& flow_def);
+        utility::string_t get_mxl_flow_def_name(const web::json::value& flow_def);
         // extract an optional group hint from the urn:x-nmos:tag:grouphint/v1.0 tag (or empty)
         utility::string_t get_mxl_flow_def_group_hint(const web::json::value& flow_def);
         // returns true if the urn:x-nvnmos:tag:caps tag asks for a fully-flexible
@@ -214,17 +214,17 @@ namespace nvnmos
         const auto sdp_params = nmos::get_session_description_sdp_parameters(sdp);
         const auto ts_refclks = impl::get_session_description_ts_refclks(sdp);
         const auto transport_params = impl::get_session_description_transport_params(nmos::types::sender, sdp);
-        const auto internal_id = impl::get_session_description_internal_id(sdp);
-        // hm, could check the internal id is unique across all senders and receivers
+        const auto name = impl::get_session_description_resource_name(sdp);
+        // hm, could check the name is unique across all senders and receivers
         const auto group_hint = impl::get_session_description_group_hint(sdp);
         const auto session_info = impl::get_session_description_session_info(sdp);
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto node_id = impl::make_id(seed_id, nmos::types::node);
         const auto device_id = impl::make_id(seed_id, nmos::types::device);
-        const auto source_id = impl::make_id(seed_id, nmos::types::source, internal_id);
-        const auto flow_id = impl::make_id(seed_id, nmos::types::flow, internal_id);
-        const auto sender_id = impl::make_id(seed_id, nmos::types::sender, internal_id);
+        const auto source_id = impl::make_id(seed_id, nmos::types::source, name);
+        const auto flow_id = impl::make_id(seed_id, nmos::types::flow, name);
+        const auto sender_id = impl::make_id(seed_id, nmos::types::sender, name);
 
         // for now, only manage a single clock
         const auto clock = nmos::clock_names::clk0;
@@ -240,7 +240,7 @@ namespace nvnmos
             if (host_interfaces.end() == interface)
             {
                 slog::log<slog::severities::severe>(gate, SLOG_FLF)
-                    << "No network interface corresponding to the connection address: " << address << " for: " << internal_id;
+                    << "No network interface corresponding to the connection address: " << address << " for: " << name;
                 throw node_implementation_exception();
             }
             return interface->name;
@@ -367,8 +367,8 @@ namespace nvnmos
         // override default label and description from model.settings
         sender.data[nmos::fields::label] = value::string(sdp_params.session_name);
         sender.data[nmos::fields::description] = value::string(session_info);
-        // set the internal id as a resource tag
-        impl::set_internal_id(sender, internal_id);
+        // set the name as a resource tag
+        impl::set_name(sender, name);
         // set the group hint as a resource tag
         if (!group_hint.empty()) impl::set_group_hint(sender, group_hint);
 
@@ -412,15 +412,15 @@ namespace nvnmos
         const auto sdp = sdp::parse_session_description(sdp_);
         const auto sdp_params = nmos::get_session_description_sdp_parameters(sdp);
         const auto transport_params = impl::get_session_description_transport_params(nmos::types::receiver, sdp);
-        const auto internal_id = impl::get_session_description_internal_id(sdp);
-        // hm, could check the internal id is unique across all senders and receivers
+        const auto name = impl::get_session_description_resource_name(sdp);
+        // hm, could check the name is unique across all senders and receivers
         const auto group_hint = impl::get_session_description_group_hint(sdp);
         const auto session_info = impl::get_session_description_session_info(sdp);
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto node_id = impl::make_id(seed_id, nmos::types::node);
         const auto device_id = impl::make_id(seed_id, nmos::types::device);
-        const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, internal_id);
+        const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, name);
 
         const auto media_type = nmos::get_media_type(sdp_params);
         const auto format = impl::get_format(media_type);
@@ -434,7 +434,7 @@ namespace nvnmos
             if (host_interfaces.end() == interface)
             {
                 slog::log<slog::severities::severe>(gate, SLOG_FLF)
-                    << "No network interface corresponding to the connection address: " << address << " for: " << internal_id;
+                    << "No network interface corresponding to the connection address: " << address << " for: " << name;
                 throw node_implementation_exception();
             }
             return interface->name;
@@ -554,8 +554,8 @@ namespace nvnmos
         // override default label and description from settings
         receiver.data[nmos::fields::label] = value::string(sdp_params.session_name);
         receiver.data[nmos::fields::description] = value::string(session_info);
-        // set the internal id as a resource tag
-        impl::set_internal_id(receiver, internal_id);
+        // set the name as a resource tag
+        impl::set_name(receiver, name);
         // set the group hint as a resource tag
         if (!group_hint.empty()) impl::set_group_hint(receiver, group_hint);
 
@@ -587,16 +587,16 @@ namespace nvnmos
         using web::json::value_of;
 
         const auto flow_def = impl::parse_mxl_flow_def(flow_def_);
-        const auto internal_id = impl::get_mxl_flow_def_internal_id(flow_def);
+        const auto name = impl::get_mxl_flow_def_name(flow_def);
         const auto group_hint = impl::get_mxl_flow_def_group_hint(flow_def);
         const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(flow_def);
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto node_id = impl::make_id(seed_id, nmos::types::node);
         const auto device_id = impl::make_id(seed_id, nmos::types::device);
-        const auto source_id = impl::make_id(seed_id, nmos::types::source, internal_id);
-        const auto flow_id = impl::make_id(seed_id, nmos::types::flow, internal_id);
-        const auto sender_id = impl::make_id(seed_id, nmos::types::sender, internal_id);
+        const auto source_id = impl::make_id(seed_id, nmos::types::source, name);
+        const auto flow_id = impl::make_id(seed_id, nmos::types::flow, name);
+        const auto sender_id = impl::make_id(seed_id, nmos::types::sender, name);
 
         // the NMOS Flow id is always generated (flow_id, above); the MXL flow id is taken from the flow
         // definition's 'id' property if present, otherwise it falls back to the NMOS Flow id
@@ -686,7 +686,7 @@ namespace nvnmos
         // json_exception if absent
         sender.data[nmos::fields::label] = value::string(nmos::fields::label(flow_def));
         sender.data[nmos::fields::description] = value::string(nmos::fields::description(flow_def));
-        impl::set_internal_id(sender, internal_id);
+        impl::set_name(sender, name);
         if (!group_hint.empty()) impl::set_group_hint(sender, group_hint);
 
         if (!insert_resource(node_resources, std::move(source)).second) throw node_implementation_exception();
@@ -715,14 +715,14 @@ namespace nvnmos
         using web::json::value_of;
 
         const auto flow_def = impl::parse_mxl_flow_def(flow_def_);
-        const auto internal_id = impl::get_mxl_flow_def_internal_id(flow_def);
+        const auto name = impl::get_mxl_flow_def_name(flow_def);
         const auto group_hint = impl::get_mxl_flow_def_group_hint(flow_def);
         const auto mxl_domain_id = impl::get_mxl_flow_def_domain_id(flow_def);
         const auto want_caps = !impl::has_mxl_flow_def_caps(flow_def);
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto device_id = impl::make_id(seed_id, nmos::types::device);
-        const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, internal_id);
+        const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, name);
 
         const nmos::media_type media_type{ nmos::fields::media_type(flow_def) };
         const auto format = impl::get_format(media_type);
@@ -814,7 +814,7 @@ namespace nvnmos
         // json_exception if absent
         receiver.data[nmos::fields::label] = value::string(nmos::fields::label(flow_def));
         receiver.data[nmos::fields::description] = value::string(nmos::fields::description(flow_def));
-        impl::set_internal_id(receiver, internal_id);
+        impl::set_name(receiver, name);
         if (!group_hint.empty()) impl::set_group_hint(receiver, group_hint);
 
         if (!insert_resource(node_resources, std::move(receiver)).second) throw node_implementation_exception();
@@ -835,16 +835,16 @@ namespace nvnmos
         });
     }
 
-    void node_implementation_remove_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const nmos::type& type, const utility::string_t& internal_id, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
+    void node_implementation_remove_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const nmos::type& type, const utility::string_t& name, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
     {
         using web::json::value;
         using web::json::value_of;
 
-        // find sender or receiver with specified internal id
+        // find sender or receiver with specified name
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
         const auto node_id = impl::make_id(seed_id, nmos::types::node);
-        const auto id = impl::make_id(seed_id, type, internal_id);
+        const auto id = impl::make_id(seed_id, type, name);
         auto resource = nmos::find_resource(node_resources, { id, type });
 
         if (node_resources.end() != resource)
@@ -908,7 +908,7 @@ namespace nvnmos
         }
         else
         {
-            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Could not find " << type.name << " with internal id: " << internal_id;
+            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Could not find " << type.name << " with name: " << name;
             throw node_implementation_exception();
         }
     }
@@ -973,26 +973,26 @@ namespace nvnmos
         model.notify();
     }
 
-    // This removes sources/flows/senders from the model corresponding to the specified id.
-    void node_implementation_remove_sender(nmos::node_model& model, const utility::string_t& internal_id, slog::base_gate& gate)
+    // This removes sources/flows/senders from the model corresponding to the specified name.
+    void node_implementation_remove_sender(nmos::node_model& model, const utility::string_t& sender_name, slog::base_gate& gate)
     {
         auto lock = model.write_lock(); // in order to update the resources
 
         const auto host_interfaces = web::hosts::experimental::host_interfaces();
 
-        node_implementation_remove_connection_(model.node_resources, model.connection_resources, nmos::types::sender, internal_id, host_interfaces, model.settings, gate);
+        node_implementation_remove_connection_(model.node_resources, model.connection_resources, nmos::types::sender, sender_name, host_interfaces, model.settings, gate);
 
         model.notify();
     }
 
-    // This removes the receiver from the model corresponding to the specified id.
-    void node_implementation_remove_receiver(nmos::node_model& model, const utility::string_t& internal_id, slog::base_gate& gate)
+    // This removes the receiver from the model corresponding to the specified name.
+    void node_implementation_remove_receiver(nmos::node_model& model, const utility::string_t& receiver_name, slog::base_gate& gate)
     {
         auto lock = model.write_lock(); // in order to update the resources
 
         const auto host_interfaces = web::hosts::experimental::host_interfaces();
 
-        node_implementation_remove_connection_(model.node_resources, model.connection_resources, nmos::types::receiver, internal_id, host_interfaces, model.settings, gate);
+        node_implementation_remove_connection_(model.node_resources, model.connection_resources, nmos::types::receiver, receiver_name, host_interfaces, model.settings, gate);
 
         model.notify();
     }
@@ -1205,7 +1205,7 @@ namespace nvnmos
 
             if (!is_rtp && !is_mxl) return;
 
-            const auto internal_id = impl::get_internal_id(resource);
+            const auto name = impl::get_name(resource);
 
             const auto& endpoint_active = nmos::fields::endpoint_active(connection_resource.data);
 
@@ -1267,10 +1267,10 @@ namespace nvnmos
 
                     const auto group_hint = impl::get_group_hint(resource);
                     const auto& session_info = nmos::fields::description(resource.data);
-                    const auto merged_sdp = impl::make_session_description(id_type.second, internal_id, group_hint, session_info, sdp_params, transport_params);
+                    const auto merged_sdp = impl::make_session_description(id_type.second, name, group_hint, session_info, sdp_params, transport_params);
                     const auto sdp_data = sdp::make_session_description(merged_sdp);
 
-                    connection_activated(utility::us2s(internal_id), sdp_data);
+                    connection_activated(id_type.second, utility::us2s(name), sdp_data);
                 }
                 else if (is_mxl)
                 {
@@ -1284,7 +1284,7 @@ namespace nvnmos
                     // concrete flow id, so translate this to a deactivation callback.
                     if (mxl_flow_id_or_null.is_null())
                     {
-                        connection_activated(utility::us2s(internal_id), {});
+                        connection_activated(id_type.second, utility::us2s(name), {});
                         return;
                     }
 
@@ -1298,13 +1298,13 @@ namespace nvnmos
                     auto config_flow_def = web::json::value::parse(config_flow_def_data);
                     const auto flow_def_data = impl::make_mxl_flow_def(std::move(config_flow_def), mxl_domain_id, mxl_flow_id);
 
-                    connection_activated(utility::us2s(internal_id), flow_def_data);
+                    connection_activated(id_type.second, utility::us2s(name), flow_def_data);
                 }
             }
             else
             {
                 // deactivate sender or receiver
-                connection_activated(utility::us2s(internal_id), {});
+                connection_activated(id_type.second, utility::us2s(name), {});
             }
         };
     }
@@ -1437,23 +1437,19 @@ namespace nvnmos
         });
     }
 
-    void node_implementation_activate_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const utility::string_t& internal_id, const std::string& transport_file, nmos::settings& settings, slog::base_gate& gate)
+    void node_implementation_activate_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const nmos::type& type, const utility::string_t& name, const std::string& transport_file, nmos::settings& settings, slog::base_gate& gate)
     {
-        // find sender or receiver with specified internal id
+        // find the sender or receiver with the specified name; a Sender and a
+        // Receiver are permitted to share a name, so we pick by `type`.
 
         const auto seed_id = nmos::experimental::fields::seed_id(settings);
-        const auto sender_id = impl::make_id(seed_id, nmos::types::sender, internal_id);
-        const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, internal_id);
+        const auto resource_id = impl::make_id(seed_id, type, name);
 
-        auto resource = nmos::find_resource(node_resources, { sender_id, nmos::types::sender });
-        if (node_resources.end() == resource)
-        {
-            resource = nmos::find_resource(node_resources, { receiver_id, nmos::types::receiver });
-        }
+        auto resource = nmos::find_resource(node_resources, { resource_id, type });
 
         if (node_resources.end() == resource)
         {
-            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Could not find sender or receiver with internal id: " << internal_id;
+            slog::log<slog::severities::error>(gate, SLOG_FLF) << "Could not find " << type.name << " with name: " << name;
             return;
         }
 
@@ -1462,7 +1458,7 @@ namespace nvnmos
         // * alternatively, by setting or patching /staged with an immediate or scheduled activation
 
         const std::pair<nmos::id, nmos::type> id_type{ resource->id, resource->type };
-        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Updating " << id_type << " with internal id: " << internal_id;
+        slog::log<slog::severities::info>(gate, SLOG_FLF) << "Updating " << id_type << " with name: " << name;
 
         const auto transport_base = nmos::transport_base(nmos::transport{ nmos::fields::transport(resource->data) });
 
@@ -1481,13 +1477,13 @@ namespace nvnmos
     }
 
     // This updates the transport parameters and transport file for the specified sender or receiver based on the specified transport file.
-    // The transport is inferred from the existing sender or receiver with the specified internal id.
+    // `type` selects between a sender and a receiver with the same name on the Node.
     // For now, the transport file is not validated against the existing sender or receiver capabilities and constraints.
-    void node_implementation_activate_connection(nmos::node_model& model, const utility::string_t& internal_id, const std::string& transport_file, slog::base_gate& gate)
+    void node_implementation_activate_connection(nmos::node_model& model, const nmos::type& type, const utility::string_t& name, const std::string& transport_file, slog::base_gate& gate)
     {
         auto lock = model.write_lock(); // in order to update the resources
 
-        node_implementation_activate_connection_(model.node_resources, model.connection_resources, internal_id, transport_file, model.settings, gate);
+        node_implementation_activate_connection_(model.node_resources, model.connection_resources, type, name, transport_file, model.settings, gate);
 
         model.notify();
     }
@@ -1496,7 +1492,7 @@ namespace nvnmos
     {
         // like nmos::make_session_description for 'internal' use
         // with support for the custom SDP attributes in nvnmos::attributes for senders as well as receivers
-        web::json::value make_session_description(const nmos::type& type, const utility::string_t& internal_id, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params)
+        web::json::value make_session_description(const nmos::type& type, const utility::string_t& name, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params)
         {
             using web::json::value;
 
@@ -1505,7 +1501,7 @@ namespace nvnmos
             {
                 // using op[] rather than at because there can be no session-level attributes
                 auto& session_attributes = session_description[sdp::fields::attributes];
-                web::json::push_back(session_attributes, sdp::named_value(nvnmos::attributes::internal_id, internal_id));
+                web::json::push_back(session_attributes, sdp::named_value(nvnmos::attributes::name, name));
                 if (!group_hint.empty()) web::json::push_back(session_attributes, sdp::named_value(nvnmos::attributes::group_hint, group_hint));
 
                 if (!session_info.empty())
@@ -1655,22 +1651,22 @@ namespace nvnmos
             return transport_params;
         }
 
-        // get the (required) internal id from the custom attribute; throws std::invalid_argument if absent or empty
-        utility::string_t get_session_description_internal_id(const web::json::value& session_description)
+        // get the (required) NvNmos resource name from the `x-nvnmos-name` custom attribute (not the SDP `s=` session-name line); throws std::invalid_argument if absent or empty
+        utility::string_t get_session_description_resource_name(const web::json::value& session_description)
         {
             const auto& session_attributes = sdp::fields::attributes(session_description);
             {
                 const auto& sa = session_attributes.as_array();
 
-                auto internal_id = sdp::find_name(sa, nvnmos::attributes::internal_id);
-                if (sa.end() != internal_id)
+                auto name = sdp::find_name(sa, nvnmos::attributes::name);
+                if (sa.end() != name)
                 {
-                    const auto& value = sdp::fields::value(*internal_id).as_string();
+                    const auto& value = sdp::fields::value(*name).as_string();
                     if (!value.empty()) return value;
                 }
             }
 
-            throw std::invalid_argument("Missing or empty x-nvnmos-id attribute in SDP");
+            throw std::invalid_argument("Missing or empty x-nvnmos-name attribute in SDP");
         }
 
         // get the optional group hint from the custom attribute
@@ -1789,9 +1785,9 @@ namespace nvnmos
         }
 
         // generate repeatable ids for the node's resources
-        nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& internal_id)
+        nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& name)
         {
-            return nmos::make_repeatable_id(seed_id, U("/x-nmos/node/") + type.name + U('/') + internal_id);
+            return nmos::make_repeatable_id(seed_id, U("/x-nmos/node/") + type.name + U('/') + name);
         }
 
         // generate a repeatable source-specific multicast address for each leg of a sender
@@ -1808,20 +1804,20 @@ namespace nvnmos
             return utility::s2us(boost::asio::ip::address_v4(a).to_string());
         }
 
-        // set the internal id for the sender or receiver as a resource tag
-        void set_internal_id(nmos::resource& resource, const utility::string_t& internal_id)
+        // set the name for the sender or receiver as a resource tag
+        void set_name(nmos::resource& resource, const utility::string_t& name)
         {
             using web::json::value_of;
 
-            resource.data[nmos::fields::tags][nvnmos::fields::internal_id] = value_of({ internal_id });
+            resource.data[nmos::fields::tags][nvnmos::fields::name] = value_of({ name });
         }
 
-        // get the internal id for the sender or receiver from a resource tag
-        utility::string_t get_internal_id(const nmos::resource& resource)
+        // get the name for the sender or receiver from a resource tag
+        utility::string_t get_name(const nmos::resource& resource)
         {
-            const auto& internal_ids = nvnmos::fields::internal_id(resource.data.at(nmos::fields::tags)).as_array();
-            return !web::json::empty(internal_ids)
-                ? web::json::front(internal_ids).as_string()
+            const auto& names = nvnmos::fields::name(resource.data.at(nmos::fields::tags)).as_array();
+            return !web::json::empty(names)
+                ? web::json::front(names).as_string()
                 : U("");
         }
 
@@ -2005,12 +2001,12 @@ namespace nvnmos
             return web::json::front(values).as_string();
         }
 
-        // extract the (required) internal id from the urn:x-nvnmos:tag:id tag;
+        // extract the (required) name from the urn:x-nvnmos:tag:name tag;
         // throws std::invalid_argument if absent or empty
-        utility::string_t get_mxl_flow_def_internal_id(const web::json::value& flow_def)
+        utility::string_t get_mxl_flow_def_name(const web::json::value& flow_def)
         {
-            const auto value = get_mxl_flow_def_tag(flow_def, nvnmos::fields::internal_id);
-            if (value.empty()) throw std::invalid_argument("Missing or empty urn:x-nvnmos:tag:id tag in MXL flow definition");
+            const auto value = get_mxl_flow_def_tag(flow_def, nvnmos::fields::name);
+            if (value.empty()) throw std::invalid_argument("Missing or empty urn:x-nvnmos:tag:name tag in MXL flow definition");
             return value;
         }
 

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -1167,7 +1167,10 @@ namespace nvnmos
                 }
 
                 // update session version since the resulting /transportfile isn't necessarily identical to the original SDP data
-                sdp_params.origin.session_version = sdp::ntp_now() >> 32;
+                // (stream-format through utility::ostringstreamed because origin.session_version is now a utility::string_t;
+                // a bare uint64_t would silently truncate to a single non-digit char via std::string::operator=(char),
+                // which then trips sdp::parse on the round-trip with "expected a sequence of digits at line 2")
+                sdp_params.origin.session_version = utility::ostringstreamed(sdp::ntp_now() >> 32);
 
                 auto& transport_params = nmos::fields::transport_params(nmos::fields::endpoint_active(connection_sender.data));
 
@@ -1260,7 +1263,7 @@ namespace nvnmos
 
                     // update session version since the resulting SDP data isn't necessarily identical to the original
                     // sender's /transportfile (e.g. due to rtp_enabled) or receiver's /active transport_file object
-                    sdp_params.origin.session_version = sdp::ntp_now() >> 32;
+                    sdp_params.origin.session_version = utility::ostringstreamed(sdp::ntp_now() >> 32);
 
                     const auto group_hint = impl::get_group_hint(resource);
                     const auto& session_info = nmos::fields::description(resource.data);

--- a/src/nvnmos_impl.h
+++ b/src/nvnmos_impl.h
@@ -51,7 +51,7 @@ namespace nvnmos
     namespace impl
     {
         // generate repeated ids for the node's resources
-        nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& internal_id = {});
+        nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& name = {});
     }
 
     // custom settings fields
@@ -76,7 +76,7 @@ namespace nvnmos
     namespace attributes
     {
         // for senders and receivers
-        const utility::string_t internal_id{ U("x-nvnmos-id") };
+        const utility::string_t name{ U("x-nvnmos-name") };
         const utility::string_t group_hint{ U("x-nvnmos-group-hint") };
         const utility::string_t caps{ U("x-nvnmos-caps") };
         // for receivers
@@ -98,7 +98,7 @@ namespace nvnmos
     // They follow the same tag URN convention as the standard
     // `urn:x-nmos:tag:grouphint/v1.0` group hint.
     //
-    // `internal_id` and `mxl_domain_id` values are single-element arrays
+    // `name` and `mxl_domain_id` values are single-element arrays
     // holding a non-empty string; readers return the first entry.
     //
     // `caps` carries a single-element array whose first entry describes
@@ -108,7 +108,7 @@ namespace nvnmos
     // today any non-empty array is treated as fully flexible.
     namespace fields
     {
-        const web::json::field_as_value_or internal_id{ U("urn:x-nvnmos:tag:id"), web::json::value::array() };
+        const web::json::field_as_value_or name{ U("urn:x-nvnmos:tag:name"), web::json::value::array() };
         const web::json::field_as_value_or caps{ U("urn:x-nvnmos:tag:caps"), web::json::value::array() };
         const web::json::field_as_value_or mxl_domain_id{ U("urn:x-nvnmos:tag:mxl-domain-id"), web::json::value::array() };
     }
@@ -128,27 +128,28 @@ namespace nvnmos
     // This constructs and inserts sources/flows/senders into the model, based on the specified transport file.
     void node_implementation_add_sender(nmos::node_model& model, const nmos::transport& transport, const std::string& transport_file, slog::base_gate& gate);
 
-    // This removes sources/flows/senders from the model corresponding to the specified id.
-    void node_implementation_remove_sender(nmos::node_model& model, const utility::string_t& id, slog::base_gate& gate);
+    // This removes sources/flows/senders from the model corresponding to the specified name.
+    void node_implementation_remove_sender(nmos::node_model& model, const utility::string_t& sender_name, slog::base_gate& gate);
 
     // This constructs and inserts a receiver into the model, based on the specified transport file.
     void node_implementation_add_receiver(nmos::node_model& model, const nmos::transport& transport, const std::string& transport_file, slog::base_gate& gate);
 
-    // This removes the receiver from the model corresponding to the specified id.
-    void node_implementation_remove_receiver(nmos::node_model& model, const utility::string_t& id, slog::base_gate& gate);
+    // This removes the receiver from the model corresponding to the specified name.
+    void node_implementation_remove_receiver(nmos::node_model& model, const utility::string_t& receiver_name, slog::base_gate& gate);
 
     // This is an application callback to update the specified sender or receiver, as a result of an IS-05 Connection API activation.
+    // `type` is `nmos::types::sender` or `nmos::types::receiver` and disambiguates `name`, which is unique within the given side on the Node.
     // The transport file is the updated SDP (for nmos::transports::rtp) or the updated MXL flow definition JSON (for nmos::transports::mxl).
     // If the transport file is empty, the sender or receiver has been deactivated.
-    typedef std::function<void(const std::string& id, const std::string& transport_file)> connection_activation_handler;
+    typedef std::function<void(const nmos::type& type, const std::string& name, const std::string& transport_file)> connection_activation_handler;
 
     // This constructs all the callbacks used to integrate the application into the server instance for the NMOS Node.
     nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, connection_activation_handler connection_activated, slog::base_gate& gate);
 
     // This updates the transport parameters and transport file for the specified sender or receiver based on the specified transport file.
-    // The transport is inferred from the existing sender or receiver with the specified id.
+    // `type` selects between a sender and a receiver with the same `name` on the Node.
     // For now, the transport file is not validated against the existing sender or receiver capabilities and constraints.
-    void node_implementation_activate_connection(nmos::node_model& model, const utility::string_t& id, const std::string& transport_file, slog::base_gate& gate);
+    void node_implementation_activate_connection(nmos::node_model& model, const nmos::type& type, const utility::string_t& name, const std::string& transport_file, slog::base_gate& gate);
 }
 
 #endif

--- a/src/nvnmos_impl.h
+++ b/src/nvnmos_impl.h
@@ -28,6 +28,7 @@
 
 #include "cpprest/json_utils.h"
 #include "nmos/id.h"
+#include "nmos/settings.h"
 #include "nmos/transport.h"
 #include "nmos/type.h"
 
@@ -52,6 +53,9 @@ namespace nvnmos
     {
         // generate repeated ids for the node's resources
         nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& name = {});
+
+        // generate URLs for the Node API and Connection API
+        std::pair<utility::string_t, utility::string_t> make_api_base_urls(const nmos::settings& settings);
     }
 
     // custom settings fields

--- a/src/nvnmos_impl.h
+++ b/src/nvnmos_impl.h
@@ -91,12 +91,26 @@ namespace nvnmos
         const web::json::field_as_integer channel_count{ U("channel_count") };
     }
 
-    // custom MXL flow definition JSON properties
+    // custom NvNmos tag fields
+    //
+    // These name entries in the `tags` property -- both within an MXL flow
+    // definition JSON document and on an NMOS resource.
+    // They follow the same tag URN convention as the standard
+    // `urn:x-nmos:tag:grouphint/v1.0` group hint.
+    //
+    // `internal_id` and `mxl_domain_id` values are single-element arrays
+    // holding a non-empty string; readers return the first entry.
+    //
+    // `caps` carries a single-element array whose first entry describes
+    // the receiver's capability advertisement: an empty string means
+    // "fully flexible" (format-derived capabilities omitted). Non-empty
+    // strings are reserved for future use (e.g. constraint expressions);
+    // today any non-empty array is treated as fully flexible.
     namespace fields
     {
-        const web::json::field_as_string internal_id{ U("x-nvnmos-id") };
-        const web::json::field_as_value_or caps{ U("x-nvnmos-caps"), {} }; // null when absent
-        const web::json::field_as_string mxl_domain_id{ U("x-nvnmos-mxl-domain-id") };
+        const web::json::field_as_value_or internal_id{ U("urn:x-nvnmos:tag:id"), web::json::value::array() };
+        const web::json::field_as_value_or caps{ U("urn:x-nvnmos:tag:caps"), web::json::value::array() };
+        const web::json::field_as_value_or mxl_domain_id{ U("urn:x-nvnmos:tag:mxl-domain-id"), web::json::value::array() };
     }
 
     // custom SDP format-specific parameters

--- a/src/nvnmos_impl.h
+++ b/src/nvnmos_impl.h
@@ -27,7 +27,9 @@
 #define NVNMOS_IMPL_H
 
 #include "cpprest/json_utils.h"
+#include "nmos/id.h"
 #include "nmos/transport.h"
+#include "nmos/type.h"
 
 namespace slog
 {
@@ -46,6 +48,12 @@ namespace nmos
 
 namespace nvnmos
 {
+    namespace impl
+    {
+        // generate repeated ids for the node's resources
+        nmos::id make_id(const nmos::id& seed_id, const nmos::type& type, const utility::string_t& internal_id = {});
+    }
+
     // custom settings fields
     namespace fields
     {

--- a/src/nvnmos_impl.h
+++ b/src/nvnmos_impl.h
@@ -27,6 +27,7 @@
 #define NVNMOS_IMPL_H
 
 #include "cpprest/json_utils.h"
+#include "nmos/transport.h"
 
 namespace slog
 {
@@ -58,7 +59,7 @@ namespace nvnmos
 
         const web::json::field_as_value senders{ U("senders") }; // object with ids as keys
         const web::json::field_as_value receivers{ U("receivers") }; // object with ids as keys
-        const web::json::field_as_string sdp{ U("sdp") };
+        const web::json::field_as_string transport_file{ U("transport_file") };
 
         const web::json::field_as_value clocks{ U("clocks") }; // object with clock names as keys
     }
@@ -76,6 +77,20 @@ namespace nvnmos
         const utility::string_t source_port{ U("x-nvnmos-src-port") };
     }
 
+    // extra MXL flow definition properties
+    namespace fields
+    {
+        const web::json::field_as_integer channel_count{ U("channel_count") };
+    }
+
+    // custom MXL flow definition JSON properties
+    namespace fields
+    {
+        const web::json::field_as_string internal_id{ U("x-nvnmos-id") };
+        const web::json::field_as_value_or caps{ U("x-nvnmos-caps"), {} }; // null when absent
+        const web::json::field_as_string mxl_domain_id{ U("x-nvnmos-mxl-domain-id") };
+    }
+
     // custom SDP format-specific parameters
     namespace fields
     {
@@ -88,28 +103,30 @@ namespace nvnmos
     // This constructs and inserts a node resource and a device resource into the model, based on the model settings.
     void node_implementation_init(nmos::node_model& model, slog::base_gate& gate);
 
-    // This constructs and inserts sources/flows/senders into the model, based on the specified SDP file.
-    void node_implementation_add_sender(nmos::node_model& model, const std::string& sdp, slog::base_gate& gate);
+    // This constructs and inserts sources/flows/senders into the model, based on the specified transport file.
+    void node_implementation_add_sender(nmos::node_model& model, const nmos::transport& transport, const std::string& transport_file, slog::base_gate& gate);
 
     // This removes sources/flows/senders from the model corresponding to the specified id.
     void node_implementation_remove_sender(nmos::node_model& model, const utility::string_t& id, slog::base_gate& gate);
 
-    // This constructs and inserts a receiver into the model, based on the specified SDP file.
-    void node_implementation_add_receiver(nmos::node_model& model, const std::string& sdp, slog::base_gate& gate);
+    // This constructs and inserts a receiver into the model, based on the specified transport file.
+    void node_implementation_add_receiver(nmos::node_model& model, const nmos::transport& transport, const std::string& transport_file, slog::base_gate& gate);
 
     // This removes the receiver from the model corresponding to the specified id.
     void node_implementation_remove_receiver(nmos::node_model& model, const utility::string_t& id, slog::base_gate& gate);
 
     // This is an application callback to update the specified sender or receiver, as a result of an IS-05 Connection API activation.
-    // If the SDP file is empty, the sender or receiver has been deactivated.
-    typedef std::function<void(const std::string& id, const std::string& sdp)> rtp_connection_activation_handler;
+    // The transport file is the updated SDP (for nmos::transports::rtp) or the updated MXL flow definition JSON (for nmos::transports::mxl).
+    // If the transport file is empty, the sender or receiver has been deactivated.
+    typedef std::function<void(const std::string& id, const std::string& transport_file)> connection_activation_handler;
 
     // This constructs all the callbacks used to integrate the application into the server instance for the NMOS Node.
-    nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, rtp_connection_activation_handler rtp_connection_activated, slog::base_gate& gate);
+    nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, connection_activation_handler connection_activated, slog::base_gate& gate);
 
-    // This updates the transport parameters and transport file for the specified sender or receiver based on the specified SDP file.
-    // For now, the SDP file is not validated against the existing sender or receiver capabilities and constraints.
-    void node_implementation_activate_rtp_connection(nmos::node_model& model, const utility::string_t& id, const std::string& sdp, slog::base_gate& gate);
+    // This updates the transport parameters and transport file for the specified sender or receiver based on the specified transport file.
+    // The transport is inferred from the existing sender or receiver with the specified id.
+    // For now, the transport file is not validated against the existing sender or receiver capabilities and constraints.
+    void node_implementation_activate_connection(nmos::node_model& model, const utility::string_t& id, const std::string& transport_file, slog::base_gate& gate);
 }
 
 #endif


### PR DESCRIPTION
Add support for AMWA BCP-007-03 MXL transport alongside RTP. NvNmos sender/receiver configuration now selects between transports via a new NvNmosTransport enum, and the per-resource 'sdp' field is replaced with a generic 'transport_file' carrying either an SDP file (RTP) or an MXL flow definition JSON (MXL).

New 'x-nvnmos-' JSON keys mirror the existing SDP attribute extensions: x-nvnmos-id, x-nvnmos-caps and x-nvnmos-mxl-domain-id. The IS-04 Flow is published as a coded video flow (with the parameter-register 'components' extension) or as a raw audio flow.

The connection_activated callback supersedes rtp_connection_activated and reports an updated transport_file (SDP for RTP; MXL flow definition JSON with the active mxl_domain_id and mxl_flow_id spliced in for MXL). nmos_connection_activate replaces nmos_connection_rtp_activate.

The example application is updated to exercise both transports end-to-end.