### PR TITLE
Fix receiver-caps-mode=wide (part 2)

### DIFF
--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -352,6 +352,23 @@ pub(crate) fn splice_overrides(
     Ok(serde_json::to_string(&value).expect("flow_def value is always serialisable"))
 }
 
+const CAPS_TAG: &str = "urn:x-nvnmos:tag:caps";
+
+/// Whether a transport file's `urn:x-nvnmos:tag:caps` tag indicates
+/// wide Receiver Caps per libnvnmos's BCP-007-03 rule: present with a
+/// non-empty JSON array (including `[""]`).
+pub(crate) fn transport_file_indicates_wide_caps(text: &str) -> Result<bool, FlowDefError> {
+    let value: serde_json::Value =
+        serde_json::from_str(text).map_err(|source| FlowDefError::Parse { source })?;
+    let Some(tags) = value.get("tags").and_then(|t| t.as_object()) else {
+        return Ok(false);
+    };
+    let Some(arr) = tags.get(CAPS_TAG).and_then(|v| v.as_array()) else {
+        return Ok(false);
+    };
+    Ok(!arr.is_empty())
+}
+
 /// Inputs to [`from_caps`]. All borrowed; the builder doesn't
 /// hold any of these beyond the call.
 #[derive(Debug)]
@@ -956,6 +973,22 @@ mod tests {
         // libnvnmos's rule is "present + non-empty array means wide";
         // assert that's what we wrote.
         assert!(!arr.is_empty(), "wide-mode array must be non-empty; got {v}");
+    }
+
+    #[test]
+    fn transport_file_indicates_wide_caps_matches_libnvnmos_rule() {
+        let wide = format!(
+            r#"{{"id":"{UUID_A}","format":"urn:x-nmos:format:video","tags":{{"urn:x-nvnmos:tag:caps":[""]}}}}"#
+        );
+        assert!(transport_file_indicates_wide_caps(&wide).unwrap());
+
+        let narrow = video_flow_def(UUID_A);
+        assert!(!transport_file_indicates_wide_caps(&narrow).unwrap());
+
+        let empty_tag = format!(
+            r#"{{"id":"{UUID_A}","format":"urn:x-nmos:format:video","tags":{{"urn:x-nvnmos:tag:caps":[]}}}}"#
+        );
+        assert!(!transport_file_indicates_wide_caps(&empty_tag).unwrap());
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -357,7 +357,7 @@ const CAPS_TAG: &str = "urn:x-nvnmos:tag:caps";
 /// Whether a transport file's `urn:x-nvnmos:tag:caps` tag indicates
 /// wide Receiver Caps per libnvnmos's BCP-007-03 rule: present with a
 /// non-empty JSON array (including `[""]`).
-pub(crate) fn transport_file_indicates_wide_caps(text: &str) -> Result<bool, FlowDefError> {
+pub(crate) fn indicates_wide_receiver_caps(text: &str) -> Result<bool, FlowDefError> {
     let value: serde_json::Value =
         serde_json::from_str(text).map_err(|source| FlowDefError::Parse { source })?;
     let Some(tags) = value.get("tags").and_then(|t| t.as_object()) else {
@@ -976,19 +976,19 @@ mod tests {
     }
 
     #[test]
-    fn transport_file_indicates_wide_caps_matches_libnvnmos_rule() {
+    fn indicates_wide_receiver_caps_matches_libnvnmos_rule() {
         let wide = format!(
             r#"{{"id":"{UUID_A}","format":"urn:x-nmos:format:video","tags":{{"urn:x-nvnmos:tag:caps":[""]}}}}"#
         );
-        assert!(transport_file_indicates_wide_caps(&wide).unwrap());
+        assert!(indicates_wide_receiver_caps(&wide).unwrap());
 
         let narrow = video_flow_def(UUID_A);
-        assert!(!transport_file_indicates_wide_caps(&narrow).unwrap());
+        assert!(!indicates_wide_receiver_caps(&narrow).unwrap());
 
         let empty_tag = format!(
             r#"{{"id":"{UUID_A}","format":"urn:x-nmos:format:video","tags":{{"urn:x-nvnmos:tag:caps":[]}}}}"#
         );
-        assert!(!transport_file_indicates_wide_caps(&empty_tag).unwrap());
+        assert!(!indicates_wide_receiver_caps(&empty_tag).unwrap());
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -99,15 +99,17 @@
 //! out of scope (no peer to query).
 //!
 //! `nmossrc` advertises essence caps on its ghost source pad when a
-//! configuring transport file is in play, except for MXL receivers
-//! whose effective transport file indicates wide Receiver Caps (the
-//! `urn:x-nvnmos:tag:caps` tag after NULL→READY property splice, or on
-//! the daemon activation file): those use bare `mxlsrc` so runtime
-//! caps come from the filesystem flow_def, not the configuring one.
-//! Otherwise the configuring flow_def is reverse-mapped via
-//! [`flow_def::caps_from`] and pinned by an internal
-//! `mxlsrc ! capssetter` chain so downstream caps queries see the
-//! concrete shape the flow will carry — the canonical
+//! configuring transport file is in play, except for receivers whose
+//! effective transport file indicates wide Receiver Caps: MXL receivers
+//! use the `urn:x-nvnmos:tag:caps` tag (after NULL→READY property
+//! splice, or on the daemon activation file) and use bare `mxlsrc` so
+//! runtime caps come from the filesystem flow_def; UDP receivers use
+//! media-level `a=x-nvnmos-caps:` (spliced at registration or emitted
+//! by libnvnmos on IS-05 activation) and omit the trailing
+//! `capssetter` so runtime caps come from the live RTP flow.
+//! Otherwise the configuring transport file is reverse-mapped and
+//! pinned by an internal `capssetter` so downstream caps queries see
+//! the concrete shape the flow will carry — the canonical
 //! `nmossrc ! transform ! nmossink` pipeline then resolves end-to-end
 //! at READY→PAUSED: the deferred `nmossink`'s peer_query_caps lands
 //! on the pinned caps and `AddSender` runs against the right

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -98,17 +98,20 @@
 //! `capsfilter`" hint. Receiver-side deferred mode is intentionally
 //! out of scope (no peer to query).
 //!
-//! `nmossrc` advertises essence caps on its ghost source pad
-//! whenever a flow_def is in play (`transport-file*` at NULL→READY,
-//! a flow_def synthesised from `caps + mxl-flow-id`, or the
-//! daemon-spliced internal transport file at activation). The
-//! flow_def is reverse-mapped via [`flow_def::caps_from`]
-//! and pinned by an internal `mxlsrc ! capssetter` chain so
-//! downstream caps queries see the concrete shape the flow will
-//! carry — the canonical `nmossrc ! transform ! nmossink` pipeline
-//! then resolves end-to-end at READY→PAUSED: the deferred
-//! `nmossink`'s peer_query_caps lands on the pinned caps and
-//! `AddSender` runs against the right flow_def.
+//! `nmossrc` advertises essence caps on its ghost source pad when a
+//! configuring transport file is in play, except for MXL receivers
+//! whose effective transport file indicates wide Receiver Caps (the
+//! `urn:x-nvnmos:tag:caps` tag after NULL→READY property splice, or on
+//! the daemon activation file): those use bare `mxlsrc` so runtime
+//! caps come from the filesystem flow_def, not the configuring one.
+//! Otherwise the configuring flow_def is reverse-mapped via
+//! [`flow_def::caps_from`] and pinned by an internal
+//! `mxlsrc ! capssetter` chain so downstream caps queries see the
+//! concrete shape the flow will carry — the canonical
+//! `nmossrc ! transform ! nmossink` pipeline then resolves end-to-end
+//! at READY→PAUSED: the deferred `nmossink`'s peer_query_caps lands
+//! on the pinned caps and `AddSender` runs against the right
+//! flow_def.
 //!
 //! Receiver-side caps→flow_def synthesis is symmetric with the
 //! Sender path: `nmossrc` with `caps` + `mxl-flow-id` (no transport

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -595,21 +595,18 @@ impl NmosSrc {
                             chain.bin
                         }
                     }
-                    TransportConfig::Udp { variant, media, .. } => {
-                        // Receiver-side advertise_caps for UDP is the
-                        // essence shape carried by `media.raw_caps`
-                        // (derived from the SDP transport-file at
-                        // resolution time). Pinned via the bare
-                        // factory call here; the factory itself wraps
-                        // the depayloader + a trailing capsfilter so
-                        // downstream caps queries see the concrete
-                        // shape the flow will carry, mirroring the
-                        // `mxlsrc ! capssetter` sub-bin pattern.
+                    TransportConfig::Udp {
+                        variant,
+                        media,
+                        transport_file,
+                    } => {
+                        let advertise_caps =
+                            udp_receiver_advertise_caps(transport_file.as_deref(), media);
                         {
                             let chain = inner::build_udpsrc(
                                 media,
                                 *variant,
-                                Some(&media.raw_caps),
+                                advertise_caps.as_ref(),
                             )?;
                             let settings = self.settings.lock().unwrap();
                             inner::apply_udp_src_inner_properties(
@@ -839,9 +836,15 @@ impl NmosSrc {
                     }
                 }
             }
-            InnerConfig::Real(TransportConfig::Udp { variant, media, .. }) => {
+            InnerConfig::Real(TransportConfig::Udp {
+                variant,
+                media,
+                transport_file,
+            }) => {
+                let advertise_caps =
+                    udp_receiver_advertise_caps(transport_file.as_deref(), media);
                 let settings = self.settings.lock().unwrap();
-                match inner::build_udpsrc(media, *variant, Some(&media.raw_caps)) {
+                match inner::build_udpsrc(media, *variant, advertise_caps.as_ref()) {
                     Ok(chain) => {
                         inner::apply_udp_src_inner_properties(
                             &CAT,
@@ -962,7 +965,7 @@ fn mxl_receiver_skips_capssetter(transport_file: Option<&str>) -> bool {
     transport_file
         .filter(|s| !s.is_empty())
         .and_then(|text| {
-            crate::flow_def::transport_file_indicates_wide_caps(text)
+            crate::flow_def::indicates_wide_receiver_caps(text)
                 .map_err(|e| {
                     gst::warning!(
                         CAT,
@@ -991,6 +994,29 @@ fn mxl_receiver_advertise_caps(
         return Ok(None);
     }
     derive_advertise_caps(transport_file)
+}
+
+/// UDP receiver inner-chain caps advertisement. When the effective
+/// transport file (activation SDP from libnvnmos, or the post-splice
+/// configuring SDP) carries `a=x-nvnmos-caps:`, omit `capssetter` so
+/// runtime caps come from the live RTP flow; otherwise pin essence
+/// caps parsed from the same SDP.
+fn udp_receiver_advertise_caps(
+    transport_file: Option<&str>,
+    media: &crate::session::UdpMedia,
+) -> Option<gst::Caps> {
+    if transport_file
+        .filter(|s| !s.is_empty())
+        .is_some_and(crate::sdp::indicates_wide_receiver_caps)
+    {
+        gst::debug!(
+            CAT,
+            "nmossrc: wide UDP receiver — depay only (no capssetter); \
+             runtime caps from activation SDP",
+        );
+        return None;
+    }
+    Some(media.raw_caps.clone())
 }
 
 /// Best-available caps for the bin's fake chain, resolved from
@@ -1186,6 +1212,42 @@ mod tests {
                 .unwrap()
                 .is_some(),
             "post-splice narrow transport file must use capssetter",
+        );
+    }
+
+    #[test]
+    fn udp_wide_receiver_skips_capssetter_advertise_caps() {
+        let _ = gst::init();
+        const NARROW_SDP: &str = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=Example\r\n",
+            "t=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 239.2.2.2/64\r\n",
+            "a=rtpmap:96 raw/90000\r\n",
+            "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25/1; depth=10\r\n",
+        );
+        const WIDE_SDP: &str = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=Example\r\n",
+            "t=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 239.2.2.2/64\r\n",
+            "a=rtpmap:96 raw/90000\r\n",
+            "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25/1; depth=10\r\n",
+            "a=x-nvnmos-caps:96\r\n",
+        );
+        let narrow_media = crate::sdp::parse_sdp(NARROW_SDP).expect("parse narrow");
+        let wide_media = crate::sdp::parse_sdp(WIDE_SDP).expect("parse wide");
+        assert!(
+            udp_receiver_advertise_caps(Some(NARROW_SDP), &narrow_media).is_some(),
+            "narrow SDP must pin capssetter",
+        );
+        assert!(
+            udp_receiver_advertise_caps(Some(WIDE_SDP), &wide_media).is_none(),
+            "wide SDP (a=x-nvnmos-caps) must skip capssetter",
         );
     }
 

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -282,15 +282,16 @@ impl ObjectImpl for NmosSrc {
                     .nick("Receiver caps mode")
                     .blurb(
                         "Selects whether the published NMOS Receiver advertises narrow \
-                         or wide Receiver Caps in IS-04, via the presence of the \
-                         `urn:x-nvnmos:tag:caps` tag on the flow_def. `auto` (default) \
-                         leaves the tag untouched in the spliced transport file: the \
-                         result is narrow when the transport file is present and the \
-                         tag is absent (or no transport file is in play), and wide \
-                         when the tag is already there. `narrow` strips the tag from \
-                         the transport file if present. `wide` ensures the tag is \
-                         present with a non-empty marker (libnvnmos's rule for wide \
-                         is \"present + non-empty\").",
+                         or wide Receiver Caps in IS-04. On MXL (`transport=mxl`) this \
+                         is encoded via the `urn:x-nvnmos:tag:caps` flow_def tag; on \
+                         RTP/UDP it is encoded via the media-level SDP \
+                         `a=x-nvnmos-caps` attribute. `auto` (default) leaves both \
+                         untouched in the spliced transport file: the result is narrow \
+                         when the file is present and the marker is absent (or no \
+                         transport file is in play), and wide when the marker is \
+                         already there. `narrow` strips the tag / attribute if \
+                         present. `wide` ensures each is present (libnvnmos's rule \
+                         for wide is \"present + non-empty\").",
                     )
                     .default_value(CapsMode::Auto)
                     .mutable_ready()
@@ -574,7 +575,8 @@ impl NmosSrc {
                         format,
                         transport_file,
                     } => {
-                        let advertise_caps = derive_advertise_caps(transport_file.as_deref())?;
+                        let advertise_caps =
+                            mxl_receiver_advertise_caps(transport_file.as_deref())?;
                         {
                             let chain = inner::build_mxlsrc(
                                 domain_path,
@@ -808,7 +810,7 @@ impl NmosSrc {
             InnerConfig::Real(TransportConfig::Mxl {
                 domain_path, flow_id, format, transport_file,
             }) => {
-                let advertise_caps = match derive_advertise_caps(transport_file.as_deref()) {
+                let advertise_caps = match mxl_receiver_advertise_caps(transport_file.as_deref()) {
                     Ok(c) => c,
                     Err(e) => {
                         return ActivationOutcome::Failed {
@@ -952,6 +954,45 @@ fn derive_advertise_caps(
     Ok(Some(caps))
 }
 
+/// True when the MXL receiver inner chain should omit `capssetter` and
+/// use bare `mxlsrc` so runtime caps come from the filesystem flow.
+/// Reads the wide caps tag from the effective configuring transport file
+/// (post-splice at NULL→READY, or the daemon activation file).
+fn mxl_receiver_skips_capssetter(transport_file: Option<&str>) -> bool {
+    transport_file
+        .filter(|s| !s.is_empty())
+        .and_then(|text| {
+            crate::flow_def::transport_file_indicates_wide_caps(text)
+                .map_err(|e| {
+                    gst::warning!(
+                        CAT,
+                        "nmossrc: could not read wide caps tag from transport file \
+                         for inner-chain decision: {e:#}",
+                    );
+                })
+                .ok()
+        })
+        .unwrap_or(false)
+}
+
+/// MXL receiver inner-chain caps advertisement. When the effective
+/// transport file indicates wide Receiver Caps, omit `capssetter` so
+/// runtime caps come from the filesystem flow via `mxlsrc`; otherwise
+/// pin configuring essence caps from the same file.
+fn mxl_receiver_advertise_caps(
+    transport_file: Option<&str>,
+) -> Result<Option<gst::Caps>, anyhow::Error> {
+    if mxl_receiver_skips_capssetter(transport_file) {
+        gst::debug!(
+            CAT,
+            "nmossrc: wide MXL receiver — bare mxlsrc (no capssetter); \
+             runtime caps from MXL flow on disk",
+        );
+        return Ok(None);
+    }
+    derive_advertise_caps(transport_file)
+}
+
 /// Best-available caps for the bin's fake chain, resolved from
 /// current `Settings` in priority order:
 ///   1. `caps` property (user-supplied; authoritative).
@@ -1084,6 +1125,68 @@ mod tests {
         };
         let cs: CommonSettings = s.into();
         assert_eq!(cs.transport_caps.as_ref(), Some(&caps));
+    }
+
+    #[test]
+    fn mxl_wide_receiver_skips_capssetter_advertise_caps() {
+        use crate::flow_def::{FlowDefOverrides, splice_overrides};
+        use crate::types::CapsMode;
+        let _ = gst::init();
+        let narrow_file = r#"{
+            "format":"urn:x-nmos:format:video",
+            "media_type":"video/v210",
+            "grain_rate":{"numerator":25,"denominator":1},
+            "frame_width":1920,
+            "frame_height":1080
+        }"#;
+        let wide_file = r#"{
+            "format":"urn:x-nmos:format:video",
+            "media_type":"video/v210",
+            "grain_rate":{"numerator":25,"denominator":1},
+            "frame_width":1920,
+            "frame_height":1080,
+            "tags":{"urn:x-nvnmos:tag:caps":[""]}
+        }"#;
+        let spliced_wide = splice_overrides(
+            narrow_file,
+            &FlowDefOverrides {
+                caps_mode: CapsMode::Wide,
+                ..FlowDefOverrides::default()
+            },
+        )
+        .expect("wide splice");
+        assert!(
+            mxl_receiver_advertise_caps(Some(&spliced_wide))
+                .unwrap()
+                .is_none(),
+            "post-splice wide transport file must skip capssetter",
+        );
+        assert!(
+            mxl_receiver_advertise_caps(Some(wide_file))
+                .unwrap()
+                .is_none(),
+            "activation/configuring file with wide caps tag must skip capssetter",
+        );
+        assert!(
+            mxl_receiver_advertise_caps(Some(narrow_file))
+                .unwrap()
+                .is_some(),
+            "narrow transport file still uses capssetter",
+        );
+        let spliced_narrow = splice_overrides(
+            wide_file,
+            &FlowDefOverrides {
+                caps_mode: CapsMode::Narrow,
+                ..FlowDefOverrides::default()
+            },
+        )
+        .expect("narrow splice");
+        assert!(
+            mxl_receiver_advertise_caps(Some(&spliced_narrow))
+                .unwrap()
+                .is_some(),
+            "post-splice narrow transport file must use capssetter",
+        );
     }
 
 }

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -388,6 +388,23 @@ pub(crate) struct SdpSession<'a> {
     pub advertise_caps: bool,
 }
 
+/// Whether an SDP transport file advertises wide Receiver Caps via
+/// media-level `a=x-nvnmos-caps:` (libnvnmos adds this on IS-05
+/// activation for wide receivers; configuring SDPs may carry it when
+/// `receiver-caps-mode=wide` splices it in at registration).
+///
+/// Both `a=x-nvnmos-caps` (flag form) and `a=x-nvnmos-caps:<pt>`
+/// (property form) signal wide to libnvnmos. Unparseable input is
+/// treated as narrow.
+pub(crate) fn indicates_wide_receiver_caps(text: &str) -> bool {
+    let Ok(msg) = SDPMessage::parse_buffer(text.as_bytes()) else {
+        return false;
+    };
+    msg.media(0)
+        .and_then(|m| m.attribute_val("x-nvnmos-caps").map(|_| ()))
+        .is_some()
+}
+
 /// Parse an SDP transport file into a [`UdpMedia`].
 ///
 /// Single-media SDPs only today; multi-media SDPs (ST 2022-7
@@ -920,7 +937,8 @@ pub(crate) use crate::sdp_passthrough::passthrough_with_overrides;
 /// so the error message is specific.
 ///
 /// [`EssenceCrossCheckMode::FormatFamilyOnly`] is used on UDP
-/// receiver activation when `receiver-caps-mode=wide`: the
+/// receiver activation when the activation SDP carries
+/// `a=x-nvnmos-caps:` (wide Receiver Caps per libnvnmos): the
 /// element's `caps` are an IS-04 configuring hint, not a
 /// constraint on the activation SDP's essence shape or RTP
 /// layer.
@@ -2015,6 +2033,23 @@ mod tests {
 
     fn init_gst() {
         let _ = gst::init();
+    }
+
+    #[test]
+    fn indicates_wide_receiver_caps_matches_attribute_presence() {
+        const NARROW: &str = concat!(
+            "v=0\r\no=- 1 0 IN IP4 127.0.0.1\r\ns=x\r\nt=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\nc=IN IP4 239.0.0.1/64\r\n",
+            "a=rtpmap:96 raw/90000\r\n",
+        );
+        const WIDE: &str = concat!(
+            "v=0\r\no=- 1 0 IN IP4 127.0.0.1\r\ns=x\r\nt=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\nc=IN IP4 239.0.0.1/64\r\n",
+            "a=rtpmap:96 raw/90000\r\na=x-nvnmos-caps:96\r\n",
+        );
+        assert!(!indicates_wide_receiver_caps(NARROW));
+        assert!(indicates_wide_receiver_caps(WIDE));
+        assert!(!indicates_wide_receiver_caps("not sdp"));
     }
 
     // `defaults` regression guards: every constant pins a
@@ -3462,19 +3497,6 @@ mod tests {
         "a=x-nvnmos-caps:96\r\n",
     );
 
-    /// Round-trip check: does the serialised SDP carry an
-    /// `a=x-nvnmos-caps` attribute at media level? Uses
-    /// `SDPMedia::attribute_val` so it works with both
-    /// `a=x-nvnmos-caps` (flag form) and `a=x-nvnmos-caps:`
-    /// (property form with empty value) — both parse to
-    /// `Some("")` and both signal wide to libnvnmos.
-    fn has_x_nvnmos_caps(sdp: &str) -> bool {
-        let msg = SDPMessage::parse_buffer(sdp.as_bytes()).expect("parse");
-        msg.media(0)
-            .and_then(|m| m.attribute_val("x-nvnmos-caps").map(|_| ()))
-            .is_some()
-    }
-
     // `caps_mode` is the SDP-side override slot mirroring
     // `flow_def::FlowDefOverrides::caps_mode`. Each test pins
     // one (input-state, CapsMode) cell of the 2×3 matrix:
@@ -3495,7 +3517,7 @@ mod tests {
         session.advertise_caps = true;
         let text = build_sdp(&media, session).expect("build");
         assert!(
-            has_x_nvnmos_caps(&text),
+            indicates_wide_receiver_caps(&text),
             "advertise_caps=true must emit media-level `a=x-nvnmos-caps`: {text}",
         );
         // Canonical wire form per `nvnmos_impl.cpp:1727-1731`:
@@ -3523,7 +3545,7 @@ mod tests {
         let media = parse_sdp(VIDEO_YCBCR_422_10BIT_1080P50_SDP).expect("parse");
         let text = build_sdp(&media, test_session()).expect("build");
         assert!(
-            !has_x_nvnmos_caps(&text),
+            !indicates_wide_receiver_caps(&text),
             "advertise_caps=false (test_session default) must omit `a=x-nvnmos-caps`: {text}",
         );
     }
@@ -3537,7 +3559,7 @@ mod tests {
         )
         .expect("splice");
         assert!(
-            !has_x_nvnmos_caps(&spliced),
+            !indicates_wide_receiver_caps(&spliced),
             "input had no a=x-nvnmos-caps; Auto must leave it absent: {spliced}",
         );
     }
@@ -3551,7 +3573,7 @@ mod tests {
         )
         .expect("splice");
         assert!(
-            has_x_nvnmos_caps(&spliced),
+            indicates_wide_receiver_caps(&spliced),
             "input had a=x-nvnmos-caps; Auto must preserve it: {spliced}",
         );
     }
@@ -3565,7 +3587,7 @@ mod tests {
         )
         .expect("splice");
         assert!(
-            !has_x_nvnmos_caps(&spliced),
+            !indicates_wide_receiver_caps(&spliced),
             "Narrow must strip a=x-nvnmos-caps from a wide input: {spliced}",
         );
     }
@@ -3579,7 +3601,7 @@ mod tests {
         )
         .expect("splice");
         assert!(
-            !has_x_nvnmos_caps(&spliced),
+            !indicates_wide_receiver_caps(&spliced),
             "Narrow on an already-narrow input must remain narrow: {spliced}",
         );
     }
@@ -3593,7 +3615,7 @@ mod tests {
         )
         .expect("splice");
         assert!(
-            has_x_nvnmos_caps(&spliced),
+            indicates_wide_receiver_caps(&spliced),
             "Wide must add a=x-nvnmos-caps to a narrow input: {spliced}",
         );
         // Canonical form: pt of the (single) media. Fixture pt
@@ -3612,7 +3634,7 @@ mod tests {
             &SdpOverrides { caps_mode: CapsMode::Wide, ..Default::default() },
         )
         .expect("splice");
-        assert!(has_x_nvnmos_caps(&spliced));
+        assert!(indicates_wide_receiver_caps(&spliced));
         // Re-emission collapses to the canonical `<pt>` form
         // regardless of the input value (libnvnmos's parser is
         // presence-only; we don't try to preserve constraint

--- a/rust/gst-nmos-rs/src/session.rs
+++ b/rust/gst-nmos-rs/src/session.rs
@@ -439,9 +439,11 @@ pub(crate) enum TransportConfig {
     },
     /// OSS UDP/RTP transport. The inner chain is
     /// `rtp*pay ! udpsink` for senders and
-    /// `udpsrc ! capsfilter(rtp_caps) ! rtp*depay ! capsfilter(raw_caps)?`
-    /// for receivers. The exact element factory names dispatch on
-    /// [`UdpVariant`].
+    /// `udpsrc ! rtp*depay [! capssetter(raw_caps)]` for receivers.
+    /// Wide receivers (activation SDP carries `a=x-nvnmos-caps:`)
+    /// omit `capssetter`; narrow receivers pin configuring essence
+    /// caps parsed from the transport file. The exact element factory
+    /// names dispatch on [`UdpVariant`].
     ///
     /// Constructed at runtime by `resolve_inner_config_udp` (in
     /// `validate_and_open`) and `decide_inner_config_udp` (in
@@ -1130,14 +1132,16 @@ fn decide_inner_config_udp(
 }
 
 /// Cross-check strictness for [`decide_inner_config_udp`]: wide
-/// receivers relax essence shape on activation only.
+/// receivers (activation SDP carries `a=x-nvnmos-caps:`) relax
+/// essence shape on activation only.
 fn udp_essence_cross_check_mode(
     settings: &CommonSettings,
     activation: bool,
+    transport_file: Option<&str>,
 ) -> sdp::EssenceCrossCheckMode {
     if activation
         && settings.side == Side::Receiver
-        && settings.caps_mode == CapsMode::Wide
+        && transport_file.is_some_and(sdp::indicates_wide_receiver_caps)
     {
         sdp::EssenceCrossCheckMode::FormatFamilyOnly
     } else {
@@ -1637,7 +1641,7 @@ pub(crate) fn make_activation_plan(
             settings,
             UdpVariant::V1,
             Some(transport_file),
-            udp_essence_cross_check_mode(settings, true),
+            udp_essence_cross_check_mode(settings, true, Some(transport_file)),
         ) {
             Ok(inner) => inner,
             Err(e) => {
@@ -1656,7 +1660,7 @@ pub(crate) fn make_activation_plan(
             settings,
             UdpVariant::V2,
             Some(transport_file),
-            udp_essence_cross_check_mode(settings, true),
+            udp_essence_cross_check_mode(settings, true, Some(transport_file)),
         ) {
             Ok(inner) => inner,
             Err(e) => {
@@ -2759,10 +2763,56 @@ mod tests {
         }
 
         /// Wide receiver activation: stereo `caps` must not
-        /// block mono activation SDP (essence shape is not
-        /// cross-checked; format family still matches).
+        /// block mono activation SDP when the SDP carries
+        /// `a=x-nvnmos-caps:` (essence shape is not cross-checked;
+        /// format family still matches).
         #[test]
         fn activation_udp_wide_receiver_skips_essence_shape_cross_check() {
+            const AUDIO_MONO_ACTIVATION_SDP: &str = concat!(
+                "v=0\r\n",
+                "o=- 1 0 IN IP4 192.0.2.10\r\n",
+                "s=Example\r\n",
+                "t=0 0\r\n",
+                "m=audio 5004 RTP/AVP 97\r\n",
+                "c=IN IP4 239.2.2.2/64\r\n",
+                "a=rtpmap:97 L24/48000\r\n",
+                "a=x-nvnmos-caps:97\r\n",
+            );
+            let s = CommonSettings {
+                caps: Some(
+                    gst::Caps::builder("audio/x-raw")
+                        .field("channels", 2i32)
+                        .build(),
+                ),
+                ..udp_settings(Side::Receiver, Transport::Udp)
+            };
+            let plan = make_activation_plan(
+                &cat(),
+                "nmossrc",
+                &s,
+                &req(Side::Receiver, Some(AUDIO_MONO_ACTIVATION_SDP)),
+            );
+            match plan.inner {
+                InnerConfig::Real(TransportConfig::Udp { media, .. }) => {
+                    assert_eq!(
+                        media
+                            .raw_caps
+                            .structure(0)
+                            .and_then(|s| s.get::<i32>("channels").ok()),
+                        Some(1),
+                        "activation SDP is authoritative for channel count",
+                    );
+                }
+                other => panic!("expected Real(Udp) inner on wide activation; got {other:?}"),
+            }
+            assert!(matches!(plan.ack, ActivationAck::Success));
+        }
+
+        /// `receiver-caps-mode=wide` alone does not relax activation
+        /// cross-check — the activation SDP must carry
+        /// `a=x-nvnmos-caps:` (libnvnmos adds it for wide receivers).
+        #[test]
+        fn activation_udp_property_wide_without_sdp_marker_still_cross_checks() {
             const AUDIO_MONO_ACTIVATION_SDP: &str = concat!(
                 "v=0\r\n",
                 "o=- 1 0 IN IP4 192.0.2.10\r\n",
@@ -2787,20 +2837,14 @@ mod tests {
                 &s,
                 &req(Side::Receiver, Some(AUDIO_MONO_ACTIVATION_SDP)),
             );
-            match plan.inner {
-                InnerConfig::Real(TransportConfig::Udp { media, .. }) => {
-                    assert_eq!(
-                        media
-                            .raw_caps
-                            .structure(0)
-                            .and_then(|s| s.get::<i32>("channels").ok()),
-                        Some(1),
-                        "activation SDP is authoritative for channel count",
-                    );
-                }
-                other => panic!("expected Real(Udp) inner on wide activation; got {other:?}"),
+            assert!(matches!(plan.inner, InnerConfig::Fake { .. }));
+            match plan.ack {
+                ActivationAck::Failure { reason } => assert!(
+                    reason.contains("cross-checking SDP"),
+                    "expected essence cross-check failure; got: {reason}",
+                ),
+                other => panic!("expected Failure ack; got {other:?}"),
             }
-            assert!(matches!(plan.ack, ActivationAck::Success));
         }
 
         /// Activation SDP cross-check fires too: a video

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -91,7 +91,7 @@ namespace nvnmos
 
         // like nmos::make_session_description for 'internal' use
         // with support for the custom SDP attributes in nvnmos::attributes for senders as well as receivers
-        web::json::value make_session_description(const nmos::type& type, const utility::string_t& name, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params);
+        web::json::value make_session_description(const nmos::type& type, const utility::string_t& name, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params, bool caps);
 
         // like nmos::get_session_description_sdp_parameters
         // with support for multiple ts-refclk attributes in each media description
@@ -112,6 +112,9 @@ namespace nvnmos
 
         // get the optional capabilities from the custom attribute
         bool has_session_description_caps(const web::json::value& session_description);
+
+        // whether the IS-04 receiver has no BCP-004-01 constraint_sets (wide caps)
+        bool has_no_receiver_caps(const web::json::value& receiver);
 
         // get the format bit rate from the custom attribute if present or calculate an approximate value
         uint64_t get_format_bit_rate(const nmos::sdp_parameters& sdp_params);
@@ -1311,7 +1314,8 @@ namespace nvnmos
 
                     const auto group_hint = impl::get_group_hint(resource);
                     const auto& session_info = nmos::fields::description(resource.data);
-                    const auto merged_sdp = impl::make_session_description(id_type.second, name, group_hint, session_info, sdp_params, transport_params);
+                    const auto caps = nmos::types::receiver == id_type.second && impl::has_no_receiver_caps(resource.data);
+                    auto merged_sdp = impl::make_session_description(id_type.second, name, group_hint, session_info, sdp_params, transport_params, caps);
                     const auto sdp_data = sdp::make_session_description(merged_sdp);
 
                     connection_activated(id_type.second, utility::us2s(name), sdp_data);
@@ -1536,7 +1540,7 @@ namespace nvnmos
     {
         // like nmos::make_session_description for 'internal' use
         // with support for the custom SDP attributes in nvnmos::attributes for senders as well as receivers
-        web::json::value make_session_description(const nmos::type& type, const utility::string_t& name, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params)
+        web::json::value make_session_description(const nmos::type& type, const utility::string_t& name, const utility::string_t& group_hint, const utility::string_t& session_info, const nmos::sdp_parameters& sdp_params, const web::json::value& transport_params, bool caps)
         {
             using web::json::value;
 
@@ -1562,7 +1566,14 @@ namespace nvnmos
                 auto& media_description = media_descriptions.at(leg);
                 auto& media_attributes = media_description.at(sdp::fields::attributes);
 
-                if (nmos::types::sender == type)
+                if (nmos::types::receiver == type)
+                {
+                    if (caps)
+                    {
+                        web::json::push_back(media_attributes, sdp::named_value(nvnmos::attributes::caps, utility::ostringstreamed(sdp_params.rtpmap.payload_type)));
+                    }
+                }
+                else // if (nmos::types::sender == type)
                 {
                     const auto& source_port = nmos::fields::source_port(transport_param);
                     if (source_port.is_integer())
@@ -1773,6 +1784,12 @@ namespace nvnmos
                 auto caps = sdp::find_name(ma, nvnmos::attributes::caps);
                 return ma.end() != caps;
             }
+        }
+
+        // whether the IS-04 receiver has no BCP-004-01 constraint_sets (wide caps)
+        bool has_no_receiver_caps(const web::json::value& receiver)
+        {
+            return !nmos::fields::constraint_sets(nmos::fields::caps(receiver)).is_array();
         }
 
         // approximate IP/UDP/RTP overhead


### PR DESCRIPTION
Follow-up to wide receiver caps mode: align **runtime** behaviour across MXL and UDP so wide/narrow is read from the **effective transport file**, not `receiver-caps-mode` at activation.

- **libnvnmos:** On IS-05 receiver activation, emit `a=x-nvnmos-caps:<pt>` when the IS-04 receiver has no `constraint_sets` (wide); narrow receivers omit it. No merge from configuring SDP.
- **gst-nmos-rs (MXL):** Wide receivers ( `urn:x-nvnmos:tag:caps` in flow_def) skip inner `capssetter`; runtime caps come from the filesystem flow.
- **gst-nmos-rs (UDP):** Wide receivers (`a=x-nvnmos-caps:` in SDP) skip `capssetter`, relax activation essence cross-check, and use shared `flow_def::indicates_wide_receiver_caps` / `sdp::indicates_wide_receiver_caps` helpers. `receiver-caps-mode` still only affects registration-time splice.
