### PR TITLE
nvnmosd UDS listen guard

### DIFF
--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -157,6 +157,38 @@ _demo_line_buffered() {
     fi
 }
 
+# Return 0 when ss reports a LISTEN socket on path (another nvnmosd up).
+# No listener / missing path in ss → return 1.
+_uds_socket_listening() {
+    local path=$1
+    command -v ss >/dev/null 2>&1 || return 1
+    ss -xlpn 2>/dev/null | rg -F "LISTEN" | rg -qF "$path"
+}
+
+# Return 0 when ss reports pid is listening on the socket path.
+_uds_listener_owned_by_pid() {
+    local pid=$1 path=$2
+    command -v ss >/dev/null 2>&1 || return 0
+    ss -xlpn 2>/dev/null | rg -F "$path" | rg -q "pid=$pid[,)]"
+}
+
+# Fail if more than one nvnmosd was started with this --uds path.
+_assert_single_nvnmosd_on_sock() {
+    local -a pids=()
+    mapfile -t pids < <(pgrep -f "nvnmosd --uds $SOCK" 2>/dev/null || true)
+    if (( ${#pids[@]} != 1 )); then
+        echo "[error] expected exactly one nvnmosd on $SOCK, found ${#pids[@]}:"
+        pgrep -af "nvnmosd --uds $SOCK" 2>/dev/null || true
+        echo "        stop extras: pkill -9 -f 'nvnmosd --uds $SOCK'"
+        exit 1
+    fi
+    if (( pids[0] != DAEMON_PID )); then
+        echo "[error] nvnmosd on $SOCK is pid ${pids[0]}, not demo daemon pid $DAEMON_PID"
+        pgrep -af "nvnmosd --uds $SOCK" 2>/dev/null || true
+        exit 1
+    fi
+}
+
 # Shared MXL Domain (tmpfs-backed). All three Nodes operate inside
 # it. Only used when DEMO_TRANSPORT=mxl; the bootstrap block below
 # only creates the directory + `domain_def.json` in that case.
@@ -427,7 +459,16 @@ PLUGIN_DIR="$TARGET_DIR/debug"
 
 # ---- Daemon --------------------------------------------------------
 
-rm -f "$SOCK"
+# Do not `rm -f` the socket: that only unlinks the pathname while a
+# zombie nvnmosd can keep listening (and hold HTTP ports). nvnmosd probes
+# the path and exits if another listener is already up.
+if _uds_socket_listening "$SOCK"; then
+    echo "[error] UDS socket $SOCK is already in use (another nvnmosd listening?)."
+    echo "        Stop it, e.g.: pkill -9 -f 'nvnmosd --uds $SOCK'"
+    pgrep -af "nvnmosd --uds $SOCK" 2>/dev/null || true
+    exit 1
+fi
+
 echo "[daemon] starting nvnmosd on $SOCK"
 RUST_LOG=${RUST_LOG:-info} \
 LD_LIBRARY_PATH="$LIB:${LD_LIBRARY_PATH:-}" \
@@ -482,11 +523,33 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 
 for _ in $(seq 1 50); do
-    [[ -S "$SOCK" ]] && break
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        echo "[daemon] nvnmosd exited during startup"
+        cat "$DAEMON_LOG"
+        exit 1
+    fi
+    # A socket file alone is not enough: a stale pathname or another
+    # nvnmosd can satisfy -S before our daemon has bound.
+    if _uds_socket_listening "$SOCK" && _uds_listener_owned_by_pid "$DAEMON_PID" "$SOCK"; then
+        break
+    fi
     sleep 0.1
 done
-[[ -S "$SOCK" ]] || { echo "[daemon] socket did not appear"; cat "$DAEMON_LOG"; exit 1; }
-echo "[daemon] ready (pid $DAEMON_PID)"
+if ! _uds_socket_listening "$SOCK"; then
+    echo "[daemon] $SOCK is not listening (stale file or nvnmosd failed to bind?)"
+    ls -la "$SOCK" 2>/dev/null || true
+    cat "$DAEMON_LOG"
+    exit 1
+fi
+if ! _uds_listener_owned_by_pid "$DAEMON_PID" "$SOCK"; then
+    echo "[daemon] $SOCK is not owned by nvnmosd pid $DAEMON_PID"
+    ss -xlpn 2>/dev/null | rg 'gst-nmos-rs-demo\.sock' || true
+    pgrep -af "nvnmosd --uds $SOCK" 2>/dev/null || true
+    cat "$DAEMON_LOG"
+    exit 1
+fi
+_assert_single_nvnmosd_on_sock
+echo "[daemon] ready (pid $DAEMON_PID, listening on $SOCK)"
 
 # ---- Common gst env for nmossrc / nmossink + inner mxl* ----------
 

--- a/rust/nvnmosd/Cargo.toml
+++ b/rust/nvnmosd/Cargo.toml
@@ -11,6 +11,10 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 
+[lib]
+name = "nvnmosd"
+path = "src/lib.rs"
+
 [[bin]]
 name = "nvnmosd"
 path = "src/main.rs"

--- a/rust/nvnmosd/src/lib.rs
+++ b/rust/nvnmosd/src/lib.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Library surface for unit tests. The `nvnmosd` binary adds the gRPC
+//! service and NvNmos integration in `main.rs`.
+
+pub mod uds;

--- a/rust/nvnmosd/src/main.rs
+++ b/rust/nvnmosd/src/main.rs
@@ -53,8 +53,9 @@ const SUBSCRIPTION_BUFFER: usize = 16;
 #[derive(Parser, Debug)]
 #[command(version, about = "NMOS daemon (nvnmosd)")]
 struct Args {
-    /// Path to the UDS socket to listen on. A pre-existing file at this
-    /// path is removed before binding.
+    /// Path to the UDS socket to listen on. Fails at startup if another
+    /// listener is already accepting connections on this path; removes
+    /// only a stale socket file left behind by a crashed process.
     #[arg(long, env = "NVNMOSD_UDS", default_value = "/tmp/nvnmosd.sock")]
     uds: PathBuf,
 }
@@ -463,14 +464,7 @@ async fn main() -> anyhow::Result<()> {
 
     let args = Args::parse();
 
-    if args.uds.exists() {
-        std::fs::remove_file(&args.uds)
-            .with_context(|| format!("removing stale UDS socket at {}", args.uds.display()))?;
-    }
-    if let Some(parent) = args.uds.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating parent directory for {}", args.uds.display()))?;
-    }
+    nvnmosd::uds::prepare_listen_path(&args.uds)?;
 
     let listener = UnixListener::bind(&args.uds)
         .with_context(|| format!("binding UDS socket at {}", args.uds.display()))?;

--- a/rust/nvnmosd/src/uds.rs
+++ b/rust/nvnmosd/src/uds.rs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unix-domain socket path preparation for `nvnmosd` startup.
+//!
+//! A second daemon must not unlink a path that still has a live listener:
+//! clients would keep talking to the old process while HTTP ports stay
+//! pinned. We probe with [`std::os::unix::net::UnixStream::connect`] and
+//! only remove a stale pathname when nothing accepts connections.
+
+use std::io::ErrorKind;
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+
+use anyhow::Context;
+
+/// Ensure `path` is safe to bind: fail if another listener is already
+/// accepting connections; remove only a stale socket file.
+///
+/// Always probes with [`UnixStream::connect`], even when the pathname is
+/// missing. Relying on [`Path::exists`] first allowed a second `nvnmosd` to
+/// `bind()` in the window before the demo daemon created the socket file,
+/// or when a live listener held an unlinked inode after a careless `rm`.
+pub fn prepare_listen_path(path: &Path) -> anyhow::Result<()> {
+    match UnixStream::connect(path) {
+        Ok(_stream) => {
+            anyhow::bail!(
+                "UDS socket {} is already in use by another listener \
+                 (another nvnmosd is probably still running); stop it \
+                 before starting a new instance",
+                path.display()
+            );
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            // Nothing listening at this path yet (no file, or racing creator).
+        }
+        Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
+            // Stale socket file with no acceptor.
+            if path.exists() {
+                std::fs::remove_file(path).with_context(|| {
+                    format!("removing stale UDS socket at {}", path.display())
+                })?;
+            }
+        }
+        Err(e) => {
+            anyhow::bail!(
+                "cannot probe UDS socket at {}: {e}",
+                path.display()
+            );
+        }
+    }
+
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("creating parent directory for {}", path.display())
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::net::UnixListener as StdUnixListener;
+
+    use super::*;
+
+    #[test]
+    fn rejects_live_listener() {
+        let dir = std::env::temp_dir().join(format!(
+            "nvnmosd-uds-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("nvnmosd.sock");
+
+        let listener = StdUnixListener::bind(&sock).expect("bind test socket");
+        let _guard = listener;
+
+        let err = prepare_listen_path(&sock).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("already in use"),
+            "unexpected error: {msg}"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn probes_even_when_pathname_is_missing() {
+        let dir = std::env::temp_dir().join(format!(
+            "nvnmosd-uds-missing-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("nvnmosd.sock");
+
+        prepare_listen_path(&sock).expect("missing path should be bindable");
+
+        let _ = std::fs::remove_file(&sock);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn removes_stale_socket_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "nvnmosd-uds-stale-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("nvnmosd.sock");
+        std::fs::write(&sock, b"").expect("create stale socket file");
+
+        prepare_listen_path(&sock).expect("stale socket should be removed");
+
+        assert!(!sock.exists(), "stale socket file should have been removed");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rejects_while_background_listener_holds_path() {
+        let dir = std::env::temp_dir().join(format!(
+            "nvnmosd-uds-bg-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        let sock = dir.join("nvnmosd.sock");
+
+        let _listener = StdUnixListener::bind(&sock).expect("bind");
+
+        let err = prepare_listen_path(&sock).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("already in use"),
+            "expected in-use error"
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}


### PR DESCRIPTION
Stop unlinking the socket path before bind, which let a second daemon replace the pathname while the first process kept HTTP ports. Probe with `connect()` and only remove a stale file when nothing is listening.