### PR TITLE
gst-nmos-rs: fix live reroute swaps and harden three-node demo

### DIFF
--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -79,6 +79,11 @@ set -u
 # the helper functions are in place.
 DEMO_TRANSPORT=${DEMO_TRANSPORT:-mxl}
 
+# Short queues on live paths (nmossrc → processing → nmossink / sinks).
+# Video: buffer count (2 frames @ 59.94 ≈ 33 ms); buffers=1 caused visible skips.
+DEMO_VIDEO_QUEUE_MAX_BUFFERS=${DEMO_VIDEO_QUEUE_MAX_BUFFERS:-2}
+# Audio: time limit — mxlsrc emits ~48 samples/buffer (1 ms @ 48 kHz).
+DEMO_AUDIO_QUEUE_MAX_TIME_MS=${DEMO_AUDIO_QUEUE_MAX_TIME_MS:-50}
 # Local NIC IP used by the UDP path: drives the receiver's
 # `interface-ip` (the IGMP-join interface, resolved to an iface name
 # for `udpsrc.multicast-iface`) and the sender's `source-ip`
@@ -128,7 +133,7 @@ MXL_REPO=${MXL_REPO:-$REPO/../mxl}
 
 # `libnvnmos.so` (consumed by nvnmosd) and the gst-mxl-rs plugin +
 # libmxl.so runtime (consumed by the inner mxlsink/mxlsrc swaps).
-LIB=${NVNMOS_LIB_DIR:-$REPO/build-mxl}
+LIB=${NVNMOS_LIB_DIR:-$REPO/build}
 MXL_PLUGIN_DIR=${MXL_PLUGIN_DIR:-$MXL_REPO/rust/target/debug}
 MXL_RT_LIB_DIR=${MXL_RT_LIB_DIR:-$MXL_REPO/build/Linux-Clang-Debug/lib}
 
@@ -138,6 +143,19 @@ LOG_DIR=$(mktemp -d -t gst-nmos-rs-demo-XXXXXX)
 source "$_SCRIPT_DIR/pipeline-dots.sh"
 PIPELINE_DOT_ROOT="$LOG_DIR/pipeline-dots"
 DAEMON_LOG="$LOG_DIR/daemon.log"
+
+# Line-buffer stdout/stderr when redirected to log files so GST_DEBUG and
+# daemon traces appear promptly in tail -f (default block buffering hides them).
+# Must `exec` the target so background launches record the real process in $!
+# (a non-exec function wrapper leaves gst-launch as an orphan when cleanup
+# kills only the subshell pid).
+_demo_line_buffered() {
+    if command -v stdbuf >/dev/null 2>&1; then
+        exec stdbuf -oL -eL "$@"
+    else
+        exec "$@"
+    fi
+}
 
 # Shared MXL Domain (tmpfs-backed). All three Nodes operate inside
 # it. Only used when DEMO_TRANSPORT=mxl; the bootstrap block below
@@ -304,6 +322,18 @@ udp_video_buffer_props() {
 #   MXL:          `flow=11111111-aaaa-1111-aaaa-111111111111`
 #   UDP sender:   `dest=232.99.99.1:5004`
 #   UDP receiver: `join=232.99.99.1:5004`
+# GstQueue after each nmossrc: video by frame count, audio by duration (mxlsrc ~1 ms/buffer).
+_demo_video_queue() {
+    local name=$1
+    echo queue name="$name" "max-size-buffers=$DEMO_VIDEO_QUEUE_MAX_BUFFERS" max-size-bytes=0 max-size-time=0
+}
+
+_demo_audio_queue() {
+    local name=$1
+    local max_time_ns=$(( DEMO_AUDIO_QUEUE_MAX_TIME_MS * 1000000 ))
+    echo queue name="$name" max-size-time="$max_time_ns" max-size-buffers=0 max-size-bytes=0
+}
+
 transport_identity_from_active() {
     local side=$1 body=$2
     case "$DEMO_TRANSPORT" in
@@ -370,6 +400,7 @@ IS05_VERSION=v1.2
 
 echo "Logs: $LOG_DIR"
 echo "Transport: $DEMO_TRANSPORT"
+echo "Queues after each nmossrc: video max-size-buffers=$DEMO_VIDEO_QUEUE_MAX_BUFFERS; audio max-size-time=${DEMO_AUDIO_QUEUE_MAX_TIME_MS}ms (Node 2 consumer + Node 3 processor)"
 
 # Re-create the MXL Domain directory. Only needed when
 # DEMO_TRANSPORT=mxl: the UDP / UDP2 transports go straight from
@@ -400,7 +431,7 @@ rm -f "$SOCK"
 echo "[daemon] starting nvnmosd on $SOCK"
 RUST_LOG=${RUST_LOG:-info} \
 LD_LIBRARY_PATH="$LIB:${LD_LIBRARY_PATH:-}" \
-    "$DAEMON_BIN" --uds "$SOCK" > "$DAEMON_LOG" 2>&1 &
+    _demo_line_buffered "$DAEMON_BIN" --uds "$SOCK" > "$DAEMON_LOG" 2>&1 &
 declare -i DAEMON_PID=$!
 
 # Per-pipeline PID globals. Each launcher (`launch_node1` etc) writes
@@ -423,23 +454,20 @@ cleanup() {
     _cleanup_done=1
     echo
     echo "[cleanup] stopping pipelines and daemon..."
-    # SIGTERM first — `gst-launch -e` responds with graceful EOS,
-    # `nvnmosd` tears its listeners down cleanly. If anyone is
-    # wedged (e.g. a pipeline stuck flushing EOS through an idle
-    # placeholder, or a daemon still serving an in-flight RPC) the
-    # SIGKILL after a short grace period guarantees Ctrl+C reliably
-    # exits the script instead of leaving the user with no choice
-    # but Ctrl+Z (which in turn leaks daemon zombies parented to
-    # the stopped script).
-    local -a pids=()
+    # gst-launch: SIGINT (`-e` EOS handler), same as menu teardown. nvnmosd:
+    # SIGTERM. SIGKILL after a short grace if anything is wedged.
     local p
-    for p in "$DAEMON_PID" "$NODE1_PID" "$NODE2_PID" \
-             "$NODE3_VIDEO_PID" "$NODE3_AUDIO_PID" "$BARE_PREVIEW_PID"; do
-        (( p > 0 )) && pids+=("$p")
+    for p in "$NODE1_PID" "$NODE2_PID" "$NODE3_VIDEO_PID" \
+             "$NODE3_AUDIO_PID" "$BARE_PREVIEW_PID"; do
+        (( p > 0 )) && kill -INT "$p" 2>/dev/null || true
     done
-    for p in "${pids[@]}"; do kill -TERM "$p" 2>/dev/null || true; done
+    (( DAEMON_PID > 0 )) && kill -TERM "$DAEMON_PID" 2>/dev/null || true
     sleep 2
-    for p in "${pids[@]}"; do kill -KILL "$p" 2>/dev/null || true; done
+    for p in "$NODE1_PID" "$NODE2_PID" "$NODE3_VIDEO_PID" \
+             "$NODE3_AUDIO_PID" "$BARE_PREVIEW_PID"; do
+        (( p > 0 )) && kill -KILL "$p" 2>/dev/null || true
+    done
+    (( DAEMON_PID > 0 )) && kill -KILL "$DAEMON_PID" 2>/dev/null || true
     wait 2>/dev/null
     rm -f "$SOCK"
     echo "[cleanup] logs retained at $LOG_DIR"
@@ -579,7 +607,7 @@ launch_node1() {
     _rotate_log "$LOG_DIR/node1-producer.log"
     pipeline_dots_prepare_launch node1
     GST_DEBUG=${GST_DEBUG:-nmossink:3} \
-        gst-launch-1.0 -e \
+        _demo_line_buffered gst-launch-1.0 -e \
             videotestsrc pattern=smpte horizontal-speed=2 is-live=true ! \
                 $VIDEO_CAPS ! \
                 nmossink \
@@ -629,11 +657,11 @@ launch_node3_video() {
         echo "[node3-video] already running (pid $NODE3_VIDEO_PID)"
         return 1
     fi
-    echo "[node3-video] starting video processor (nmossrc -> videoflip horizontal -> nmossink)"
+    echo "[node3-video] starting video processor (nmossrc -> queue(${DEMO_VIDEO_QUEUE_MAX_BUFFERS} buffers) -> videoflip -> nmossink)"
     _rotate_log "$LOG_DIR/node3-video.log"
     pipeline_dots_prepare_launch node3-video
     GST_DEBUG=${GST_DEBUG:-nmossrc:3,nmossink:3} \
-        gst-launch-1.0 -e \
+        _demo_line_buffered gst-launch-1.0 -e \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
                 transport="$DEMO_TRANSPORT" \
@@ -645,6 +673,7 @@ launch_node3_video() {
                 caps="$VIDEO_CAPS" \
                 label="Node 3 / video-in" \
                 auto-activate=false ! \
+            $(_demo_video_queue n3-v-in) ! \
             videoconvert ! videoflip method=horizontal-flip ! videoconvert ! \
                 nmossink \
                     daemon-uri="unix:$SOCK" \
@@ -666,11 +695,11 @@ launch_node3_audio() {
         echo "[node3-audio] already running (pid $NODE3_AUDIO_PID)"
         return 1
     fi
-    echo "[node3-audio] starting audio processor (nmossrc -> volume 0.3 -> nmossink)"
+    echo "[node3-audio] starting audio processor (nmossrc -> queue(${DEMO_AUDIO_QUEUE_MAX_TIME_MS}ms) -> volume -> nmossink)"
     _rotate_log "$LOG_DIR/node3-audio.log"
     pipeline_dots_prepare_launch node3-audio
     GST_DEBUG=${GST_DEBUG:-nmossrc:3,nmossink:3} \
-        gst-launch-1.0 -e \
+        _demo_line_buffered gst-launch-1.0 -e \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
                 transport="$DEMO_TRANSPORT" \
@@ -681,6 +710,7 @@ launch_node3_audio() {
                 caps="$AUDIO_CAPS" \
                 label="Node 3 / audio-in" \
                 auto-activate=false ! \
+            $(_demo_audio_queue n3-a-in) ! \
             audioconvert ! volume volume=0.3 ! audioconvert ! \
                 nmossink \
                     daemon-uri="unix:$SOCK" \
@@ -710,11 +740,11 @@ launch_node2() {
         echo "[node2] already running (pid $NODE2_PID)"
         return 1
     fi
-    echo "[node2] starting consumer pipeline (2 nmossrcs -> $AUDIO_SINK / $VIDEO_SINK)"
+    echo "[node2] starting consumer pipeline (nmossrc --> queue(${DEMO_VIDEO_QUEUE_MAX_BUFFERS} buffers) --> ${VIDEO_SINK}; nmossrc --> queue(${DEMO_AUDIO_QUEUE_MAX_TIME_MS}ms) --> ${AUDIO_SINK})"
     _rotate_log "$LOG_DIR/node2-consumer.log"
     pipeline_dots_prepare_launch node2
     GST_DEBUG=${GST_DEBUG:-nmossrc:3} \
-        gst-launch-1.0 -e \
+        _demo_line_buffered gst-launch-1.0 -e \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
                 transport="$DEMO_TRANSPORT" \
@@ -726,6 +756,7 @@ launch_node2() {
                 caps="$VIDEO_CAPS" \
                 label="Node 2 / video2" \
                 auto-activate=true ! \
+            $(_demo_video_queue n2-v-in) ! \
                 videoconvert ! "$VIDEO_SINK" sync=false \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
@@ -737,6 +768,7 @@ launch_node2() {
                 caps="$AUDIO_CAPS" \
                 label="Node 2 / audio2" \
                 auto-activate=true ! \
+            $(_demo_audio_queue n2-a-in) ! \
                 audioconvert ! "$AUDIO_SINK" sync=false \
         > "$LOG_DIR/node2-consumer.log" 2>&1 &
     NODE2_PID=$!
@@ -767,7 +799,7 @@ launch_bare_preview() {
     _rotate_log "$LOG_DIR/bare-preview.log"
     pipeline_dots_prepare_launch bare-preview
     GST_DEBUG=${GST_DEBUG:-mxlsrc:5,basesrc:4} \
-        gst-launch-1.0 -e \
+        _demo_line_buffered gst-launch-1.0 -e \
             mxlsrc \
                 domain="$MXL_DOMAIN_PATH" \
                 video-flow-id="$FLOW_VIDEO_NODE1" \
@@ -1413,7 +1445,7 @@ connect_receiver_to_sender() {
     resp_sender=$(jq -r '.sender_id // "null"' <<< "$active_body" 2>/dev/null)
     resp_identity=$(transport_identity_from_active receiver "$active_body")
     friendly=${SENDER_ID_TO_NAME[$resp_sender]:-$resp_sender}
-    echo "[ok] master_enable=$resp_enable sender=$friendly $resp_identity"
+    echo "[ok] master_enable=$resp_enable $resp_identity sender=$friendly"
 }
 
 # Compact dump of /active for every discovered resource.
@@ -1455,7 +1487,7 @@ show_state() {
         sender_id=$(jq -r '.sender_id // "null"' <<< "$body" 2>/dev/null)
         identity=$(transport_identity_from_active receiver "$body")
         friendly=${SENDER_ID_TO_NAME[$sender_id]:-$sender_id}
-        printf '    %-22s  master_enable=%-5s  sender=%-22s  %s\n' "$lbl" "$en" "$friendly" "$identity"
+        printf '    %-22s  master_enable=%-5s  %s  sender=%s\n' "$lbl" "$en" "$identity" "$friendly"
     done
 }
 
@@ -1599,7 +1631,7 @@ diag_snapshot() {
         sender_id=$(jq -r '.sender_id // "null"' <<< "$body" 2>/dev/null)
         identity=$(transport_identity_from_active receiver "$body")
         friendly=${SENDER_ID_TO_NAME[$sender_id]:-$sender_id}
-        printf '    %-22s  master_enable=%-5s  sender=%-22s  %s\n' "$lbl" "$en" "$friendly" "$identity"
+        printf '    %-22s  master_enable=%-5s  %s  sender=%s\n' "$lbl" "$en" "$identity" "$friendly"
     done
 
     # MXL flow filesystem layout (cf. lib/internal/include/mxl-internal/FlowManager.hpp):

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -85,6 +85,15 @@ const PROBE_WAIT: Duration = Duration::from_secs(2);
 /// failing) without dragging out a healthy activation.
 const STATE_WAIT: gst::ClockTime = gst::ClockTime::from_seconds(2);
 
+/// Options for [`rebuild_chain_with_opts`]. When `drain_downstream` is
+/// true, [`flush_external_of_ghost`] runs on an [`nmossrc`] src ghost
+/// before the anchor block probe (see callers). Used only for live
+/// PLAYING inner swaps, not initial NULL→READY activation.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct RebuildChainOpts {
+    pub drain_downstream: bool,
+}
+
 /// Swap the chain behind the bin's permanent anchor.
 ///
 /// This is the **only** mutator of the bin's child set after
@@ -118,12 +127,13 @@ const STATE_WAIT: gst::ClockTime = gst::ClockTime::from_seconds(2);
 /// bins. For wrapped sub-bins (e.g. the `mxlsrc ! capssetter` bin
 /// built by `build_mxlsrc` with `advertise_caps`) this is the
 /// ghosted outer pad name on the sub-bin, which is `"src"`.
-pub(crate) fn rebuild_chain(
+pub(crate) fn rebuild_chain_with_opts(
     cat: &gst::DebugCategory,
     bin: &gst::Bin,
     ghost: &gst::GhostPad,
     new_chain: &gst::Element,
     pad_name: &str,
+    opts: RebuildChainOpts,
 ) -> Result<(), anyhow::Error> {
     let anchor_outer_pad = ghost
         .target()
@@ -153,6 +163,10 @@ pub(crate) fn rebuild_chain(
         anyhow!("anchor `{ANCHOR_NAME}` missing `{probe_pad_name}` pad")
     })?;
 
+    if opts.drain_downstream {
+        flush_external_of_ghost(cat, ghost);
+    }
+
     let probe_id = block_and_wait(cat, &probe_pad)
         .context("blocking anchor pad before chain rebuild")?;
 
@@ -170,7 +184,18 @@ pub(crate) fn rebuild_chain(
     result
 }
 
-/// Inner half of [`rebuild_chain`] — runs with the anchor pad held
+/// [`rebuild_chain_with_opts`] with default options (no downstream drain).
+pub(crate) fn rebuild_chain(
+    cat: &gst::DebugCategory,
+    bin: &gst::Bin,
+    ghost: &gst::GhostPad,
+    new_chain: &gst::Element,
+    pad_name: &str,
+) -> Result<(), anyhow::Error> {
+    rebuild_chain_with_opts(cat, bin, ghost, new_chain, pad_name, RebuildChainOpts::default())
+}
+
+/// Inner half of [`rebuild_chain_with_opts`] — runs with the anchor pad held
 /// blocked. Factored out so we can `?`-propagate errors and still
 /// remove the probe unconditionally in the caller.
 fn swap_chain_inner(
@@ -246,21 +271,66 @@ fn swap_chain_inner(
             "new chain `{}` missing `{new_chain_pad_name}` pad",
             new_chain.name(),
         ))?;
-    match ghost.direction() {
-        gst::PadDirection::Sink => link_pad.link(&new_chain_pad),
-        gst::PadDirection::Src => new_chain_pad.link(&link_pad),
-        _ => unreachable!(),
+
+    // The anchor retains sticky events (e.g. CAPS) from the previous
+    // inner chain after unlink. Default pad-link caps/template checks
+    // then fail with "Pads do not have common format" even when the
+    // new chain would negotiate correctly. Link with empty checks;
+    // the identity anchor forwards stickies to the new chain.
+    if let Err(e) = link_pads_for_chain_swap(ghost, &link_pad, &new_chain_pad) {
+        let _ = new_chain.set_state(gst::State::Null);
+        let _ = bin.remove(new_chain);
+        return Err(anyhow!(
+            "linking anchor to new chain `{}`: {e}",
+            new_chain.name(),
+        ));
     }
-    .map_err(|e| anyhow!(
-        "linking anchor to new chain `{}`: {e}",
-        new_chain.name(),
-    ))?;
 
     new_chain
         .sync_state_with_parent()
         .with_context(|| format!("syncing state of `{}` with parent", new_chain.name()))?;
 
     wait_for_chain_state(cat, bin, new_chain)
+}
+
+/// Link the anchor to a new inner chain without caps/template checks
+/// so a prior inner's sticky caps on the anchor do not block the swap.
+fn link_pads_for_chain_swap(
+    ghost: &gst::GhostPad,
+    link_pad: &gst::Pad,
+    new_chain_pad: &gst::Pad,
+) -> Result<(), gst::PadLinkError> {
+    use gst::PadLinkCheck;
+    match ghost.direction() {
+        gst::PadDirection::Sink => {
+            link_pad.link_full(new_chain_pad, PadLinkCheck::empty())?;
+        }
+        gst::PadDirection::Src => {
+            new_chain_pad.link_full(link_pad, PadLinkCheck::empty())?;
+        }
+        _ => unreachable!(),
+    }
+    Ok(())
+}
+
+/// Optional pre-probe flush on the peer of an [`nmossrc`] src ghost when
+/// [`RebuildChainOpts::drain_downstream`] is set. May shorten how long
+/// the anchor stays blocked if something downstream still holds buffers.
+///
+/// Not used on [`nmossink`]: its ghost is a sink. Flushing upstream of a
+/// sender bin walks the whole processor (`nmossrc` included) and has
+/// been observed to wedge sender activation (HTTP PATCH timeout).
+fn flush_external_of_ghost(cat: &gst::DebugCategory, ghost: &gst::GhostPad) {
+    if ghost.direction() != gst::PadDirection::Src || ghost.peer().is_none() {
+        return;
+    }
+    gst::debug!(
+        cat,
+        "rebuild_chain: flushing downstream of ghost `{}` before anchor block",
+        ghost.name(),
+    );
+    let _ = ghost.send_event(gst::event::FlushStart::new());
+    let _ = ghost.send_event(gst::event::FlushStop::builder(true).build());
 }
 
 /// Install an `IDLE | BLOCK_DOWNSTREAM` probe on `pad` and wait for
@@ -410,8 +480,10 @@ fn parent_target_state(bin: &gst::Bin) -> gst::State {
 /// single-swap rebuild rather than inserting an intermediate fake
 /// hop.
 ///
-/// Used by `execute_activation_plan` to decide whether to go via a fake
-/// hop when swapping real → real: even though IS-05 requires every
+/// Used by `execute_activation_plan` to decide whether to go via a
+/// fake hop when swapping real → real (transport teardown; separate
+/// from anchor sticky-caps / pad-link policy in
+/// [`link_pads_for_chain_swap`]). Even though IS-05 requires every
 /// activation to rebuild the data path, doing real → new real in
 /// one step can race the transport's per-process state (libmxl, for
 /// instance: the old `FlowReader` may not be fully released before
@@ -2379,5 +2451,98 @@ mod tests {
             None,
             Some(&pay_props),
         );
+    }
+
+    /// Sticky caps on the anchor from the first inner chain must not block
+    /// linking a second chain with different advertised caps; default
+    /// pad-link checks fail, [`link_pads_for_chain_swap`] uses
+    /// [`gst::PadLinkCheck::empty`].
+    #[test]
+    fn link_pads_for_chain_swap_allows_mismatched_sticky_caps() {
+        init_gst();
+        if gst::ElementFactory::find("capssetter").is_none() {
+            return;
+        }
+        let narrow = gst::Caps::from_str(
+            "video/x-raw,format=v210,width=1920,height=1080,framerate=25/1",
+        )
+        .expect("narrow caps");
+        let other = gst::Caps::from_str(
+            "video/x-raw,format=UYVY,width=1920,height=1080,framerate=25/1",
+        )
+        .expect("other caps");
+
+        let anchor = gst::ElementFactory::make("identity")
+            .name("anchor")
+            .build()
+            .expect("identity");
+        let narrow_chain = gst::ElementFactory::make("capssetter")
+            .name("narrow")
+            .property("caps", &narrow)
+            .build()
+            .expect("narrow capssetter");
+        let wide_chain = gst::ElementFactory::make("capssetter")
+            .name("wide")
+            .property("caps", &other)
+            .build()
+            .expect("wide capssetter");
+
+        let bin = gst::Bin::new();
+        bin.add_many([&anchor, &narrow_chain, &wide_chain])
+            .expect("add elements");
+        anchor
+            .link(&narrow_chain)
+            .expect("link anchor to narrow chain");
+
+        bin.set_state(gst::State::Paused)
+            .expect("bin -> PAUSED");
+        let (_ret, state, _pending) = bin.state(gst::ClockTime::from_seconds(5));
+        assert_eq!(state, gst::State::Paused);
+
+        anchor.unlink(&narrow_chain);
+        // nmossrc topology: new_chain.src → anchor.sink (see `build_initial` / `rebuild_chain`).
+        let anchor_sink = anchor.static_pad("sink").expect("anchor sink");
+        let wide_src = wide_chain.static_pad("src").expect("wide src");
+
+        let ghost = gst::GhostPad::builder(gst::PadDirection::Src)
+            .name("src")
+            .build();
+        ghost
+            .set_target(Some(&anchor.static_pad("src").expect("anchor src")))
+            .expect("ghost target");
+        ghost.set_active(true).expect("ghost active");
+
+        assert!(
+            anchor_sink.link(&wide_src).is_err(),
+            "default pad-link check must reject mismatched sticky caps"
+        );
+        link_pads_for_chain_swap(&ghost, &anchor_sink, &wide_src).expect(
+            "empty pad-link check must allow swap despite sticky caps on anchor",
+        );
+
+        let _ = bin.set_state(gst::State::Null);
+    }
+
+    #[test]
+    fn flush_external_of_ghost_noop_without_downstream_peer() {
+        init_gst();
+        let cat = test_log_cat();
+        let nmos_bin = gst::Bin::with_name("test-nmossrc");
+        let initial = gst::ElementFactory::make("fakesrc")
+            .property("is-live", true)
+            .build()
+            .expect("fakesrc");
+        let ghost =
+            build_initial(&nmos_bin, initial, "src", gst::PadDirection::Src).expect("build_initial");
+        nmos_bin.add_pad(&ghost).expect("add ghost");
+        assert!(ghost.peer().is_none());
+
+        flush_external_of_ghost(cat, &ghost);
+        // No peer → no panic, no effect to assert beyond "returns".
+    }
+
+    #[test]
+    fn rebuild_chain_opts_drain_defaults_to_false() {
+        assert!(!RebuildChainOpts::default().drain_downstream);
     }
 }

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -620,7 +620,7 @@ impl NmosSrc {
                         }
                     }
                 };
-                self.swap_inner(bin, &new_inner)?;
+                self.swap_inner(bin, &new_inner, inner::RebuildChainOpts::default())?;
                 // Reaching the `Real` branch at NULL→READY implies
                 // `auto-activate=true` (the `validate_and_open` gate
                 // downgrades to a fake chain otherwise). Tell the
@@ -655,7 +655,7 @@ impl NmosSrc {
                 let caps = fake_caps_from_settings(&snapshot)?;
                 if let Some(caps) = caps {
                     let fake = inner::build_fake_src(Some(&caps))?;
-                    self.swap_inner(bin, &fake)?;
+                    self.swap_inner(bin, &fake, inner::RebuildChainOpts::default())?;
                 } else {
                     gst::warning!(
                         CAT,
@@ -681,7 +681,7 @@ impl NmosSrc {
         let caps = fake_caps_from_settings(&snapshot).ok().flatten();
         match inner::build_fake_src(caps.as_ref()) {
             Ok(fake) => {
-                if let Err(e) = self.swap_inner(bin_ref, &fake) {
+                if let Err(e) = self.swap_inner(bin_ref, &fake, inner::RebuildChainOpts::default()) {
                     gst::warning!(CAT, "restoring nmossrc fake chain: {e:#}");
                 }
             }
@@ -689,12 +689,17 @@ impl NmosSrc {
         }
     }
 
-    fn swap_inner(&self, bin: &gst::Bin, new_inner: &gst::Element) -> Result<(), anyhow::Error> {
+    fn swap_inner(
+        &self,
+        bin: &gst::Bin,
+        new_inner: &gst::Element,
+        opts: inner::RebuildChainOpts,
+    ) -> Result<(), anyhow::Error> {
         let ghost_guard = self.ghost.lock().unwrap();
         let ghost = ghost_guard
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("nmossrc ghost pad missing"))?;
-        inner::rebuild_chain(&CAT, bin, ghost, new_inner, "src")
+        inner::rebuild_chain_with_opts(&CAT, bin, ghost, new_inner, "src", opts)
     }
 
     /// True iff the bin's current inner chain is a real chain
@@ -773,9 +778,19 @@ impl NmosSrc {
     /// intermittently fails the new chain's start-up for reasons
     /// internal to the transport; the intermediate fake hop is one
     /// extra `rebuild_chain` cycle and reliably avoids the failure.
+    ///
+    /// `drain_downstream` is true only for real→real while PLAYING
+    /// so [`inner::rebuild_chain_with_opts`] may flush downstream of
+    /// the src ghost before blocking the anchor; NULL→READY
+    /// activation leaves it false.
     fn execute_activation_plan(&self, plan: &ActivationPlan) -> ActivationOutcome {
         let bin = self.obj();
         let bin_ref: &gst::Bin = bin.upcast_ref();
+        let drain_downstream = self.current_chain_is_real()
+            && bin_ref.current_state() == gst::State::Playing;
+        let reroute_opts = inner::RebuildChainOpts {
+            drain_downstream,
+        };
 
         if matches!(plan.inner, InnerConfig::Real(_))
             && self.current_chain_is_real()
@@ -786,10 +801,10 @@ impl NmosSrc {
                  to fully release the old transport state before re-attaching",
             );
             let snapshot = self.settings.lock().unwrap().clone();
-            let caps = fake_caps_from_settings(&snapshot).ok().flatten();
+            let caps = intermediate_fake_src_caps(plan, &snapshot).ok().flatten();
             match inner::build_fake_src(caps.as_ref()) {
                 Ok(p) => {
-                    if let Err(e) = self.swap_inner(bin_ref, &p) {
+                    if let Err(e) = self.swap_inner(bin_ref, &p, reroute_opts) {
                         gst::warning!(
                             CAT,
                             "nmossrc intermediate fake-chain swap failed: {e:#}",
@@ -888,7 +903,7 @@ impl NmosSrc {
                 }
             }
         };
-        if let Err(e) = self.swap_inner(bin_ref, &new_inner) {
+        if let Err(e) = self.swap_inner(bin_ref, &new_inner, reroute_opts) {
             // Loud-log the swap failure so the cause shows up in
             // the consumer log, not just stuffed into the daemon's
             // (currently-discarded) `AckActivation` reason.
@@ -904,7 +919,7 @@ impl NmosSrc {
             let snapshot = self.settings.lock().unwrap().clone();
             let fallback_caps = fake_caps_from_settings(&snapshot).ok().flatten();
             if let Ok(p) = inner::build_fake_src(fallback_caps.as_ref()) {
-                if let Err(e2) = self.swap_inner(bin_ref, &p) {
+                if let Err(e2) = self.swap_inner(bin_ref, &p, inner::RebuildChainOpts::default()) {
                     gst::warning!(
                         CAT,
                         "nmossrc fake-chain restore also failed: {e2:#}",
@@ -955,6 +970,38 @@ fn derive_advertise_caps(
     })?;
     gst::info!(CAT, "nmossrc: advertising caps `{caps}` from transport file");
     Ok(Some(caps))
+}
+
+/// Caps for the intermediate fake `appsrc` on real→real activations.
+///
+/// For [`InnerConfig::Real`] plans, use the incoming activation transport
+/// file the same way as the real inner chain (wide receivers skip
+/// `capssetter`; narrow ones advertise caps from the file). Otherwise
+/// fall back to [`fake_caps_from_settings`].
+///
+/// Keeps the fake hop aligned with activation transport policy when
+/// inner-chain shape differs from the element `caps` property. Sticky
+/// caps on the anchor during the final swap are handled separately in
+/// [`inner::link_pads_for_chain_swap`].
+fn intermediate_fake_src_caps(
+    plan: &ActivationPlan,
+    snapshot: &Settings,
+) -> Result<Option<gst::Caps>, anyhow::Error> {
+    match &plan.inner {
+        InnerConfig::Real(TransportConfig::Mxl { transport_file, .. }) => {
+            if mxl_receiver_skips_capssetter(transport_file.as_deref()) {
+                Ok(None)
+            } else {
+                mxl_receiver_advertise_caps(transport_file.as_deref())
+            }
+        }
+        InnerConfig::Real(TransportConfig::Udp {
+            transport_file,
+            media,
+            ..
+        }) => Ok(udp_receiver_advertise_caps(transport_file.as_deref(), media)),
+        _ => fake_caps_from_settings(snapshot),
+    }
 }
 
 /// True when the MXL receiver inner chain should omit `capssetter` and
@@ -1095,7 +1142,10 @@ impl From<Settings> for crate::session::CommonSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::CommonSettings;
+    use crate::session::{
+        ActivationAck, ActivationPlan, CommonSettings, InnerConfig, TransportConfig, UdpVariant,
+    };
+    use crate::types::FlowFormat;
 
     /// Pins the IS-05 Receiver `transport_params` →
     /// `CommonSettings` mapping. `nmossrc` populates the
@@ -1248,6 +1298,140 @@ mod tests {
         assert!(
             udp_receiver_advertise_caps(Some(WIDE_SDP), &wide_media).is_none(),
             "wide SDP (a=x-nvnmos-caps) must skip capssetter",
+        );
+    }
+
+    fn mxl_activation_plan(transport_file: &str) -> ActivationPlan {
+        ActivationPlan {
+            inner: InnerConfig::Real(TransportConfig::Mxl {
+                domain_path: "/dev/shm/test".to_owned(),
+                flow_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+                format: FlowFormat::Video,
+                transport_file: Some(transport_file.to_owned()),
+            }),
+            ack: ActivationAck::Success,
+        }
+    }
+
+    fn udp_activation_plan(sdp: &str) -> ActivationPlan {
+        let media = crate::sdp::parse_sdp(sdp).expect("parse sdp");
+        ActivationPlan {
+            inner: InnerConfig::Real(TransportConfig::Udp {
+                variant: UdpVariant::V1,
+                media,
+                transport_file: Some(sdp.to_owned()),
+            }),
+            ack: ActivationAck::Success,
+        }
+    }
+
+    /// Real→real: fake-hop caps follow the activation transport file for
+    /// `Real` plans (wide vs narrow inner-chain policy), not stale element
+    /// `caps` from an earlier chain.
+    #[test]
+    fn intermediate_fake_src_caps_follows_activation_not_element_property() {
+        use std::str::FromStr;
+        let _ = gst::init();
+        const NARROW_MXL: &str = r#"{
+            "format":"urn:x-nmos:format:video",
+            "media_type":"video/v210",
+            "grain_rate":{"numerator":25,"denominator":1},
+            "frame_width":1920,
+            "frame_height":1080
+        }"#;
+        const WIDE_MXL: &str = r#"{
+            "format":"urn:x-nmos:format:video",
+            "media_type":"video/v210",
+            "grain_rate":{"numerator":25,"denominator":1},
+            "frame_width":1920,
+            "frame_height":1080,
+            "tags":{"urn:x-nvnmos:tag:caps":[""]}
+        }"#;
+        let narrow_element_caps = gst::Caps::from_str(
+            "video/x-raw,format=v210,width=1920,height=1080,framerate=25/1",
+        )
+        .expect("narrow caps");
+        let snapshot = Settings {
+            caps: Some(narrow_element_caps),
+            ..Settings::default()
+        };
+
+        let wide_plan = mxl_activation_plan(WIDE_MXL);
+        assert!(
+            intermediate_fake_src_caps(&wide_plan, &snapshot)
+                .expect("wide activation")
+                .is_none(),
+            "wide activation must not pin fake-hop caps from the element property",
+        );
+
+        let narrow_plan = mxl_activation_plan(NARROW_MXL);
+        assert!(
+            intermediate_fake_src_caps(&narrow_plan, &snapshot)
+                .expect("narrow activation")
+                .is_some(),
+            "narrow activation must still advertise caps on the fake hop",
+        );
+    }
+
+    #[test]
+    fn intermediate_fake_src_caps_udp_wide_follows_sdp_marker() {
+        let _ = gst::init();
+        const NARROW_SDP: &str = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=Example\r\n",
+            "t=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 239.2.2.2/64\r\n",
+            "a=rtpmap:96 raw/90000\r\n",
+            "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25/1; depth=10\r\n",
+        );
+        const WIDE_SDP: &str = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=Example\r\n",
+            "t=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 239.2.2.2/64\r\n",
+            "a=rtpmap:96 raw/90000\r\n",
+            "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25/1; depth=10\r\n",
+            "a=x-nvnmos-caps:96\r\n",
+        );
+        let snapshot = Settings::default();
+
+        assert!(
+            intermediate_fake_src_caps(&udp_activation_plan(WIDE_SDP), &snapshot)
+                .expect("wide udp")
+                .is_none(),
+        );
+        assert!(
+            intermediate_fake_src_caps(&udp_activation_plan(NARROW_SDP), &snapshot)
+                .expect("narrow udp")
+                .is_some(),
+        );
+    }
+
+    #[test]
+    fn intermediate_fake_src_caps_deactivation_uses_element_settings() {
+        use std::str::FromStr;
+        let _ = gst::init();
+        let caps = gst::Caps::from_str(
+            "video/x-raw,format=v210,width=1920,height=1080,framerate=25/1",
+        )
+        .expect("caps");
+        let snapshot = Settings {
+            caps: Some(caps.clone()),
+            ..Settings::default()
+        };
+        let plan = ActivationPlan {
+            inner: InnerConfig::Fake {
+                reason: "deactivation".to_owned(),
+            },
+            ack: ActivationAck::Success,
+        };
+        assert_eq!(
+            intermediate_fake_src_caps(&plan, &snapshot).expect("fake plan"),
+            Some(caps),
         );
     }
 


### PR DESCRIPTION
Allow inner-chain swaps when the anchor still has sticky caps from the previous chain (`PadLinkCheck::empty`). On nmossrc real→real activations while PLAYING, optionally flush downstream of the src ghost before the block probe; keep real→fake→real for MXL transport teardown.

Derive intermediate fake appsrc caps from the activation transport file for `Real` plans so the fake hop matches wide/narrow inner-chain policy. Add unit tests for pad-link swap, flush noop, rebuild opts, and `intermediate_fake_src_caps`.

Demo: queues after nmossrc, line-buffered gst-launch for reliable cleanup, SIGINT on pipelines, default LIB to `build/`.