### PR TITLE
Add nvnmosd smoke tests to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Keep in sync with .gitignore (paths relative to docker build context = repo root).
+# Same as .gitignore, plus rust/target/ for the Docker build context.
 
 # Python venv (README recommends `.venv` beside the repo)
 .venv/
@@ -12,3 +12,6 @@ CMakeUserPresets.json
 # Local Conan + CMake output (README layout)
 build/
 src/conan/
+
+# Rust workspace artifacts
+rust/target/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,16 @@ jobs:
           NVNMOS_LIB_DIR: ${{ github.workspace }}/build
           LD_LIBRARY_PATH: ${{ github.workspace }}/build
         run: cargo test --workspace --locked --no-fail-fast
+  docker:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build -t nvnmos:ci .
+
+      - name: Run entrypoint smoke tests (non-root)
+        run: docker run --rm --user 1000:1000 --cap-drop=ALL nvnmos:ci true
   license-check:
     runs-on: ubuntu-24.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,36 +20,39 @@ ARG PIP_BREAK_SYSTEM_PACKAGES=1
 # Match .github/workflows/ci.yml until a Conan Center nmos-cpp release is published.
 ARG NMOS_CPP_REF=079620d88756aa138ede92d3f52a0102370307fe
 
-FROM ${BASE_IMAGE} as builder
-
-ARG BASE_IMAGE
-ARG DEBIAN_FRONTEND
-ARG PACKAGE_SUFFIX
-ARG PIP_BREAK_SYSTEM_PACKAGES
-ARG NMOS_CPP_REF
-
 # use pattern replacement to clean up '/' and ':'
-ENV _BASE_IMAGE=${BASE_IMAGE//\//-}
-ENV PACKAGE_NAME=nvnmos${PACKAGE_SUFFIX:--${_BASE_IMAGE//:/-}}
+ARG _BASE_IMAGE=${BASE_IMAGE//\//-}
+ARG PACKAGE_NAME=nvnmos${PACKAGE_SUFFIX:--${_BASE_IMAGE//:/-}}
 
-RUN apt update && apt install -y gcc git python3-pip doxygen graphviz
+# -----------------------------------------------------------------------------
+# C++ library (libnvnmos) — same layout as README / CI (repo root, build/ sibling of src/).
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS cpp-builder
+
+ARG DEBIAN_FRONTEND
+ARG NMOS_CPP_REF
+ARG PACKAGE_NAME
+ARG PIP_BREAK_SYSTEM_PACKAGES
+
+ENV PIP_BREAK_SYSTEM_PACKAGES=${PIP_BREAK_SYSTEM_PACKAGES}
+
+RUN apt update && apt install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install cmake~=3.17
 RUN pip install conan~=2.2 && conan profile detect
 
-# nmos-cpp alongside nvnmos (see src/CMakeLists.txt NMOS_CPP_DIRECTORY).
 RUN git init /nmos-cpp \
     && git -C /nmos-cpp remote add origin https://github.com/sony/nmos-cpp.git \
     && git -C /nmos-cpp fetch --depth 1 origin "${NMOS_CPP_REF}" \
     && git -C /nmos-cpp checkout FETCH_HEAD
 
-# Same layout as README / CI: repo root with src/ and build/ siblings.
 WORKDIR /nvnmos
 
 COPY src/ src/
-COPY entrypoint.sh LICENSE README.md Doxyfile ./
-COPY doc/doxygen doc/doxygen
-
-RUN chmod +x entrypoint.sh
 
 RUN conan install src \
     --settings:all build_type=Release \
@@ -70,27 +73,96 @@ RUN cmake --build build --parallel 2
 
 RUN cmake --install build --prefix=${PACKAGE_NAME}
 
-RUN cp src/conan.lock ${PACKAGE_NAME}/
+# -----------------------------------------------------------------------------
+# Rust workspace — links against libnvnmos from cpp-builder (CI NVNMOS_LIB_DIR layout).
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS rust-builder
 
-RUN cp LICENSE README.md ${PACKAGE_NAME}/
+ARG DEBIAN_FRONTEND
 
+RUN apt update && apt install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    clang \
+    cmake \
+    curl \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    libgstreamer-plugins-base1.0-dev \
+    libgstreamer1.0-dev \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain 1.85 --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /nvnmos
+
+COPY --from=cpp-builder /nvnmos/build /nvnmos/build
+COPY --from=cpp-builder /nvnmos/src /nvnmos/src
+COPY rust/ rust/
+
+RUN NVNMOS_LIB_DIR=/nvnmos/build cargo build --manifest-path rust/Cargo.toml --workspace --release --locked
+
+# -----------------------------------------------------------------------------
+# Package tarball (C++ install tree + Rust artifacts + docs).
+# -----------------------------------------------------------------------------
+FROM ${BASE_IMAGE} AS package
+
+ARG DEBIAN_FRONTEND
+ARG PACKAGE_NAME
+
+RUN apt update && apt install -y --no-install-recommends \
+    doxygen \
+    graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /nvnmos
+
+COPY --from=cpp-builder /nvnmos/${PACKAGE_NAME} /nvnmos/${PACKAGE_NAME}
+COPY --from=cpp-builder /nvnmos/src /nvnmos/src
+COPY --from=cpp-builder /nvnmos/src/conan.lock /nvnmos/src/conan.lock
+COPY --from=rust-builder /nvnmos/rust/target/release/libgstnmos.so \
+    /nvnmos/${PACKAGE_NAME}/lib/
+COPY --from=rust-builder /nvnmos/rust/target/release/nvnmosd \
+    /nvnmos/${PACKAGE_NAME}/bin/
+COPY --from=rust-builder /nvnmos/rust/target/release/nvnmosd-example \
+    /nvnmos/${PACKAGE_NAME}/bin/
+
+COPY entrypoint.sh entrypoint-setup.sh LICENSE README.md Doxyfile ./
+COPY doc/doxygen doc/doxygen
+
+RUN chmod +x entrypoint.sh entrypoint-setup.sh \
+    && cp src/conan.lock ${PACKAGE_NAME}/ \
+    && cp LICENSE README.md ${PACKAGE_NAME}
 # Doxyfile paths assume CWD is src/ (INPUT, HTML_HEADER, etc.).
 RUN cd src && doxygen ../Doxyfile && mv html ../${PACKAGE_NAME}/
 
 RUN tar -cvzf ${PACKAGE_NAME}.tar.gz ${PACKAGE_NAME}
 
+# -----------------------------------------------------------------------------
+# Runtime image (tarball + entrypoint only).
+# -----------------------------------------------------------------------------
 FROM ${BASE_IMAGE}
 
-ARG BASE_IMAGE
-ARG PACKAGE_SUFFIX
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PACKAGE_NAME
+ENV PACKAGE_NAME=${PACKAGE_NAME}
 
-# use pattern replacement to clean up '/' and ':'
-ENV _BASE_IMAGE=${BASE_IMAGE//\//-}
-ENV PACKAGE_NAME=nvnmos${PACKAGE_SUFFIX:--${_BASE_IMAGE//:/-}}
+RUN apt update && apt install -y --no-install-recommends \
+    avahi-daemon \
+    avahi-utils \
+    dbus \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder \
+# Socket under /tmp so dbus-daemon does not need root. entrypoint-setup.sh binds here.
+# Derived images that start D-Bus differently must override this variable.
+ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/tmp/dbus-system-bus-socket
+
+COPY --from=package \
     /nvnmos/${PACKAGE_NAME}.tar.gz \
     /nvnmos/entrypoint.sh \
+    /nvnmos/entrypoint-setup.sh \
     ./
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ docker cp nvnmos-test:/nvnmos-ubuntu-24.04.tar.gz .
 docker rm nvnmos-test
 ```
 
-The container also has an _entrypoint.sh_ which demonstrates how to install the run-time requirements and run the application.
+The runtime image includes _dbus_, _avahi-daemon_, and _avahi-utils_. _entrypoint.sh_ (and _entrypoint-setup.sh_) start D-Bus and Avahi without systemd or chroot, run the C _nvnmos-example_ and the Rust _nvnmosd_ / _nvnmosd-example_ pair, then exec your command.
 
 ```sh
 docker run -it nvnmos /bin/bash
@@ -180,7 +180,7 @@ The following build arguments are available.
 | PACKAGE_SUFFIX | Controls the package filename, which will be _nvnmos\<suffix\>.tar.gz_. Default is based on the base image, e.g. `-ubuntu-24.04`. |
 | NMOS_CPP_REF | Git commit of [sony/nmos-cpp](https://github.com/sony/nmos-cpp) to build via `add_subdirectory`. Default is the same hash pinned in `.github/workflows/ci.yml`. |
 
-The image clones that _nmos-cpp_ revision, runs `conan install` with `nmos_cpp_from_source=True` (no input lockfile), configures with `-DUSE_ADD_SUBDIRECTORY=ON`, and writes a fresh `conan.lock` into the package tarball from the resolved dependency graph.
+The image clones that _nmos-cpp_ revision, runs `conan install` with `nmos_cpp_from_source=True` (no input lockfile), configures with `-DUSE_ADD_SUBDIRECTORY=ON`, and writes a fresh `conan.lock` into the package tarball from the resolved dependency graph. Also builds the Rust workspace (`nvnmosd`, `gst-nmos-rs`, …) against the built `libnvnmos.so`.
 
 If this isn't sufficient for your purposes, read on for manual build instructions.
 

--- a/entrypoint-setup.sh
+++ b/entrypoint-setup.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sourceable infrastructure setup for nvnmos containers.
+#
+# Starts dbus-daemon and avahi-daemon without systemd, without chroot, and
+# without requiring CAP_SYS_CHROOT. Uses a dedicated Unix socket for D-Bus
+# (exported as DBUS_SYSTEM_BUS_ADDRESS) so Avahi and libnvnmos can share a bus
+# without the host system dbus. Provides a publish_mdns_hostname function.
+#
+# Usage:
+#   source /entrypoint-setup.sh
+#
+# Expects DBUS_SYSTEM_BUS_ADDRESS (e.g. set via Dockerfile ENV). Derived
+# images that start D-Bus differently must override that variable.
+#
+# The caller should set shell options (e.g. set -euxo pipefail) before
+# sourcing this script.
+#
+# This script sets a trap on EXIT/INT/TERM to clean up background processes.
+# If the caller needs its own trap, it should call cleanup() from within it,
+# e.g. trap 'my_cleanup; cleanup' EXIT INT TERM
+
+pids=()
+
+# Use a session bus and avoid daemonizing so that root privileges are not needed
+dbus_address="${DBUS_SYSTEM_BUS_ADDRESS:-}"
+case "$dbus_address" in
+  unix:path=/*)
+    dbus_path=${dbus_address#unix:path=}
+    ;;
+  "")
+    echo "DBUS_SYSTEM_BUS_ADDRESS is not set" >&2
+    echo "Expected: unix:path=/absolute/path" >&2
+    exit 1
+    ;;
+  *)
+    echo "Unsupported DBUS_SYSTEM_BUS_ADDRESS: $dbus_address" >&2
+    echo "Expected: unix:path=/absolute/path" >&2
+    exit 1
+    ;;
+esac
+dbus_dir=$(dirname "$dbus_path")
+mkdir -p "$dbus_dir"
+rm -f "$dbus_path"
+dbus-daemon --session --nofork --nopidfile --address="$dbus_address" &
+pids+=($!)
+
+for _ in {1..20}; do [ -S "$dbus_path" ] && break; sleep 0.1; done
+[ -S "$dbus_path" ] || { echo "dbus-daemon failed to start"; exit 1; }
+
+# Do not daemonize and run as current user so that CAP_SYS_CHROOT is not needed
+# (running in the container provides sufficient isolation)
+avahi-daemon --no-drop-root --no-chroot &
+pids+=($!)
+
+cleanup() {
+    echo "Stopping background processes..."
+    for pid in "${pids[@]}"; do
+        kill "$pid" 2>/dev/null
+    done
+    wait
+}
+trap cleanup EXIT INT TERM
+
+publish_mdns_hostname() {
+    local mdns_hostname="$1"
+    echo "Publishing mDNS hostname: $mdns_hostname"
+    while IFS= read -r ip; do
+        [[ -n "$ip" ]] || continue
+        echo "  Advertising $mdns_hostname at $ip"
+        avahi-publish-address -R "$mdns_hostname" "$ip" &
+        pids+=($!)
+    done < <(hostname --all-ip-addresses | tr ' ' '\n')
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/usr/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +15,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -euo pipefail
 
-apt update
-apt install -y dbus avahi-daemon
+_nvnmos_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=entrypoint-setup.sh
+source "${_nvnmos_dir}/entrypoint-setup.sh"
 
-[ -e "/etc/init.d/dbus" ] && /etc/init.d/dbus start || dbus-daemon --system --fork
-[ -e "/etc/init.d/avahi-daemon" ] && /etc/init.d/avahi-daemon start || avahi-daemon --daemonize
+NVNMOS_WORK_DIR="${NVNMOS_WORK_DIR:-/tmp/nvnmos}"
+mkdir -p "${NVNMOS_WORK_DIR}"
+tar -xf "${_nvnmos_dir}/${PACKAGE_NAME}.tar.gz" -C "${NVNMOS_WORK_DIR}"
+PACKAGE_ROOT="${NVNMOS_WORK_DIR}/${PACKAGE_NAME}"
 
-tar -xvf ${PACKAGE_NAME}.tar.gz
+export HOSTIP
+HOSTIP="$(awk 'END{print $1}' /etc/hosts)"
 
-export HOSTIP=`awk 'END{print $1}' /etc/hosts`
+# User-mode Avahi does not register the host name the way systemd does; publish
+# explicitly so nvnmos-example's ${HOSTNAME}.local resolves in the container.
+publish_mdns_hostname "${HOSTNAME}.local"
+sleep 1
 
-yes | LD_LIBRARY_PATH=${PACKAGE_NAME}/lib ${PACKAGE_NAME}/bin/nvnmos-example ${HOSTNAME}.local 8080 ${HOSTIP}
+export LD_LIBRARY_PATH="${PACKAGE_ROOT}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+# yes(1) exits with SIGPIPE once nvnmos-example stops reading; check the example only.
+set +o pipefail
+yes | "${PACKAGE_ROOT}/bin/nvnmos-example" "${HOSTNAME}.local" 8080 "${HOSTIP}"
+example_status=${PIPESTATUS[1]}
+set -o pipefail
+if [[ "${example_status}" -ne 0 ]]; then
+    echo "nvnmos-example failed with status ${example_status}" >&2
+    exit 1
+fi
+
+export NVNMOSD_UDS="${NVNMOSD_UDS:-/tmp/nvnmosd.sock}"
+rm -f "${NVNMOSD_UDS}"
+"${PACKAGE_ROOT}/bin/nvnmosd" &
+nvnmosd_pid=$!
+pids+=("${nvnmosd_pid}")
+for _ in {1..50}; do [ -S "${NVNMOSD_UDS}" ] && break; sleep 0.1; done
+[ -S "${NVNMOSD_UDS}" ] || {
+    echo "nvnmosd failed to listen on ${NVNMOSD_UDS}" >&2
+    exit 1
+}
+"${PACKAGE_ROOT}/bin/nvnmosd-example"
+kill "${nvnmosd_pid}" 2>/dev/null || true
+wait "${nvnmosd_pid}" 2>/dev/null || true
 
 exec "$@"


### PR DESCRIPTION
Entrypoint runs the C nvnmos-example and nvnmosd/nvnmosd-example pair after extracting the package to a writable work dir.

* Multi-stage Dockerfile builds the Rust workspace into the tarball and installs dbus and Avahi in the runtime image.
* Entrypoint starts D-Bus and Avahi without systemd, chroot, or runtime apt via entrypoint-setup.sh and DBUS_SYSTEM_BUS_ADDRESS on a /tmp socket.

CI builds the image and runs the entrypoint as a non-root user without extra capabilities.