### PR TITLE
nvnmosd-bench: daemon scalability test bench

### DIFF
--- a/doc/designs/nvnmosd/scale-smoke.md
+++ b/doc/designs/nvnmosd/scale-smoke.md
@@ -1,0 +1,197 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# nvnmosd Scale Smoke / Benchmark Harness
+
+Smoke and scaling measurements for a single `nvnmosd` process: memory usage and
+latency of gRPC lifecycle operations and IS-05 activation paths.
+
+## Quick Start
+
+**Prerequisites**
+
+1. Build `libnvnmos.so` via the usual CMake flow under `src/` (install tree or `build/`).
+2. Rust workspace: see [`rust/README.md`](../../rust/README.md).
+
+```bash
+export NVNMOS_LIB_DIR=/absolute/path/to/build   # directory containing libnvnmos.so
+
+./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+```
+
+Default: **`small`** preset only (`syncs=1`, `patches=10`). Results in JSON Lines (JSONL)
+format land in `rust/nvnmosd-bench/results/` (gitignored).
+
+```bash
+PRESETS="medium large" ./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+PRESETS=xlarge ./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+# sync-only: edit preset row or pass --syncs N --patches 0 to nvnmosd-bench directly
+```
+
+**Presets** — each row sets all scale axes:
+
+| Label | nodes | senders | receivers | sessions | clients | syncs | patches | Intent |
+|-------|-------|---------|-----------|----------|---------|-------|---------|--------|
+| small | 1 | 10 | 10 | 1 | 1 | 1 | 10 | Harness sanity |
+| medium | 1 | 100 | 100 | 1 | 1 | 10 | 100 | Big single node |
+| large | 1 | 1000 | 1000 | 10 | 10 | 100 | 100 | Bigger node, multi-session |
+| xlarge | 10 | 10000 | 10000 | 100 | 10 | 1000 | 1000 | Multi-node |
+
+**Node HTTP ports:** each bench node gets `http_port = base_http_port + node_index`.
+`base_http_port` defaults to `18080` (`NVNMOSD_BENCH_BASE_PORT`, passed through as
+`nvnmosd-bench --base-http-port`). `xlarge` uses 18080–18089.
+
+**Registration API:** bench `OpenSession` sets `network_services.registration_address`
+to `127.0.0.1` and `registration_port` to **9**. Any fixed `registration_address`
+disables DNS-SD browse/advertise in libnvnmos; **port 9** (the discard port — nothing
+listens there) makes registration HTTP fail immediately with connection refused, rather
+than mDNS browse timeouts (~seconds on WSL) or slow TCP timeouts to a dead host.
+
+## Reading Results
+
+One **JSON object per line** (JSONL). Example:
+
+```json
+{
+  "scenario": { "label": "small", "nodes": 1, "senders": 10, "receivers": 10, "sessions": 1, "clients": 1, "syncs": 1, "patches": 10 },
+  "memory_kb": { "baseline": 42000, "after_register": 98000, "after_activate": 100500, "after_teardown": 43000 },
+  "wall_ms": 412.5,
+  "add_sender_ms": { "count": 10, "total": 8.0, "p50": 0.15, "p95": 0.22, "p99": 0.28, "max": 0.35 },
+  "close_session_ms": { "count": 1, "total": 3.1, "p50": 3.1, "p95": 3.1, "p99": 3.1, "max": 3.1 }
+}
+```
+
+**`wall_ms`** — end-to-end wall clock for the whole scenario (all phases, sequential).
+
+**Per-RPC latency fields** (`add_sender_ms`, `close_session_ms`, …) — one sample per
+call. Phases spawn **parallel** tasks across sessions (and up to `clients`
+concurrent controller HTTP workflows for PATCH). So:
+
+- Do **not** multiply `p50` by `count` to compare with `wall_ms`.
+- **`max`** is closer to that phase's wall-clock cost than `p50 × count`.
+- **`total`** is the sum of all per-call samples (aggregate client wait time); it can be
+  much larger than `wall_ms` when many calls overlap on the clock but each waited on a
+  serialized daemon lock.
+
+| Metric | Sampled |
+|--------|----------------|
+| Memory (kB) | Resident Set Size (RSS) - baseline, after open, after register, after activate, after teardown |
+| **OpenSession** / **CloseSession** (ms) | Per gRPC call |
+| **AddSender** / **AddReceiver** (ms) | Per gRPC call |
+| **SubscribeActivations** (ms) | Per session when `patches > 0` |
+| **SyncResourceState** (ms) | Per activate/deactivate when `syncs > 0` |
+| **IS-05 GET / PATCH** (ms) | Per PATCH workflow when `patches > 0` |
+
+Latency values are **milliseconds** (float): `count`, `total`, `p50`, `p95`, `p99`, `max`.
+
+**Interpretation Hints**
+
+- **RSS vs resources** — daemon maps + libnvnmos model growth.
+- **RSS vs nodes** — more `NodeServer` / HTTP listeners at fixed per-node resource count.
+- **PATCH p95** vs **sync_activate_ms** — HTTP + in-band path vs out-of-band RPC only.
+
+## Architecture
+
+```
+run-nvnmosd-scale-smoke.sh
+  ├─ start nvnmosd (UDS)
+  ├─ loop presets → nvnmosd-bench --label … --daemon-pid $!
+  ├─ append JSONL → results/<timestamp>.jsonl
+  └─ stop nvnmosd (SIGTERM)
+```
+
+**`nvnmosd-bench`** (`rust/nvnmosd-bench/`) — modelled on `nvnmosd-example`:
+
+- **Node side (gRPC over UDS):** `OpenSession`, register resources, optional
+  `SubscribeActivations` + auto-`AckActivation`, `CloseSession`.
+- **Controller side (HTTP):** GET/PATCH on Connection API when `patches > 0`.
+- Minimal ST 2110-20 SDP; no GStreamer.
+
+Memory: `/proc/<daemon-pid>/status` `VmRSS` when `--daemon-pid` is set.
+
+## Phases (One Scenario Run)
+
+1. **baseline** — idle daemon RSS.
+2. **open_sessions** — parallel `OpenSession` (one gRPC client per session).
+3. **subscribe** *(when `patches > 0`)* — activations stream + background `AckActivation` per session.
+4. **add_resources** — parallel per session; senders then receivers on each session's client.
+5. **activate_sync** *(when `syncs > 0`)* — `syncs` out-of-band `SyncResourceState` workflows.
+6. **activate_patch** *(when `patches > 0`)* — `patches` in-band workflows: GET staged → PATCH
+   activate → GET staged → PATCH deactivate (`clients` limits HTTP concurrency).
+7. **close_sessions** — parallel `CloseSession`.
+
+The driver checks `base_http_port .. base_http_port + nodes − 1` are free before start.
+
+## Scale Knobs
+
+| Dimension | Range | Notes |
+|-----------|-------|-------|
+| **Nodes** | 1–10000 | One libnvnmos HTTP listener per seed; distinct `http_port` each. |
+| **Senders / receivers** | 0–100000 each | Registered via gRPC. |
+| **Sessions** | 0–10000 | Concurrent gRPC sessions (`>= 1` when registering resources). |
+| **Clients** | 0–1000 | Concurrent controller HTTP workflows (`0` when `patches == 0`). |
+| **Syncs** | 0–100000 | Out-of-band `SyncResourceState` workflows (`0` = skip sync phase). |
+| **Patches** | 0–100000 | In-band GET/PATCH activation workflows (`0` = skip PATCH phase). |
+
+`nvnmosd-bench` enforces these upper bounds as typo guards, not product limits.
+
+Resources are placed **round-robin across nodes** (`node_index = resource_index % nodes`).
+Sessions are opened **round-robin across nodes** (`session_index % nodes`). Each resource
+is registered on **session `resource_index % sessions`**.
+
+**`syncs`** and **`patches`** are how many activation **workflows** to run (independent
+counts). Targets are **evenly spaced** when the count is at most the number of registered
+Connection API **senders** (receivers are registered but not activated). Larger counts
+**round-robin** through those senders again. PATCH HTTP work runs in parallel up to
+**`clients`**. Set either or both axes; phases run in order: sync, then patch.
+
+Common values:
+
+- **`sessions == nodes`** — one session per node; resources on a node share that session.
+- **`sessions == senders + receivers`** — one session per resource.
+- **Other `sessions`** — `N` parallel gRPC clients; resources spread round-robin.
+- **`syncs` / `patches`** — workflow counts; see preset table (10% sender sample on
+  `large`/`xlarge` at time of writing).
+
+PATCH requires a routable interface IP (autodetected, or `--interface-ip` on `nvnmosd-bench`).
+
+## Details
+
+### NMOS Roles
+
+The bench plays **both** NMOS roles when `patches > 0`:
+
+| Role | NMOS meaning | Bench behaviour |
+|------|--------------|-----------------|
+| **Controller** | IS-05 client: GET/PATCH Connection API | HTTP PATCH workflows (no `OpenSession`) |
+| **Node data-plane client** | Registers resources, applies activations | gRPC: `OpenSession`, add/remove, subscribe, ack, close |
+
+A controller does not own a daemon session. `clients` is concurrent
+controller-side HTTP workflows in the one bench process, not “number of `OpenSession`s”.
+
+### Concurrency
+
+- **One gRPC connection per `OpenSession`.** Node-side RPCs run in parallel across sessions;
+  within a session, register RPCs stay sequential on that connection.
+- **`clients`** caps concurrent controller GET/PATCH HTTP workflows (`0` unused when
+  `patches == 0`; `patches > 0` requires `clients >= 1`).
+- **`syncs`** is how many out-of-band `SyncResourceState` round-trips to run (evenly
+  spaced; `0` = none).
+- **`patches`** is how many in-band GET/PATCH workflows to run (evenly spaced; `0` = none).
+  PATCH latency includes HTTP, daemon delivery, auto-`AckActivation`, and waiting on the
+  matching activation event.
+
+### What Is Not Under Test
+
+- Real media pipelines (`nmossrc` / `nmossink`, MXL, UDP).
+- Multi-process daemon fan-out (always one `nvnmosd`).
+- Production mDNS / registry discovery (bench uses dummy registry).
+
+## Future Extensions
+
+- Multiple `nvnmosd-bench` OS processes on one daemon.
+- MXL `flow_def` resources.
+- Persistent nodes (`AddNode`) mixed with session-refcounted nodes.
+- `perf record` / heap profiling hooks on the daemon PID.

--- a/doc/designs/nvnmosd/scale-smoke.md
+++ b/doc/designs/nvnmosd/scale-smoke.md
@@ -5,8 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # nvnmosd Scale Smoke / Benchmark Harness
 
-Smoke and scaling measurements for a single `nvnmosd` process: memory usage and
-latency of gRPC lifecycle operations and IS-05 activation paths.
+Smoke and scaling measurements for a single `nvnmosd` process: memory usage, per-phase
+daemon CPU (Linux `/proc`), and latency of gRPC lifecycle operations and IS-05
+activation paths.
 
 ## Quick Start
 
@@ -43,11 +44,11 @@ PRESETS=xlarge ./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
 `base_http_port` defaults to `18080` (`NVNMOSD_BENCH_BASE_PORT`, passed through as
 `nvnmosd-bench --base-http-port`). `xlarge` uses 18080–18089.
 
-**Registration API:** bench `OpenSession` sets `network_services.registration_address`
-to `127.0.0.1` and `registration_port` to **9**. Any fixed `registration_address`
-disables DNS-SD browse/advertise in libnvnmos; **port 9** (the discard port — nothing
-listens there) makes registration HTTP fail immediately with connection refused, rather
-than mDNS browse timeouts (~seconds on WSL) or slow TCP timeouts to a dead host.
+**Registration API:** bench `OpenSession` sets `network_services.registration_port` to
+**65535** and leaves `registration_address` unset. In libnvnmos this is an internal
+sentinel: DNS-SD browse/advertise disabled, no `registry_address`, no Registration
+API HTTP — so `CloseSession` is not dominated by mDNS browse timeouts (~seconds on WSL)
+or dead-registry retries.
 
 ## Reading Results
 
@@ -57,6 +58,13 @@ One **JSON object per line** (JSONL). Example:
 {
   "scenario": { "label": "small", "nodes": 1, "senders": 10, "receivers": 10, "sessions": 1, "clients": 1, "syncs": 1, "patches": 10 },
   "memory_kb": { "baseline": 42000, "after_register": 98000, "after_activate": 100500, "after_teardown": 43000 },
+  "cpu_pct": {
+    "open": { "avg": 45.0, "max": 80.0, "p95": 75.0, "samples": 1 },
+    "register": { "avg": 120.0, "max": 180.0, "p95": 170.0, "samples": 8 },
+    "activate_patch": { "avg": 90.0, "max": 110.0, "p95": 105.0, "samples": 4 },
+    "teardown": { "avg": 60.0, "max": 90.0, "p95": 85.0, "samples": 2 },
+    "overall": { "avg": 100.0, "max": 180.0, "p95": 160.0, "samples": 15 }
+  },
   "wall_ms": 412.5,
   "add_sender_ms": { "count": 10, "total": 8.0, "p50": 0.15, "p95": 0.22, "p99": 0.28, "max": 0.35 },
   "close_session_ms": { "count": 1, "total": 3.1, "p50": 3.1, "p95": 3.1, "p99": 3.1, "max": 3.1 }
@@ -78,6 +86,7 @@ concurrent controller HTTP workflows for PATCH). So:
 | Metric | Sampled |
 |--------|----------------|
 | Memory (kB) | Resident Set Size (RSS) - baseline, after open, after register, after activate, after teardown |
+| **cpu_pct** (%, Linux) | Per-phase daemon CPU when `--daemon-pid` set: background `/proc` sample every **100 ms** (override `--cpu-sample-ms`). Phases: `open`, `register`, `teardown`, plus `subscribe` / `activate_sync` / `activate_patch` when those phases run. Each phase reports `avg`, `max`, `p95`, `samples`; `overall` merges all interval samples. Values are **core-equivalent** (100% = one full core; may exceed 100% on multi-threaded load). Omitted when no daemon PID. |
 | **OpenSession** / **CloseSession** (ms) | Per gRPC call |
 | **AddSender** / **AddReceiver** (ms) | Per gRPC call |
 | **SubscribeActivations** (ms) | Per session when `patches > 0` |
@@ -90,6 +99,7 @@ Latency values are **milliseconds** (float): `count`, `total`, `p50`, `p95`, `p9
 
 - **RSS vs resources** — daemon maps + libnvnmos model growth.
 - **RSS vs nodes** — more `NodeServer` / HTTP listeners at fixed per-node resource count.
+- **cpu_pct.register / activate_patch** — hottest phases on large presets; compare `avg` across runs, `max` for burst peaks.
 - **PATCH p95** vs **sync_activate_ms** — HTTP + in-band path vs out-of-band RPC only.
 
 ## Architecture
@@ -109,7 +119,8 @@ run-nvnmosd-scale-smoke.sh
 - **Controller side (HTTP):** GET/PATCH on Connection API when `patches > 0`.
 - Minimal ST 2110-20 SDP; no GStreamer.
 
-Memory: `/proc/<daemon-pid>/status` `VmRSS` when `--daemon-pid` is set.
+Memory and CPU (Linux): `/proc/<daemon-pid>/status` `VmRSS` and per-phase background
+sampling of `/proc/<daemon-pid>/stat` when `--daemon-pid` / `NVNMOSD_PID` is set.
 
 ## Phases (One Scenario Run)
 
@@ -187,7 +198,24 @@ controller-side HTTP workflows in the one bench process, not “number of `OpenS
 
 - Real media pipelines (`nmossrc` / `nmossink`, MXL, UDP).
 - Multi-process daemon fan-out (always one `nvnmosd`).
-- Production mDNS / registry discovery (bench uses dummy registry).
+- Production mDNS / registry discovery (bench uses registry-less sentinel; see above).
+
+## Troubleshooting
+
+**Port already in use** — the smoke script checks `base_http_port .. base_http_port + nodes − 1`
+before start. Free stale listeners (often a prior `nvnmosd`) or set `NVNMOSD_BENCH_BASE_PORT`.
+
+**Stale `nvnmosd` processes** — failed or interrupted runs can leave background daemons running
+(`pgrep -a nvnmosd`). They are usually idle (~24 MB RSS each) but clutter process lists.
+Clean up with `pkill -TERM -f 'target/debug/nvnmosd'` and `rm -f /tmp/nvnmosd*.sock`.
+
+**PATCH / interface IP** — when `patches > 0`, SDP needs a routable local IP. The bench
+autodetects via the routing table; on WSL or multi-homed hosts set
+`NVNMOSD_BENCH_INTERFACE_IP` or pass `--interface-ip` to `nvnmosd-bench`.
+
+**Short phases with few CPU samples** — `open` and `subscribe` can finish in under one
+sample interval (default 100 ms), yielding `samples: 0` or `1`. Lower `--cpu-sample-ms`
+(e.g. 25) for finer peaks on long phases; very short phases may still have no samples.
 
 ## Future Extensions
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1139,6 +1139,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nvnmosd-bench"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hyper-util",
+ "nvnmos-rpc",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "nvnmosd-example"
 version = "0.1.0"
 dependencies = [

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "nvnmos-rpc",
     "nvnmosd",
     "nvnmosd-example",
+    "nvnmosd-bench",
     "gst-nmos-rs",
 ]
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All 
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# nvnmos Rust workspace
+# nvnmos Rust Workspace
 
 Rust components for the new GStreamer NMOS plugin family described in
 [`doc/designs/nvnmosd/README.md`](../doc/designs/nvnmosd/README.md).
@@ -17,6 +17,7 @@ Rust components for the new GStreamer NMOS plugin family described in
 | `nvnmos-rpc`       | library     | gRPC protocol crate (`nvnmosd.proto` + `tonic`-generated stubs).     |
 | `nvnmosd`          | binary      | The NMOS daemon. Wraps `nvnmos-sys`, serves `nvnmos-rpc`.            |
 | `nvnmosd-example`  | binary      | Example/regression client modelled on the C `nvnmos-example`.        |
+| `nvnmosd-bench`    | binary      | Scale smoke / benchmark client for `nvnmosd`.                        |
 | `gst-nmos-rs`      | GStreamer plugin (cdylib) | `nmos` plugin (`nmossrc` / `nmossink`); session lifecycle, inner `mxlsink`/`mxlsrc`, IS-05 activation handling, deferred `nmossink` AddSender (peer-query at READY→PAUSED), `nmossrc` essence-caps advertisement, and property-override-vs-cross-check semantics are all wired. See [`gst-nmos-rs/README.md`](gst-nmos-rs/README.md). |
 
 See `gst-nmos-rs`'s own
@@ -40,7 +41,21 @@ cargo build --workspace
 
 `protoc` is vendored via [`protobuf-src`](https://crates.io/crates/protobuf-src) — no system `protoc` is required.
 
-## Running the smoke test
+## Scale Benchmark (`nvnmosd-bench`)
+
+Measures daemon memory usage and RPC/HTTP latencies across preset scenarios. See
+[`doc/designs/nvnmosd/scale-smoke.md`](../doc/designs/nvnmosd/scale-smoke.md).
+
+```sh
+# Build libnvnmos first (../build/libnvnmos.so), then:
+export NVNMOS_LIB_DIR=/absolute/path/to/build
+./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh              # default: small preset
+PRESETS="medium large" ./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+```
+
+Results land in `rust/nvnmosd-bench/results/` (gitignored).
+
+## Running the Smoke Test
 
 ```sh
 # Terminal 1: daemon

--- a/rust/nvnmosd-bench/.gitignore
+++ b/rust/nvnmosd-bench/.gitignore
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# JSONL / logs from run-nvnmosd-scale-smoke.sh (local measurements only)
+/results/

--- a/rust/nvnmosd-bench/Cargo.toml
+++ b/rust/nvnmosd-bench/Cargo.toml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "nvnmosd-bench"
+description = "Scale smoke / benchmark client for nvnmosd (memory + RPC timing)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "nvnmosd-bench"
+path = "src/main.rs"
+
+[dependencies]
+nvnmos-rpc = { path = "../nvnmos-rpc" }
+
+tokio.workspace = true
+tonic.workspace = true
+tower.workspace = true
+hyper-util.workspace = true
+
+anyhow.workspace = true
+clap.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+++ b/rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run nvnmosd scale-smoke presets and append JSONL results.
+#
+# Usage:
+#   ./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+#   PRESETS="medium large" ./rust/nvnmosd-bench/scripts/run-nvnmosd-scale-smoke.sh
+#
+# Bench nodes always use a dummy Registration API (DNS-SD disabled) so
+# CloseSession is not dominated by nmos-cpp browse timeouts.
+#
+# Requires: built nvnmosd + nvnmosd-bench, routable interface IP when patches > 0.
+
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RUST_MANIFEST="$REPO/rust/Cargo.toml"
+TARGET_DIR="${CARGO_TARGET_DIR:-$REPO/rust/target}"
+DAEMON_BIN="$TARGET_DIR/debug/nvnmosd"
+BENCH_BIN="$TARGET_DIR/debug/nvnmosd-bench"
+SOCK="${NVNMOSD_UDS:-/tmp/nvnmosd-scale-smoke.sock}"
+BASE_HTTP_PORT="${NVNMOSD_BENCH_BASE_PORT:-18080}"
+RESULTS_DIR="${RESULTS_DIR:-$REPO/rust/nvnmosd-bench/results}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="$RESULTS_DIR/$STAMP.jsonl"
+
+# label nodes senders receivers sessions clients syncs patches
+DEFAULT_PRESETS=(
+    "small 1 10 10 1 1 1 10"
+    "medium 1 100 100 1 1 10 100"
+    "large 1 1000 1000 10 10 100 100"
+    "xlarge 10 10000 10000 100 10 1000 1000"
+)
+
+PRESET_NAMES="${PRESETS:-small}"
+read -r -a REQUESTED <<<"$PRESET_NAMES"
+SELECTED=()
+for name in "${REQUESTED[@]}"; do
+    found=0
+    for row in "${DEFAULT_PRESETS[@]}"; do
+        if [[ "${row%% *}" == "$name" ]]; then
+            SELECTED+=("$row")
+            found=1
+            break
+        fi
+    done
+    if (( ! found )); then
+        echo "unknown preset: $name (available: small medium large xlarge)" >&2
+        exit 1
+    fi
+done
+PRESET_ROWS=("${SELECTED[@]}")
+
+mkdir -p "$RESULTS_DIR"
+LIB="${NVNMOS_LIB_DIR:-$REPO/build}"
+if [[ ! -f "$LIB/libnvnmos.so" ]]; then
+    echo "missing $LIB/libnvnmos.so — build nvnmos in \$REPO/build first" >&2
+    exit 1
+fi
+export NVNMOS_LIB_DIR="$LIB"
+export LD_LIBRARY_PATH="$LIB:${LD_LIBRARY_PATH:-}"
+
+# Fail fast if a prior nvnmosd (or other process) still owns the node HTTP port range.
+max_nodes=1
+for row in "${PRESET_ROWS[@]}"; do
+    read -r _ nodes _ _ _ _ _ _ <<<"$row"
+    if (( nodes > max_nodes )); then
+        max_nodes=$nodes
+    fi
+done
+for ((i = 0; i < max_nodes; i++)); do
+    port=$((BASE_HTTP_PORT + i))
+    if command -v ss >/dev/null 2>&1; then
+        if ss -tln "sport = :$port" 2>/dev/null | grep -q LISTEN; then
+            holder=$(ss -tlnp "sport = :$port" 2>/dev/null | head -1)
+            echo "port $port already in use — free it before running (e.g. stale nvnmosd). $holder" >&2
+            exit 1
+        fi
+    elif command -v nc >/dev/null 2>&1 && nc -z 127.0.0.1 "$port" 2>/dev/null; then
+        echo "port $port already in use — free it before running (e.g. stale nvnmosd)" >&2
+        exit 1
+    fi
+done
+
+echo "[build] cargo build -p nvnmosd -p nvnmosd-bench (NVNMOS_LIB_DIR=$LIB)"
+NVNMOS_LIB_DIR="$LIB" cargo build --manifest-path "$RUST_MANIFEST" -p nvnmosd -p nvnmosd-bench
+
+rm -f "$SOCK"
+echo "[daemon] $DAEMON_BIN --uds $SOCK (LD_LIBRARY_PATH includes $LIB)"
+LD_LIBRARY_PATH="$LIB:${LD_LIBRARY_PATH:-}" NVNMOSD_UDS="$SOCK" "$DAEMON_BIN" --uds "$SOCK" &
+DAEMON_PID=$!
+cleanup() {
+    kill -TERM "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+    rm -f "$SOCK"
+}
+trap cleanup EXIT INT TERM
+
+for _ in $(seq 1 50); do
+    [[ -S "$SOCK" ]] && break
+    sleep 0.1
+done
+[[ -S "$SOCK" ]] || { echo "daemon socket not ready: $SOCK" >&2; exit 1; }
+
+echo "[results] $OUT"
+for row in "${PRESET_ROWS[@]}"; do
+    read -r label nodes senders receivers sessions clients syncs patches <<<"$row"
+    echo "[bench] preset=$label nodes=$nodes senders=$senders receivers=$receivers sessions=$sessions clients=$clients syncs=$syncs patches=$patches"
+    NVNMOSD_PID="$DAEMON_PID" NVNMOSD_UDS="$SOCK" \
+        "$BENCH_BIN" \
+        --label "$label" \
+        --daemon-pid "$DAEMON_PID" \
+        --uds "$SOCK" \
+        --nodes "$nodes" \
+        --senders "$senders" \
+        --receivers "$receivers" \
+        --sessions "$sessions" \
+        --base-http-port "$BASE_HTTP_PORT" \
+        --clients "$clients" \
+        --syncs "$syncs" \
+        --patches "$patches" \
+        >>"$OUT"
+done
+
+echo "[done] wrote $(wc -l <"$OUT") lines to $OUT"

--- a/rust/nvnmosd-bench/src/main.rs
+++ b/rust/nvnmosd-bench/src/main.rs
@@ -1,0 +1,991 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Scale smoke client for [`nvnmosd`].
+//!
+//! Drives one scenario (node / session / resource counts), records per-RPC
+//! latencies and optional daemon RSS samples, and prints one JSON line.
+//!
+//! See `doc/designs/nvnmosd/scale-smoke.md` for the full matrix and presets.
+//! Usually invoked by `scripts/run-nvnmosd-scale-smoke.sh`.
+
+use std::collections::HashMap;
+use std::net::UdpSocket;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use clap::Parser;
+use nvnmos_rpc::v1::nvnmos_daemon_client::NvnmosDaemonClient;
+use nvnmos_rpc::v1::{
+    AckActivationRequest, ActivationEvent, AddReceiverRequest, AddSenderRequest,
+    CloseSessionRequest, NetworkServicesConfig, NodeConfig, OpenSessionRequest, Side as ProtoSide,
+    SubscribeActivationsRequest, SyncResourceStateRequest, Transport as ProtoTransport,
+};
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UnixStream};
+use tokio::sync::{mpsc as tokio_mpsc, Mutex, Semaphore};
+use tokio::task::JoinSet;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+/// Typo guards for scale axes (not product limits).
+const MAX_NODES: usize = 10_000;
+const MAX_SENDERS: usize = 100_000;
+const MAX_RECEIVERS: usize = 100_000;
+const MAX_SESSIONS: usize = 10_000;
+const MAX_CLIENTS: usize = 1_000;
+const MAX_SYNCS: usize = 100_000;
+const MAX_PATCHES: usize = 100_000;
+
+#[derive(Parser, Debug)]
+#[command(version, about = "nvnmosd scale smoke / benchmark client")]
+struct Args {
+    #[arg(long, env = "NVNMOSD_UDS", default_value = "/tmp/nvnmosd.sock")]
+    uds: PathBuf,
+
+    /// Optional label echoed in JSON output (preset name).
+    #[arg(long)]
+    label: Option<String>,
+
+    /// Daemon PID for VmRSS sampling via /proc.
+    #[arg(long, env = "NVNMOSD_PID")]
+    daemon_pid: Option<u32>,
+
+    #[arg(long, default_value_t = 1)]
+    nodes: usize,
+
+    #[arg(long, default_value_t = 5)]
+    senders: usize,
+
+    #[arg(long, default_value_t = 5)]
+    receivers: usize,
+
+    /// Concurrent gRPC sessions; resources round-robin across sessions (`resource_index %
+    /// sessions`). When equal to `nodes`, one session per node; when equal to senders +
+    /// receivers, one session per resource.
+    #[arg(long, default_value_t = 1)]
+    sessions: usize,
+
+    #[arg(long, default_value_t = 18080)]
+    base_http_port: u16,
+
+    #[arg(long, env = "NVNMOSD_BENCH_INTERFACE_IP")]
+    interface_ip: Option<String>,
+
+    /// Out-of-band `SyncResourceState` workflows (`0` = none). Evenly spaced targets when
+    /// not more than registered senders; otherwise round-robin through them.
+    #[arg(long, default_value_t = 0)]
+    syncs: usize,
+
+    /// In-band GET/PATCH activation workflows (`0` = none). Evenly spaced targets when not
+    /// more than registered senders; otherwise round-robin through them.
+    #[arg(long, default_value_t = 0)]
+    patches: usize,
+
+    /// Max concurrent controller-side GET/PATCH HTTP workflows (`0` when `patches == 0`).
+    #[arg(long, default_value_t = 0)]
+    clients: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioMeta {
+    label: Option<String>,
+    nodes: usize,
+    senders: usize,
+    receivers: usize,
+    sessions: usize,
+    clients: usize,
+    syncs: usize,
+    patches: usize,
+}
+
+#[derive(Debug, Serialize, Default)]
+struct MemoryKb {
+    baseline: Option<u64>,
+    after_open: Option<u64>,
+    after_register: Option<u64>,
+    after_activate: Option<u64>,
+    after_teardown: Option<u64>,
+}
+
+/// Latency stats in **milliseconds** (floating point) for JSON output.
+#[derive(Debug, Serialize)]
+struct LatencyMs {
+    count: usize,
+    total: f64,
+    p50: f64,
+    p95: f64,
+    p99: f64,
+    max: f64,
+}
+
+impl LatencyMs {
+    fn from_samples_us(samples_us: Vec<u64>) -> Self {
+        if samples_us.is_empty() {
+            return Self::zero();
+        }
+        let mut ms: Vec<f64> = samples_us.iter().map(|&us| us_to_ms(us)).collect();
+        ms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let count = ms.len();
+        let total: f64 = ms.iter().sum();
+        Self {
+            count,
+            total,
+            p50: percentile_ms(&ms, 50),
+            p95: percentile_ms(&ms, 95),
+            p99: percentile_ms(&ms, 99),
+            max: *ms.last().unwrap_or(&0.0),
+        }
+    }
+
+    fn zero() -> Self {
+        Self {
+            count: 0,
+            total: 0.0,
+            p50: 0.0,
+            p95: 0.0,
+            p99: 0.0,
+            max: 0.0,
+        }
+    }
+}
+
+fn us_to_ms(us: u64) -> f64 {
+    us as f64 / 1000.0
+}
+
+fn percentile_ms(sorted_ms: &[f64], pct: u8) -> f64 {
+    if sorted_ms.is_empty() {
+        return 0.0;
+    }
+    let idx = ((sorted_ms.len() as f64) * (f64::from(pct) / 100.0)).ceil() as usize;
+    sorted_ms[idx.saturating_sub(1).min(sorted_ms.len() - 1)]
+}
+
+fn read_rss_kb(pid: u32) -> anyhow::Result<u64> {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status"))
+        .with_context(|| format!("reading /proc/{pid}/status"))?;
+    for line in status.lines() {
+        if let Some(kb) = line.strip_prefix("VmRSS:") {
+            let kb: u64 = kb.trim().trim_end_matches(" kB").parse()?;
+            return Ok(kb);
+        }
+    }
+    anyhow::bail!("VmRSS not found in /proc/{pid}/status");
+}
+
+fn sample_memory(pid: Option<u32>) -> Option<u64> {
+    pid.and_then(|p| read_rss_kb(p).ok())
+}
+
+#[derive(Debug, Serialize)]
+struct BenchReport {
+    scenario: ScenarioMeta,
+    memory_kb: MemoryKb,
+    open_session_ms: LatencyMs,
+    subscribe_activations_ms: LatencyMs,
+    add_sender_ms: LatencyMs,
+    add_receiver_ms: LatencyMs,
+    sync_activate_ms: LatencyMs,
+    sync_deactivate_ms: LatencyMs,
+    connection_get_ms: LatencyMs,
+    patch_activate_ms: LatencyMs,
+    patch_deactivate_ms: LatencyMs,
+    close_session_ms: LatencyMs,
+    wall_ms: f64,
+}
+
+struct SessionSlot {
+    session_handle: String,
+    http_port: u16,
+}
+
+struct SessionContext {
+    index: usize,
+    slot: SessionSlot,
+    client: NvnmosDaemonClient<Channel>,
+    activation_hub: Option<Arc<ActivationHub>>,
+    ack_task: Option<tokio::task::JoinHandle<()>>,
+}
+
+/// Node-side demux: match `ActivationEvent`s by `(resource_handle, active)` so
+/// concurrent controller PATCH workflows targeting the same session do not steal
+/// each other's subscription events.
+struct ActivationHub {
+    state: Mutex<ActivationHubState>,
+}
+
+#[derive(Default)]
+struct ActivationHubState {
+    /// Events that arrived before `wait` registered.
+    pending: HashMap<ActivationWaitKey, u32>,
+    waiters: HashMap<ActivationWaitKey, Vec<tokio::sync::oneshot::Sender<()>>>,
+}
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+struct ActivationWaitKey {
+    resource_handle: String,
+    active: bool,
+}
+
+impl ActivationHub {
+    fn new() -> (Arc<Self>, tokio_mpsc::Sender<ActivationEvent>) {
+        let (event_tx, mut event_rx) = tokio_mpsc::channel(256);
+        let hub = Arc::new(Self {
+            state: Mutex::new(ActivationHubState::default()),
+        });
+        let dispatch_hub = hub.clone();
+        tokio::spawn(async move {
+            while let Some(event) = event_rx.recv().await {
+                dispatch_hub.deliver(event).await;
+            }
+        });
+        (hub, event_tx)
+    }
+
+    async fn deliver(&self, event: ActivationEvent) {
+        let side = ProtoSide::try_from(event.side).unwrap_or(ProtoSide::Unspecified);
+        if side != ProtoSide::Sender {
+            return;
+        }
+        let key = ActivationWaitKey {
+            resource_handle: event.resource_handle,
+            active: event.transport_file.is_some(),
+        };
+        let mut st = self.state.lock().await;
+        if let Some(waiters) = st.waiters.remove(&key) {
+            for tx in waiters {
+                let _ = tx.send(());
+            }
+        } else {
+            *st.pending.entry(key).or_insert(0) += 1;
+        }
+    }
+
+    async fn wait(
+        &self,
+        resource_handle: &str,
+        active: bool,
+        timeout: Duration,
+    ) -> anyhow::Result<()> {
+        let key = ActivationWaitKey {
+            resource_handle: resource_handle.to_owned(),
+            active,
+        };
+        let rx = {
+            let mut st = self.state.lock().await;
+            if let Some(count) = st.pending.get_mut(&key) {
+                if *count > 0 {
+                    *count -= 1;
+                    if *count == 0 {
+                        st.pending.remove(&key);
+                    }
+                    return Ok(());
+                }
+            }
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            st.waiters.entry(key).or_default().push(tx);
+            rx
+        };
+        tokio::time::timeout(timeout, rx)
+            .await
+            .context("timed out waiting for ActivationEvent")?
+            .context("activation waiter dropped")?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct ResourceSlot {
+    session_index: usize,
+    resource_handle: String,
+    resource_id: String,
+    sdp: String,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    let args = Args::parse();
+    anyhow::ensure!(
+        (1..=MAX_NODES).contains(&args.nodes),
+        "nodes must be 1..={MAX_NODES}"
+    );
+    anyhow::ensure!(
+        args.senders <= MAX_SENDERS,
+        "senders must be <= {MAX_SENDERS}"
+    );
+    anyhow::ensure!(
+        args.receivers <= MAX_RECEIVERS,
+        "receivers must be <= {MAX_RECEIVERS}"
+    );
+    anyhow::ensure!(
+        args.syncs <= MAX_SYNCS,
+        "syncs must be <= {MAX_SYNCS}"
+    );
+    anyhow::ensure!(
+        args.patches <= MAX_PATCHES,
+        "patches must be <= {MAX_PATCHES}"
+    );
+    if args.syncs > 0 && args.senders == 0 {
+        anyhow::bail!("syncs > 0 requires at least one registered sender");
+    }
+    if args.patches > 0 && args.senders == 0 {
+        anyhow::bail!("patches > 0 requires at least one registered sender");
+    }
+    anyhow::ensure!(
+        args.clients <= MAX_CLIENTS,
+        "clients must be <= {MAX_CLIENTS}"
+    );
+    if args.patches > 0 {
+        anyhow::ensure!(args.clients >= 1, "patches > 0 requires clients >= 1");
+    }
+
+    anyhow::ensure!(
+        args.sessions <= MAX_SESSIONS,
+        "sessions must be <= {MAX_SESSIONS}"
+    );
+    if args.senders > 0 || args.receivers > 0 {
+        anyhow::ensure!(args.sessions >= 1, "sessions must be >= 1 when registering resources");
+    }
+    let session_count = args.sessions;
+    anyhow::ensure!(
+        u32::from(args.base_http_port) + args.nodes as u32 <= u16::MAX as u32,
+        "base_http_port + nodes overflows port range",
+    );
+
+    let needs_sync = args.syncs > 0;
+    let needs_patch = args.patches > 0;
+    let iface_ip = match args.interface_ip.clone() {
+        Some(ip) => ip,
+        None => autodetect_interface_ip().context("interface IP (set --interface-ip)")?,
+    };
+    let wall_start = Instant::now();
+    let mut memory = MemoryKb {
+        baseline: sample_memory(args.daemon_pid),
+        ..Default::default()
+    };
+
+    let node_seeds: Vec<String> = (0..args.nodes)
+        .map(|i| format!("bench-node-{i}"))
+        .collect();
+
+    // -------- Open sessions (one UDS/gRPC client per session, in parallel) --------
+    let mut open_set = JoinSet::new();
+    for s in 0..session_count {
+        let uds = args.uds.clone();
+        let node_index = session_node_index(s, args.nodes);
+        let http_port = args.base_http_port + node_index as u16;
+        let node_seed = node_seeds[node_index].clone();
+        open_set.spawn(async move {
+            let t0 = Instant::now();
+            let channel = connect_uds(&uds).await?;
+            let mut client = NvnmosDaemonClient::new(channel);
+            let resp = client
+                .open_session(OpenSessionRequest {
+                    node_config: Some(bench_node_config(&node_seed, http_port)),
+                })
+                .await
+                .with_context(|| format!("OpenSession node={node_index} session={s}"))?
+                .into_inner();
+            Ok::<_, anyhow::Error>((
+                s,
+                t0.elapsed().as_micros() as u64,
+                SessionContext {
+                    index: s,
+                    slot: SessionSlot {
+                        session_handle: resp.session_handle,
+                        http_port,
+                    },
+                    client,
+                    activation_hub: None,
+                    ack_task: None,
+                },
+            ))
+        });
+    }
+
+    let mut open_samples = Vec::with_capacity(session_count);
+    let mut open_results: Vec<(usize, u64, SessionContext)> = Vec::with_capacity(session_count);
+    while let Some(res) = open_set.join_next().await {
+        open_results.push(res.context("OpenSession task panicked")??);
+    }
+    open_results.sort_by_key(|(index, _, _)| *index);
+    let mut sessions = Vec::with_capacity(session_count);
+    for (index, sample, ctx) in open_results {
+        anyhow::ensure!(index == sessions.len(), "unexpected OpenSession index");
+        open_samples.push(sample);
+        sessions.push(ctx);
+    }
+    memory.after_open = sample_memory(args.daemon_pid);
+
+    // -------- Subscribe (PATCH path, parallel per session) --------
+    let mut subscribe_samples = Vec::new();
+    if needs_patch {
+        let mut sub_set = JoinSet::new();
+        for ctx in &mut sessions {
+            let client = ctx.client.clone();
+            let session_handle = ctx.slot.session_handle.clone();
+            let index = ctx.index;
+            sub_set.spawn(async move {
+                let t0 = Instant::now();
+                let (task, hub) = spawn_auto_ack_task(client, session_handle).await?;
+                Ok::<_, anyhow::Error>((
+                    index,
+                    t0.elapsed().as_micros() as u64,
+                    hub,
+                    task,
+                ))
+            });
+        }
+        while let Some(res) = sub_set.join_next().await {
+            let (index, sample, hub, task) = res.context("SubscribeActivations task panicked")??;
+            subscribe_samples.push(sample);
+            let ctx = &mut sessions[index];
+            ctx.activation_hub = Some(hub);
+            ctx.ack_task = Some(task);
+        }
+    }
+
+    // -------- Add resources (parallel per session, sequential within session) --------
+    let mut add_sender_samples = Vec::with_capacity(args.senders);
+    let mut add_receiver_samples = Vec::with_capacity(args.receivers);
+    let mut senders: Vec<Option<ResourceSlot>> = vec![None; args.senders];
+    let mut receivers: Vec<Option<ResourceSlot>> = vec![None; args.receivers];
+
+    let mut add_set = JoinSet::new();
+    for ctx in &mut sessions {
+        let session_index = ctx.index;
+        let session_handle = ctx.slot.session_handle.clone();
+        let mut client = ctx.client.clone();
+        let sender_indices: Vec<usize> = (0..args.senders)
+            .filter(|&i| {
+                session_for_resource(i, session_count) == session_index
+            })
+            .collect();
+        let receiver_indices: Vec<usize> = (0..args.receivers)
+            .filter(|&i| {
+                session_for_resource(args.senders + i, session_count) == session_index
+            })
+            .collect();
+        if sender_indices.is_empty() && receiver_indices.is_empty() {
+            continue;
+        }
+        let iface_ip = iface_ip.clone();
+        add_set.spawn(async move {
+            let mut local_sender_samples = Vec::new();
+            let mut local_receiver_samples = Vec::new();
+            let mut local_senders = Vec::new();
+            let mut local_receivers = Vec::new();
+
+            for i in sender_indices {
+                let name = format!("sender-{i}");
+                let sdp = build_video_sdp(&name, true, &iface_ip);
+                let t0 = Instant::now();
+                let resp = client
+                    .add_sender(AddSenderRequest {
+                        session_handle: session_handle.clone(),
+                        transport: ProtoTransport::Rtp as i32,
+                        transport_file: sdp.clone(),
+                        name: name.clone(),
+                    })
+                    .await
+                    .with_context(|| format!("AddSender {name}"))?
+                    .into_inner();
+                local_sender_samples.push((i, t0.elapsed().as_micros() as u64));
+                local_senders.push((
+                    i,
+                    ResourceSlot {
+                        session_index,
+                        resource_handle: resp.resource_handle,
+                        resource_id: resp.resource_id,
+                        sdp,
+                    },
+                ));
+            }
+
+            for i in receiver_indices {
+                let name = format!("receiver-{i}");
+                let sdp = build_video_sdp(&name, false, &iface_ip);
+                let t0 = Instant::now();
+                let resp = client
+                    .add_receiver(AddReceiverRequest {
+                        session_handle: session_handle.clone(),
+                        transport: ProtoTransport::Rtp as i32,
+                        transport_file: sdp.clone(),
+                        name: name.clone(),
+                    })
+                    .await
+                    .with_context(|| format!("AddReceiver {name}"))?
+                    .into_inner();
+                local_receiver_samples.push((i, t0.elapsed().as_micros() as u64));
+                local_receivers.push((
+                    i,
+                    ResourceSlot {
+                        session_index,
+                        resource_handle: resp.resource_handle,
+                        resource_id: resp.resource_id,
+                        sdp,
+                    },
+                ));
+            }
+
+            Ok::<_, anyhow::Error>((
+                local_sender_samples,
+                local_receiver_samples,
+                local_senders,
+                local_receivers,
+            ))
+        });
+    }
+
+    while let Some(res) = add_set.join_next().await {
+        let (s_samples, r_samples, s_slots, r_slots) =
+            res.context("AddResource task panicked")??;
+        for (_i, sample) in s_samples {
+            add_sender_samples.push(sample);
+        }
+        for (i, slot) in s_slots {
+            senders[i] = Some(slot);
+        }
+        for (_i, sample) in r_samples {
+            add_receiver_samples.push(sample);
+        }
+        for (i, slot) in r_slots {
+            receivers[i] = Some(slot);
+        }
+    }
+    let senders: Vec<ResourceSlot> = senders
+        .into_iter()
+        .map(|s| s.context("missing sender slot"))
+        .collect::<Result<_, _>>()?;
+    let _receivers: Vec<ResourceSlot> = receivers
+        .into_iter()
+        .map(|r| r.context("missing receiver slot"))
+        .collect::<Result<_, _>>()?;
+    memory.after_register = sample_memory(args.daemon_pid);
+
+    // -------- Sync activations (parallel per session) --------
+    let mut sync_activate_samples = Vec::new();
+    let mut sync_deactivate_samples = Vec::new();
+
+    if needs_sync {
+        let sync_indices = sender_activation_indices(senders.len(), args.syncs);
+        let mut sync_set = JoinSet::new();
+        for ctx in &mut sessions {
+            let session_index = ctx.index;
+            let session_handle = ctx.slot.session_handle.clone();
+            let mut client = ctx.client.clone();
+            let session_senders: Vec<ResourceSlot> = sync_indices
+                .iter()
+                .map(|&i| senders[i].clone())
+                .filter(|s| s.session_index == session_index)
+                .collect();
+            if session_senders.is_empty() {
+                continue;
+            }
+            sync_set.spawn(async move {
+                let mut activate = Vec::new();
+                let mut deactivate = Vec::new();
+                for s in &session_senders {
+                    let updated = s.sdp.replacen("o=- 0 0", "o=- 0 1", 1);
+                    let t0 = Instant::now();
+                    client
+                        .sync_resource_state(SyncResourceStateRequest {
+                            session_handle: session_handle.clone(),
+                            resource_handle: s.resource_handle.clone(),
+                            transport_file: Some(updated),
+                        })
+                        .await
+                        .context("SyncResourceState activate")?;
+                    activate.push(t0.elapsed().as_micros() as u64);
+
+                    let t0 = Instant::now();
+                    client
+                        .sync_resource_state(SyncResourceStateRequest {
+                            session_handle: session_handle.clone(),
+                            resource_handle: s.resource_handle.clone(),
+                            transport_file: None,
+                        })
+                        .await
+                        .context("SyncResourceState deactivate")?;
+                    deactivate.push(t0.elapsed().as_micros() as u64);
+                }
+                Ok::<_, anyhow::Error>((activate, deactivate))
+            });
+        }
+        while let Some(res) = sync_set.join_next().await {
+            let (activate, deactivate) = res.context("SyncResourceState task panicked")??;
+            sync_activate_samples.extend(activate);
+            sync_deactivate_samples.extend(deactivate);
+        }
+    }
+
+    // -------- PATCH activations (GET then PATCH; HTTP parallelism via clients) --------
+    let mut connection_get_samples = Vec::new();
+    let mut patch_activate_samples = Vec::new();
+    let mut patch_deactivate_samples = Vec::new();
+
+    if needs_patch {
+        let patch_indices = sender_activation_indices(senders.len(), args.patches);
+
+        let patch_work: Vec<(ResourceSlot, String)> = patch_indices
+            .iter()
+            .map(|&i| {
+                let s = &senders[i];
+                (
+                    s.clone(),
+                    format!(
+                        "/x-nmos/connection/v1.1/single/senders/{}/staged",
+                        s.resource_id
+                    ),
+                )
+            })
+            .collect();
+
+        let http_sem = Arc::new(Semaphore::new(args.clients));
+        let iface_ip = Arc::new(iface_ip);
+        let mut patch_set = JoinSet::new();
+
+        for (sender, staged_path) in patch_work {
+            let sem = http_sem.clone();
+            let iface_ip = iface_ip.clone();
+            let session_index = sender.session_index;
+            let http_port = sessions[session_index].slot.http_port;
+            let resource_handle = sender.resource_handle.clone();
+            let staged_path = staged_path.clone();
+            let activation_hub = sessions[session_index]
+                .activation_hub
+                .as_ref()
+                .context("activation hub for session")?
+                .clone();
+
+            patch_set.spawn(async move {
+                let _permit = sem
+                    .acquire()
+                    .await
+                    .context("HTTP client semaphore closed")?;
+
+                let mut get_samples = Vec::with_capacity(2);
+                let mut activate_samples = Vec::with_capacity(1);
+                let mut deactivate_samples = Vec::with_capacity(1);
+
+                let t0 = Instant::now();
+                let (status, _) =
+                    connection_get(&iface_ip, http_port, &staged_path).await?;
+                anyhow::ensure!(status == 200, "GET staged returned HTTP {status}");
+                get_samples.push(t0.elapsed().as_micros() as u64);
+
+                let t0 = Instant::now();
+                let body = r#"{"master_enable":true,"activation":{"mode":"activate_immediate"}}"#;
+                let (status, _) =
+                    connection_patch(&iface_ip, http_port, &staged_path, body).await?;
+                anyhow::ensure!(status == 200, "PATCH activate returned HTTP {status}");
+                activate_samples.push(t0.elapsed().as_micros() as u64);
+                activation_hub
+                    .wait(&resource_handle, true, Duration::from_secs(30))
+                    .await?;
+
+                let t0 = Instant::now();
+                let (status, _) =
+                    connection_get(&iface_ip, http_port, &staged_path).await?;
+                anyhow::ensure!(status == 200, "GET staged returned HTTP {status}");
+                get_samples.push(t0.elapsed().as_micros() as u64);
+
+                let t0 = Instant::now();
+                let body = r#"{"master_enable":false,"activation":{"mode":"activate_immediate"}}"#;
+                let (status, _) =
+                    connection_patch(&iface_ip, http_port, &staged_path, body).await?;
+                anyhow::ensure!(status == 200, "PATCH deactivate returned HTTP {status}");
+                deactivate_samples.push(t0.elapsed().as_micros() as u64);
+                activation_hub
+                    .wait(&resource_handle, false, Duration::from_secs(30))
+                    .await?;
+
+                Ok::<_, anyhow::Error>((get_samples, activate_samples, deactivate_samples))
+            });
+        }
+
+        while let Some(res) = patch_set.join_next().await {
+            let (gets, activates, deactivates) =
+                res.context("Connection API task panicked")??;
+            connection_get_samples.extend(gets);
+            patch_activate_samples.extend(activates);
+            patch_deactivate_samples.extend(deactivates);
+        }
+    }
+
+    memory.after_activate = sample_memory(args.daemon_pid);
+
+    // -------- Close sessions (parallel, one client per session) --------
+    let mut close_samples = Vec::with_capacity(sessions.len());
+    let mut close_set = JoinSet::new();
+    for ctx in &mut sessions {
+        let session_handle = ctx.slot.session_handle.clone();
+        let mut client = ctx.client.clone();
+        close_set.spawn(async move {
+            let t0 = Instant::now();
+            client
+                .close_session(CloseSessionRequest {
+                    session_handle,
+                })
+                .await
+                .context("CloseSession")?;
+            Ok::<_, anyhow::Error>(t0.elapsed().as_micros() as u64)
+        });
+    }
+    while let Some(res) = close_set.join_next().await {
+        close_samples.push(res.context("CloseSession task panicked")??);
+    }
+    memory.after_teardown = sample_memory(args.daemon_pid);
+
+    for ctx in &mut sessions {
+        if let Some(task) = ctx.ack_task.take() {
+            let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+        }
+    }
+
+    let report = BenchReport {
+        scenario: ScenarioMeta {
+            label: args.label,
+            nodes: args.nodes,
+            senders: args.senders,
+            receivers: args.receivers,
+            sessions: args.sessions,
+            clients: args.clients,
+            syncs: args.syncs,
+            patches: args.patches,
+        },
+        memory_kb: memory,
+        open_session_ms: LatencyMs::from_samples_us(open_samples),
+        subscribe_activations_ms: LatencyMs::from_samples_us(subscribe_samples),
+        add_sender_ms: LatencyMs::from_samples_us(add_sender_samples),
+        add_receiver_ms: LatencyMs::from_samples_us(add_receiver_samples),
+        sync_activate_ms: LatencyMs::from_samples_us(sync_activate_samples),
+        sync_deactivate_ms: LatencyMs::from_samples_us(sync_deactivate_samples),
+        connection_get_ms: LatencyMs::from_samples_us(connection_get_samples),
+        patch_activate_ms: LatencyMs::from_samples_us(patch_activate_samples),
+        patch_deactivate_ms: LatencyMs::from_samples_us(patch_deactivate_samples),
+        close_session_ms: LatencyMs::from_samples_us(close_samples),
+        wall_ms: us_to_ms(wall_start.elapsed().as_micros() as u64),
+    };
+
+    println!("{}", serde_json::to_string(&report)?);
+    Ok(())
+}
+
+fn session_node_index(session_index: usize, nodes: usize) -> usize {
+    session_index % nodes
+}
+
+fn session_for_resource(resource_index: usize, session_count: usize) -> usize {
+    resource_index % session_count
+}
+
+/// Per-workflow registered-sender index for sync or PATCH. `workflow_count == 0` → none.
+/// When `workflow_count <= registered_count`, targets are evenly spaced; when larger,
+/// round-robin through `[0, registered_count)`.
+fn sender_activation_indices(registered_count: usize, workflow_count: usize) -> Vec<usize> {
+    match (registered_count, workflow_count) {
+        (0, _) | (_, 0) => Vec::new(),
+        (n, c) if c <= n => (0..c).map(|i| i * n / c).collect(),
+        (n, c) => (0..c).map(|i| i % n).collect(),
+    }
+}
+
+fn bench_node_config(node_seed: &str, http_port: u16) -> NodeConfig {
+    NodeConfig {
+        seed: node_seed.to_string(),
+        http_port: u32::from(http_port),
+        network_services: Some(NetworkServicesConfig {
+            registration_address: "127.0.0.1".to_string(),
+            registration_port: 9,
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn autodetect_interface_ip() -> anyhow::Result<String> {
+    let sock = UdpSocket::bind("0.0.0.0:0").context("UdpSocket::bind")?;
+    sock.connect("8.8.8.8:80").context("UdpSocket::connect")?;
+    Ok(sock.local_addr()?.ip().to_string())
+}
+
+async fn spawn_auto_ack_task(
+    mut client: NvnmosDaemonClient<Channel>,
+    session_handle: String,
+) -> anyhow::Result<(tokio::task::JoinHandle<()>, Arc<ActivationHub>)> {
+    let mut stream = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session_handle.clone(),
+        })
+        .await?
+        .into_inner();
+
+    let (hub, event_tx) = ActivationHub::new();
+
+    let handle = tokio::spawn(async move {
+        while let Ok(Some(event)) = stream.message().await {
+            let _ = client
+                .ack_activation(AckActivationRequest {
+                    session_handle: session_handle.clone(),
+                    activation_handle: event.activation_handle.clone(),
+                    success: true,
+                    failure_reason: String::new(),
+                })
+                .await;
+            let _ = event_tx.send(event).await;
+        }
+    });
+    Ok((handle, hub))
+}
+
+async fn connection_get(host: &str, port: u16, path: &str) -> anyhow::Result<(u16, String)> {
+    connection_http("GET", host, port, path, None).await
+}
+
+async fn connection_patch(
+    host: &str,
+    port: u16,
+    path: &str,
+    body: &str,
+) -> anyhow::Result<(u16, String)> {
+    connection_http("PATCH", host, port, path, Some(body)).await
+}
+
+async fn connection_http(
+    method: &str,
+    host: &str,
+    port: u16,
+    path: &str,
+    body: Option<&str>,
+) -> anyhow::Result<(u16, String)> {
+    let addr = format!("{host}:{port}");
+    let request = match body {
+        Some(body) => format!(
+            "{method} {path} HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {len}\r\n\
+             Connection: close\r\n\
+             \r\n\
+             {body}",
+            len = body.len(),
+        ),
+        None => format!(
+            "{method} {path} HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Connection: close\r\n\
+             \r\n",
+        ),
+    };
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        let mut sock = TcpStream::connect(&addr).await?;
+        sock.write_all(request.as_bytes()).await?;
+        let mut buf = Vec::with_capacity(4096);
+        sock.read_to_end(&mut buf).await?;
+        let resp = String::from_utf8_lossy(&buf).into_owned();
+        let status_line = resp.lines().next().unwrap_or("");
+        let status: u16 = status_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| anyhow::anyhow!("bad HTTP status"))?;
+        Ok((status, resp))
+    })
+    .await
+    .with_context(|| format!("{method} timed out"))?
+}
+
+fn build_video_sdp(name: &str, sender: bool, iface_ip: &str) -> String {
+    const MULTICAST_IP: &str = "233.252.0.0";
+    const SOURCE_IP: &str = "192.0.2.0";
+    const DESTINATION_PORT: u16 = 5020;
+    const SOURCE_PORT: u16 = 5004;
+    const PAYLOAD_TYPE: u8 = 96;
+    const ENCODING: &str = "raw/90000";
+    const FMTP: &str = "sampling=YCbCr-4:2:2; width=1920; height=1080; \
+        exactframerate=50; depth=10; TCS=SDR; colorimetry=BT709; \
+        PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN; ";
+
+    let mut out = format!(
+        "v=0\r\n\
+         o=- 0 0 IN IP4 {iface_ip}\r\n\
+         s=nvnmosd-bench {name}\r\n\
+         t=0 0\r\n\
+         a=x-nvnmos-name:{name}\r\n\
+         m=video {DESTINATION_PORT} RTP/AVP {PAYLOAD_TYPE}\r\n\
+         c=IN IP4 {MULTICAST_IP}/64\r\n\
+         a=source-filter: incl IN IP4 {MULTICAST_IP} {}\r\n\
+         a=x-nvnmos-iface-ip:{iface_ip}\r\n\
+         a=rtpmap:{PAYLOAD_TYPE} {ENCODING}\r\n\
+         a=fmtp:{PAYLOAD_TYPE} {FMTP}\r\n\
+         a=mediaclk:direct=0\r\n",
+        if sender { iface_ip } else { SOURCE_IP },
+    );
+    if sender {
+        out.push_str(&format!("a=x-nvnmos-src-port:{SOURCE_PORT}\r\n"));
+        out.push_str("a=ts-refclk:localmac=CA-FE-01-CA-FE-02\r\n");
+    }
+    out
+}
+
+async fn connect_uds(uds: &Path) -> anyhow::Result<Channel> {
+    let uds = uds.to_path_buf();
+    let endpoint = Endpoint::try_from("http://[::1]:50051")?;
+    endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let uds = uds.clone();
+            async move {
+                let stream = UnixStream::connect(uds).await?;
+                Ok::<_, std::io::Error>(hyper_util::rt::TokioIo::new(stream))
+            }
+        }))
+        .await
+        .context("UDS connect")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sender_activation_indices;
+
+    #[test]
+    fn activation_indices_zero_means_none() {
+        assert!(sender_activation_indices(10, 0).is_empty());
+        assert!(sender_activation_indices(0, 0).is_empty());
+        assert!(sender_activation_indices(0, 5).is_empty());
+    }
+
+    #[test]
+    fn activation_indices_full_coverage() {
+        assert_eq!(sender_activation_indices(10, 10), (0..10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn activation_indices_evenly_spaced_sample() {
+        assert_eq!(sender_activation_indices(1000, 32).len(), 32);
+        assert_eq!(sender_activation_indices(1000, 32)[0], 0);
+        assert_eq!(sender_activation_indices(1000, 32)[31], 31 * 1000 / 32);
+    }
+
+    #[test]
+    fn activation_indices_round_robin_when_exceeding_registered() {
+        let indices = sender_activation_indices(1000, 5000);
+        assert_eq!(indices.len(), 5000);
+        assert_eq!(indices[0], 0);
+        assert_eq!(indices[999], 999);
+        assert_eq!(indices[1000], 0);
+        assert_eq!(indices[1001], 1);
+    }
+}

--- a/rust/nvnmosd-bench/src/main.rs
+++ b/rust/nvnmosd-bench/src/main.rs
@@ -4,7 +4,8 @@
 //! Scale smoke client for [`nvnmosd`].
 //!
 //! Drives one scenario (node / session / resource counts), records per-RPC
-//! latencies and optional daemon RSS samples, and prints one JSON line.
+//! latencies, optional daemon RSS samples, and per-phase CPU utilization (Linux
+//! `/proc` background sampling), and prints one JSON line.
 //!
 //! See `doc/designs/nvnmosd/scale-smoke.md` for the full matrix and presets.
 //! Usually invoked by `scripts/run-nvnmosd-scale-smoke.sh`.
@@ -50,9 +51,13 @@ struct Args {
     #[arg(long)]
     label: Option<String>,
 
-    /// Daemon PID for VmRSS sampling via /proc.
+    /// Daemon PID for VmRSS and CPU sampling via /proc (Linux).
     #[arg(long, env = "NVNMOSD_PID")]
     daemon_pid: Option<u32>,
+
+    /// Background CPU sample interval during each bench phase (milliseconds).
+    #[arg(long, default_value_t = 100)]
+    cpu_sample_ms: u64,
 
     #[arg(long, default_value_t = 1)]
     nodes: usize,
@@ -181,10 +186,203 @@ fn sample_memory(pid: Option<u32>) -> Option<u64> {
     pid.and_then(|p| read_rss_kb(p).ok())
 }
 
+/// Linux `CLK_TCK` for `/proc/<pid>/stat` jiffies (typically 100).
+const LINUX_CLK_TCK: f64 = 100.0;
+
+/// Poll interval for per-phase daemon CPU sampling.
+fn cpu_sample_interval(ms: u64) -> Duration {
+    Duration::from_millis(ms.max(10))
+}
+
+/// Core-equivalent CPU percent between two `/proc/<pid>/stat` samples (may exceed 100).
+fn cpu_pct_between(
+    prev_utime: u64,
+    prev_stime: u64,
+    prev_wall: Instant,
+    utime: u64,
+    stime: u64,
+    wall: Instant,
+) -> f64 {
+    let delta_jiffies = utime.saturating_sub(prev_utime) + stime.saturating_sub(prev_stime);
+    let delta_wall_secs = wall.duration_since(prev_wall).as_secs_f64();
+    if delta_wall_secs <= 0.0 {
+        return 0.0;
+    }
+    100.0 * delta_jiffies as f64 / (delta_wall_secs * LINUX_CLK_TCK)
+}
+
+fn read_proc_cpu_jiffies(pid: u32) -> anyhow::Result<(u64, u64)> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat"))
+        .with_context(|| format!("reading /proc/{pid}/stat"))?;
+    let rparen = stat
+        .rfind(')')
+        .context("parsing /proc/stat comm field")?;
+    let fields: Vec<&str> = stat[rparen + 2..].split_whitespace().collect();
+    anyhow::ensure!(
+        fields.len() > 12,
+        "short /proc/{pid}/stat (expected utime/stime)"
+    );
+    let utime: u64 = fields[11].parse().context("utime")?;
+    let stime: u64 = fields[12].parse().context("stime")?;
+    Ok((utime, stime))
+}
+
+#[derive(Debug, Serialize, Default, Clone)]
+struct CpuPhasePct {
+    avg: Option<f64>,
+    max: Option<f64>,
+    p95: Option<f64>,
+    samples: usize,
+}
+
+impl CpuPhasePct {
+    fn from_samples(mut samples: Vec<f64>) -> Self {
+        if samples.is_empty() {
+            return Self::default();
+        }
+        samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let count = samples.len();
+        let sum: f64 = samples.iter().sum();
+        Self {
+            avg: Some(sum / count as f64),
+            max: Some(*samples.last().unwrap_or(&0.0)),
+            p95: Some(percentile_ms(&samples, 95)),
+            samples: count,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Default)]
+struct CpuPct {
+    open: CpuPhasePct,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subscribe: Option<CpuPhasePct>,
+    register: CpuPhasePct,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    activate_sync: Option<CpuPhasePct>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    activate_patch: Option<CpuPhasePct>,
+    teardown: CpuPhasePct,
+    overall: CpuPhasePct,
+}
+
+struct CpuPhaseSampler {
+    stop: std::sync::mpsc::Sender<()>,
+    thread: Option<std::thread::JoinHandle<Vec<f64>>>,
+}
+
+impl CpuPhaseSampler {
+    fn start(pid: u32, interval: Duration) -> Self {
+        let (stop, rx) = std::sync::mpsc::channel();
+        let thread = std::thread::spawn(move || cpu_sampler_loop(pid, interval, rx));
+        Self {
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    fn stop(mut self) -> Vec<f64> {
+        let _ = self.stop.send(());
+        self.thread
+            .take()
+            .and_then(|t| t.join().ok())
+            .unwrap_or_default()
+    }
+}
+
+fn cpu_sampler_loop(
+    pid: u32,
+    interval: Duration,
+    stop: std::sync::mpsc::Receiver<()>,
+) -> Vec<f64> {
+    let mut samples = Vec::new();
+    let Ok((mut prev_utime, mut prev_stime)) = read_proc_cpu_jiffies(pid) else {
+        return samples;
+    };
+    let mut prev_wall = Instant::now();
+    loop {
+        match stop.recv_timeout(interval) {
+            Ok(()) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+        }
+        let wall = Instant::now();
+        let Ok((utime, stime)) = read_proc_cpu_jiffies(pid) else {
+            break;
+        };
+        let pct = cpu_pct_between(prev_utime, prev_stime, prev_wall, utime, stime, wall);
+        if pct.is_finite() && pct >= 0.0 {
+            samples.push(pct);
+        }
+        prev_utime = utime;
+        prev_stime = stime;
+        prev_wall = wall;
+    }
+    samples
+}
+
+struct CpuMonitor {
+    pid: Option<u32>,
+    interval: Duration,
+    overall_samples: Vec<f64>,
+    active: Option<CpuPhaseSampler>,
+}
+
+impl CpuMonitor {
+    fn new(pid: Option<u32>, interval: Duration) -> Self {
+        Self {
+            pid,
+            interval,
+            overall_samples: Vec::new(),
+            active: None,
+        }
+    }
+
+    fn begin_phase(&mut self) {
+        if let Some(pid) = self.pid {
+            self.active = Some(CpuPhaseSampler::start(pid, self.interval));
+        }
+    }
+
+    fn end_phase(&mut self) -> CpuPhasePct {
+        let samples = self
+            .active
+            .take()
+            .map(CpuPhaseSampler::stop)
+            .unwrap_or_default();
+        self.overall_samples.extend(samples.iter().copied());
+        CpuPhasePct::from_samples(samples)
+    }
+
+    fn into_report(
+        self,
+        open: CpuPhasePct,
+        subscribe: Option<CpuPhasePct>,
+        register: CpuPhasePct,
+        activate_sync: Option<CpuPhasePct>,
+        activate_patch: Option<CpuPhasePct>,
+        teardown: CpuPhasePct,
+    ) -> Option<CpuPct> {
+        self.pid?;
+        let overall = CpuPhasePct::from_samples(self.overall_samples);
+        Some(CpuPct {
+            open,
+            subscribe,
+            register,
+            activate_sync,
+            activate_patch,
+            teardown,
+            overall,
+        })
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct BenchReport {
     scenario: ScenarioMeta,
     memory_kb: MemoryKb,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cpu_pct: Option<CpuPct>,
     open_session_ms: LatencyMs,
     subscribe_activations_ms: LatencyMs,
     add_sender_ms: LatencyMs,
@@ -374,12 +572,14 @@ async fn main() -> anyhow::Result<()> {
         baseline: sample_memory(args.daemon_pid),
         ..Default::default()
     };
+    let mut cpu = CpuMonitor::new(args.daemon_pid, cpu_sample_interval(args.cpu_sample_ms));
 
     let node_seeds: Vec<String> = (0..args.nodes)
         .map(|i| format!("bench-node-{i}"))
         .collect();
 
     // -------- Open sessions (one UDS/gRPC client per session, in parallel) --------
+    cpu.begin_phase();
     let mut open_set = JoinSet::new();
     for s in 0..session_count {
         let uds = args.uds.clone();
@@ -426,11 +626,14 @@ async fn main() -> anyhow::Result<()> {
         open_samples.push(sample);
         sessions.push(ctx);
     }
+    let cpu_open = cpu.end_phase();
     memory.after_open = sample_memory(args.daemon_pid);
 
     // -------- Subscribe (PATCH path, parallel per session) --------
     let mut subscribe_samples = Vec::new();
+    let mut cpu_subscribe = None;
     if needs_patch {
+        cpu.begin_phase();
         let mut sub_set = JoinSet::new();
         for ctx in &mut sessions {
             let client = ctx.client.clone();
@@ -454,9 +657,11 @@ async fn main() -> anyhow::Result<()> {
             ctx.activation_hub = Some(hub);
             ctx.ack_task = Some(task);
         }
+        cpu_subscribe = Some(cpu.end_phase());
     }
 
     // -------- Add resources (parallel per session, sequential within session) --------
+    cpu.begin_phase();
     let mut add_sender_samples = Vec::with_capacity(args.senders);
     let mut add_receiver_samples = Vec::with_capacity(args.receivers);
     let mut senders: Vec<Option<ResourceSlot>> = vec![None; args.senders];
@@ -572,13 +777,16 @@ async fn main() -> anyhow::Result<()> {
         .into_iter()
         .map(|r| r.context("missing receiver slot"))
         .collect::<Result<_, _>>()?;
+    let cpu_register = cpu.end_phase();
     memory.after_register = sample_memory(args.daemon_pid);
 
     // -------- Sync activations (parallel per session) --------
     let mut sync_activate_samples = Vec::new();
     let mut sync_deactivate_samples = Vec::new();
+    let mut cpu_activate_sync = None;
 
     if needs_sync {
+        cpu.begin_phase();
         let sync_indices = sender_activation_indices(senders.len(), args.syncs);
         let mut sync_set = JoinSet::new();
         for ctx in &mut sessions {
@@ -628,14 +836,17 @@ async fn main() -> anyhow::Result<()> {
             sync_activate_samples.extend(activate);
             sync_deactivate_samples.extend(deactivate);
         }
+        cpu_activate_sync = Some(cpu.end_phase());
     }
 
     // -------- PATCH activations (GET then PATCH; HTTP parallelism via clients) --------
     let mut connection_get_samples = Vec::new();
     let mut patch_activate_samples = Vec::new();
     let mut patch_deactivate_samples = Vec::new();
+    let mut cpu_activate_patch = None;
 
     if needs_patch {
+        cpu.begin_phase();
         let patch_indices = sender_activation_indices(senders.len(), args.patches);
 
         let patch_work: Vec<(ResourceSlot, String)> = patch_indices
@@ -722,11 +933,13 @@ async fn main() -> anyhow::Result<()> {
             patch_activate_samples.extend(activates);
             patch_deactivate_samples.extend(deactivates);
         }
+        cpu_activate_patch = Some(cpu.end_phase());
     }
 
     memory.after_activate = sample_memory(args.daemon_pid);
 
     // -------- Close sessions (parallel, one client per session) --------
+    cpu.begin_phase();
     let mut close_samples = Vec::with_capacity(sessions.len());
     let mut close_set = JoinSet::new();
     for ctx in &mut sessions {
@@ -746,6 +959,7 @@ async fn main() -> anyhow::Result<()> {
     while let Some(res) = close_set.join_next().await {
         close_samples.push(res.context("CloseSession task panicked")??);
     }
+    let cpu_teardown = cpu.end_phase();
     memory.after_teardown = sample_memory(args.daemon_pid);
 
     for ctx in &mut sessions {
@@ -766,6 +980,14 @@ async fn main() -> anyhow::Result<()> {
             patches: args.patches,
         },
         memory_kb: memory,
+        cpu_pct: cpu.into_report(
+            cpu_open,
+            cpu_subscribe,
+            cpu_register,
+            cpu_activate_sync,
+            cpu_activate_patch,
+            cpu_teardown,
+        ),
         open_session_ms: LatencyMs::from_samples_us(open_samples),
         subscribe_activations_ms: LatencyMs::from_samples_us(subscribe_samples),
         add_sender_ms: LatencyMs::from_samples_us(add_sender_samples),
@@ -988,5 +1210,24 @@ mod tests {
         assert_eq!(indices[999], 999);
         assert_eq!(indices[1000], 0);
         assert_eq!(indices[1001], 1);
+    }
+
+    #[test]
+    fn cpu_pct_between_one_core_second() {
+        use std::time::{Duration, Instant};
+
+        let t0 = Instant::now();
+        // 100 jiffies at CLK_TCK=100 == 1.0 core-second over 1.0 wall second => 100%
+        let pct = super::cpu_pct_between(0, 0, t0, 100, 0, t0 + Duration::from_secs(1));
+        assert!((pct - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn cpu_phase_pct_stats() {
+        let stats = super::CpuPhasePct::from_samples(vec![10.0, 20.0, 30.0, 40.0]);
+        assert_eq!(stats.samples, 4);
+        assert!((stats.avg.unwrap() - 25.0).abs() < 0.01);
+        assert!((stats.max.unwrap() - 40.0).abs() < 0.01);
+        assert!((stats.p95.unwrap() - 40.0).abs() < 0.01);
     }
 }

--- a/rust/nvnmosd-bench/src/main.rs
+++ b/rust/nvnmosd-bench/src/main.rs
@@ -807,8 +807,9 @@ fn bench_node_config(node_seed: &str, http_port: u16) -> NodeConfig {
         seed: node_seed.to_string(),
         http_port: u32::from(http_port),
         network_services: Some(NetworkServicesConfig {
-            registration_address: "127.0.0.1".to_string(),
-            registration_port: 9,
+            // registration_port 65535 without registration_address puts libnvnmos in
+            // registry-less mode (DNS-SD disabled, no Registration API requests)
+            registration_port: 65535,
             ..Default::default()
         }),
         ..Default::default()

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -365,12 +365,17 @@ namespace nvnmos
             if (0 != services.registration_address)
             {
                 web::json::insert(settings, std::make_pair(nmos::fields::registry_address, utility::s2us(services.registration_address)));
+            }
+            // disable DNS-SD when a fixed registration_address is specified (or port 65535 without registration_address)
+            if (0 != services.registration_address || 65535 == services.registration_port)
+            {
                 // disable DNS-SD discovery
                 web::json::insert(settings, std::make_pair(nmos::fields::highest_pri, nmos::service_priorities::no_priority));
                 // disable DNS-SD advertisement
                 web::json::insert(settings, std::make_pair(nmos::fields::pri, nmos::service_priorities::no_priority));
             }
-            web::json::insert(settings, std::make_pair(nmos::fields::registration_port, 0 != services.registration_port ? services.registration_port : 80));
+            // default to port 80 when port 0 is specified (or port 65535 without registration_address)
+            web::json::insert(settings, std::make_pair(nmos::fields::registration_port, 0 != services.registration_port && (0 != services.registration_address || 65535 != services.registration_port) ? services.registration_port : 80));
             if (0 != services.registration_version)
             {
                 web::json::insert(settings, std::make_pair(nmos::fields::registry_version, utility::s2us(services.registration_version)));

--- a/src/nvnmos_impl.cpp
+++ b/src/nvnmos_impl.cpp
@@ -130,12 +130,13 @@ namespace nvnmos
         utility::string_t make_iface(const nmos::node_interface& interface);
         // parse x-nvnmos-iface from media legs that carry the attribute; legs is IS-05 transport leg count (0 to skip leg-count check)
         std::vector<nmos::node_interface> get_session_description_interfaces(const web::json::value& session_description, size_t legs = 0);
-        // collect node interface details from configured RTP transport files in settings
-        std::map<utility::string_t, nmos::node_interface> get_interfaces(const nmos::settings& settings);
-        // make a sender/receiver settings entry
-        web::json::value make_connection_settings(const nmos::transport& transport, const utility::string_t& transport_file);
-        // resolve the IS-04 interface binding name from a transport param address via host_interfaces()
+        // get node interfaces from host_interfaces for interface_bindings
+        std::map<utility::string_t, nmos::node_interface> get_interfaces_for_bindings(const std::vector<utility::string_t>& interface_names, const std::vector<web::hosts::experimental::host_interface>& host_interfaces);
+        // look up the interface name from a transport param address via host_interfaces
         utility::string_t get_interface_name(const nmos::type& type, const web::json::value& transport_param, const std::vector<web::hosts::experimental::host_interface>& host_interfaces);
+
+        // make a transport settings entry for a sender/receiver
+        web::json::value make_transport_settings(const nmos::transport& transport, const utility::string_t& transport_file);
 
         // generate a repeatable source-specific multicast address for each leg of a sender
         utility::string_t make_source_specific_multicast_address_v4(const nmos::id& id, int leg);
@@ -162,8 +163,14 @@ namespace nvnmos
         // modify node resource if necessary to update specified clock, which must already exist
         void update_node_clock(nmos::resources& node_resources, const nmos::id& node_id, const web::json::value& clock);
 
-        // modify node resource if necessary to include all of the specified interfaces that currently have interface_bindings in any senders or receivers
-        void update_node_interfaces(nmos::resources& node_resources, const nmos::id& node_id, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, const nmos::settings& settings);
+        struct interface_bindings_update
+        {
+            std::vector<utility::string_t> removed;
+            std::vector<utility::string_t> added;
+        };
+
+        // modify node resource interfaces incrementally, maintaining interface_bindings reference counts in settings
+        void update_node_interfaces(nmos::resources& node_resources, const nmos::id& node_id, const interface_bindings_update& bindings_update, const std::map<utility::string_t, nmos::node_interface>& interfaces, nmos::settings& settings);
 
         // resolve "auto" in connection transport params
         void resolve_auto(const nmos::resource& resource, const nmos::resource& connection_resource, web::json::value& transport_params, const utility::string_t& transport_file = {});
@@ -227,10 +234,11 @@ namespace nvnmos
             if (!nmos::insert_resource(node_resources, std::move(device)).second) throw node_implementation_exception();
         }
 
-        // insert empty clock, sender and receiver configs
+        // insert empty clock, sender, receiver and interface_binding configs
         settings[nvnmos::fields::clocks] = value::object();
         settings[nvnmos::fields::senders] = value::object();
         settings[nvnmos::fields::receivers] = value::object();
+        settings[nvnmos::fields::interface_bindings] = value::object();
     }
 
     void node_implementation_add_rtp_sender_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& sdp_, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
@@ -404,17 +412,15 @@ namespace nvnmos
             slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(sender_id, nmos::types::sender) << ": " << urls.first << " " << urls.second;
         }
 
-        // update device's deprecated senders array
-
-        nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
-        {
-            device.data[nmos::fields::version] = value::string(nmos::make_version());
-            web::json::push_back(nmos::fields::senders(device.data), sender_id);
-        });
-
         // update node's interfaces
 
-        impl::update_node_interfaces(node_resources, node_id, host_interfaces, settings);
+        const auto interfaces_for_bindings = !interfaces.empty()
+            ? boost::copy_range<std::map<utility::string_t, nmos::node_interface>>(interfaces | boost::adaptors::transformed([](const nmos::node_interface& interface)
+            {
+                return std::make_pair(interface.name, interface);
+            }))
+            : impl::get_interfaces_for_bindings(interface_names, host_interfaces);
+        impl::update_node_interfaces(node_resources, node_id, { {}, interface_names }, interfaces_for_bindings, settings);
 
         // update node's clocks
 
@@ -426,7 +432,7 @@ namespace nvnmos
 
         // insert into settings
 
-        nvnmos::fields::senders(settings)[sender_id] = impl::make_connection_settings(nmos::transports::rtp, utility::s2us(sdp_));
+        nvnmos::fields::senders(settings)[sender_id] = impl::make_transport_settings(nmos::transports::rtp, utility::s2us(sdp_));
     }
 
     void node_implementation_add_rtp_receiver_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& sdp_, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
@@ -585,21 +591,19 @@ namespace nvnmos
             slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(receiver_id, nmos::types::receiver) << ": " << urls.first << " " << urls.second;
         }
 
-        // update device's deprecated receivers array
-
-        nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
-        {
-            device.data[nmos::fields::version] = value::string(nmos::make_version());
-            web::json::push_back(nmos::fields::receivers(device.data), receiver_id);
-        });
-
         // update node's interfaces
 
-        impl::update_node_interfaces(node_resources, node_id, host_interfaces, settings);
+        const auto interfaces_for_bindings = !interfaces.empty()
+            ? boost::copy_range<std::map<utility::string_t, nmos::node_interface>>(interfaces | boost::adaptors::transformed([](const nmos::node_interface& interface)
+            {
+                return std::make_pair(interface.name, interface);
+            }))
+            : impl::get_interfaces_for_bindings(interface_names, host_interfaces);
+        impl::update_node_interfaces(node_resources, node_id, { {}, interface_names }, interfaces_for_bindings, settings);
 
         // insert into settings
 
-        nvnmos::fields::receivers(settings)[receiver_id] = impl::make_connection_settings(nmos::transports::rtp, utility::s2us(sdp_));
+        nvnmos::fields::receivers(settings)[receiver_id] = impl::make_transport_settings(nmos::transports::rtp, utility::s2us(sdp_));
     }
 
     void node_implementation_add_mxl_sender_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& flow_def_, nmos::settings& settings, slog::base_gate& gate)
@@ -720,17 +724,9 @@ namespace nvnmos
             slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(sender_id, nmos::types::sender) << ": " << urls.first << " " << urls.second;
         }
 
-        // update device's deprecated senders array
-
-        nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
-        {
-            device.data[nmos::fields::version] = value::string(nmos::make_version());
-            web::json::push_back(nmos::fields::senders(device.data), sender_id);
-        });
-
         // insert into settings
 
-        nvnmos::fields::senders(settings)[sender_id] = impl::make_connection_settings(nmos::transports::mxl, utility::s2us(flow_def_));
+        nvnmos::fields::senders(settings)[sender_id] = impl::make_transport_settings(nmos::transports::mxl, utility::s2us(flow_def_));
     }
 
     void node_implementation_add_mxl_receiver_(nmos::resources& node_resources, nmos::resources& connection_resources, const std::string& flow_def_, nmos::settings& settings, slog::base_gate& gate)
@@ -849,17 +845,9 @@ namespace nvnmos
             slog::log<slog::severities::info>(gate, SLOG_FLF) << "Created " << std::make_pair(receiver_id, nmos::types::receiver) << ": " << urls.first << " " << urls.second;
         }
 
-        // update device's deprecated receivers array
-
-        nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
-        {
-            device.data[nmos::fields::version] = value::string(nmos::make_version());
-            web::json::push_back(nmos::fields::receivers(device.data), receiver_id);
-        });
-
         // insert into settings
 
-        nvnmos::fields::receivers(settings)[receiver_id] = impl::make_connection_settings(nmos::transports::mxl, utility::s2us(flow_def_));
+        nvnmos::fields::receivers(settings)[receiver_id] = impl::make_transport_settings(nmos::transports::mxl, utility::s2us(flow_def_));
     }
 
     void node_implementation_remove_connection_(nmos::resources& node_resources, nmos::resources& connection_resources, const nmos::type& type, const utility::string_t& name, const std::vector<web::hosts::experimental::host_interface>& host_interfaces, nmos::settings& settings, slog::base_gate& gate)
@@ -876,6 +864,12 @@ namespace nvnmos
 
         if (node_resources.end() != resource)
         {
+            const auto bindings_removed = boost::copy_range<std::vector<utility::string_t>>(
+                nmos::fields::interface_bindings(resource->data) | boost::adaptors::transformed([](const web::json::value& binding)
+            {
+                return binding.as_string();
+            }));
+
             // erase connection resource
 
             nmos::erase_resource(connection_resources, id);
@@ -907,23 +901,9 @@ namespace nvnmos
             if (!flow_id.empty()) nmos::erase_resource(node_resources, flow_id);
             if (!source_id.empty()) nmos::erase_resource(node_resources, source_id);
 
-            // update device's deprecated senders/receivers array
-
-            nmos::modify_resource(node_resources, device_id, [&](nmos::resource& device)
-            {
-                auto& refs = nmos::types::sender == type ? nmos::fields::senders(device.data) : nmos::fields::receivers(device.data);
-                auto ref = std::find(refs.begin(), refs.end(), value::string(id));
-                if (refs.end() != ref)
-                {
-                    device.data[nmos::fields::version] = value::string(nmos::make_version());
-
-                    refs.erase(ref);
-                }
-            });
-
             // update node's interfaces
 
-            impl::update_node_interfaces(node_resources, node_id, host_interfaces, settings);
+            impl::update_node_interfaces(node_resources, node_id, { bindings_removed, {} }, {}, settings);
 
             // erase from settings
 
@@ -1944,42 +1924,21 @@ namespace nvnmos
             return interfaces;
         }
 
-        web::json::value make_connection_settings(const nmos::transport& transport, const utility::string_t& transport_file)
+        // get node interfaces from host_interfaces for interface_bindings
+        std::map<utility::string_t, nmos::node_interface> get_interfaces_for_bindings(const std::vector<utility::string_t>& interface_names, const std::vector<web::hosts::experimental::host_interface>& host_interfaces)
         {
-            using web::json::value_of;
+            if (interface_names.empty()) return {};
 
-            return value_of({
-                { nvnmos::fields::transport, transport.name },
-                { nvnmos::fields::transport_file, transport_file }
-            });
-        }
+            const auto interfaces = nmos::experimental::node_interfaces(host_interfaces);
 
-        std::map<utility::string_t, nmos::node_interface> get_interfaces(const nmos::settings& settings)
-        {
-            std::map<utility::string_t, nmos::node_interface> result;
-
-            const auto insert_interfaces = [&](const web::json::value& configs)
+            return boost::copy_range<std::map<utility::string_t, nmos::node_interface>>(interface_names | boost::adaptors::transformed([&](const utility::string_t& name)
             {
-                for (const auto& entry : configs.as_object() | boost::adaptors::map_values)
-                {
-                    if (nmos::transports::rtp != nmos::transport_base(nmos::transport{ nvnmos::fields::transport(entry) })) continue;
-
-                    for (const auto& interface : get_session_description_interfaces(sdp::parse_session_description(utility::us2s(nvnmos::fields::transport_file(entry)))))
-                    {
-                        const auto inserted = result.insert({ interface.name, interface });
-                        if (!inserted.second && inserted.first->second != interface)
-                        {
-                            throw std::invalid_argument("Conflicting x-nvnmos-iface details for interface name: " + utility::us2s(interface.name));
-                        }
-                    }
-                }
-            };
-
-            insert_interfaces(nvnmos::fields::senders(settings));
-            insert_interfaces(nvnmos::fields::receivers(settings));
-            return result;
+                const auto found = interfaces.find(name);
+                return std::make_pair(name, interfaces.end() != found ? found->second : nmos::node_interface{ {}, {}, name, {}, {} });
+            }));
         }
 
+        // look up the interface name from a transport param address via host_interfaces
         utility::string_t get_interface_name(const nmos::type& type, const web::json::value& transport_param, const std::vector<web::hosts::experimental::host_interface>& host_interfaces)
         {
             const auto& address = (nmos::types::sender == type ? nmos::fields::source_ip : nmos::fields::interface_ip)(transport_param).as_string();
@@ -1990,6 +1949,17 @@ namespace nvnmos
                     + " (provide a=x-nvnmos-iface with IS-04 interface metadata)");
             }
             return interface->name;
+        }
+
+        // make a transport settings entry for a sender/receiver
+        web::json::value make_transport_settings(const nmos::transport& transport, const utility::string_t& transport_file)
+        {
+            using web::json::value_of;
+
+            return value_of({
+                { nvnmos::fields::transport, transport.name },
+                { nvnmos::fields::transport_file, transport_file }
+            });
         }
 
         // generate repeatable ids for the node's resources
@@ -2171,59 +2141,67 @@ namespace nvnmos
             }
         }
 
-        // modify node resource if necessary to include all of the specified interfaces that currently have interface_bindings in any senders or receivers
-        void update_node_interfaces(nmos::resources& node_resources, const nmos::id& node_id, const std::vector<web::hosts::experimental::host_interface>& host_interfaces_, const nmos::settings& settings)
+        // modify node resource interfaces incrementally, maintaining interface_bindings reference counts in settings
+        void update_node_interfaces(nmos::resources& node_resources, const nmos::id& node_id, const interface_bindings_update& bindings_update, const std::map<utility::string_t, nmos::node_interface>& interfaces, nmos::settings& settings)
         {
             using web::json::value;
+
+            if (bindings_update.added.empty() && bindings_update.removed.empty()) return;
 
             auto node = nmos::find_resource(node_resources, { node_id, nmos::types::node });
             if (node_resources.end() == node) throw node_implementation_exception();
 
-            std::set<utility::string_t> interface_names;
+            auto& ref_counts = nvnmos::fields::interface_bindings(settings);
 
-            auto& by_type = node_resources.get<nmos::tags::type>();
+            std::set<utility::string_t> interface_names_to_add;
+            std::set<utility::string_t> interface_names_to_remove;
 
-            const auto senders = by_type.equal_range(nmos::details::has_data(nmos::types::sender));
-            for (auto sender = senders.first; senders.second != sender; ++sender)
+            for (const auto& name : bindings_update.removed)
             {
-                for (const auto& interface_binding : nmos::fields::interface_bindings(sender->data))
+                const auto count = web::json::field_as_integer_or{ name, 0 }(ref_counts);
+                if (count <= 1)
                 {
-                    interface_names.insert(interface_binding.as_string());
+                    interface_names_to_remove.insert(name);
+                    ref_counts.erase(name);
+                }
+                else
+                {
+                    ref_counts[name] = value::number(count - 1);
                 }
             }
 
-            const auto receivers = by_type.equal_range(nmos::details::has_data(nmos::types::receiver));
-            for (auto receiver = receivers.first; receivers.second != receiver; ++receiver)
+            for (const auto& name : bindings_update.added)
             {
-                for (const auto& interface_binding : nmos::fields::interface_bindings(receiver->data))
+                const auto count = web::json::field_as_integer_or{ name, 0 }(ref_counts);
+                if (0 == count) interface_names_to_add.insert(name);
+                ref_counts[name] = value::number(count + 1);
+            }
+
+            if (interface_names_to_add.empty() && interface_names_to_remove.empty()) return;
+
+            nmos::modify_resource(node_resources, node_id, [&](nmos::resource& node)
+            {
+                auto& node_interfaces = nmos::fields::interfaces(node.data);
+
+                for (const auto& name : interface_names_to_remove)
                 {
-                    interface_names.insert(interface_binding.as_string());
+                    const auto found = std::find_if(node_interfaces.begin(), node_interfaces.end(), [&](const value& interface)
+                    {
+                        return nmos::fields::name(interface) == name;
+                    });
+                    if (node_interfaces.end() != found) node_interfaces.erase(found);
                 }
-            }
 
-            const auto configured_interfaces = get_interfaces(settings);
-            const auto host_interfaces = nmos::experimental::node_interfaces(host_interfaces_);
-
-            const auto interfaces = nmos::make_node_interfaces(boost::copy_range<std::map<utility::string_t, nmos::node_interface>>(
-                boost::make_iterator_range(interface_names) | boost::adaptors::transformed([&](const utility::string_t& name)
+                for (const auto& name : interface_names_to_add)
                 {
-                    const auto configured = configured_interfaces.find(name);
-                    const auto host = host_interfaces.find(name);
-                    return std::make_pair(name, configured_interfaces.end() != configured ? configured->second
-                        : host_interfaces.end() != host ? host->second
-                        : nmos::node_interface{ {}, {}, name, {}, {} });
-                })
-            ));
+                    const auto found = interfaces.find(name);
+                    web::json::push_back(node_interfaces, interfaces.end() != found
+                        ? nmos::make_node_interface(found->second)
+                        : nmos::make_node_interface({ {}, {}, name, {}, {} }));
+                }
 
-            if (interfaces.as_array() != nmos::fields::interfaces(node->data))
-            {
-                nmos::modify_resource(node_resources, node_id, [&interfaces](nmos::resource& node)
-                {
-                    node.data[nmos::fields::version] = value::string(nmos::make_version());
-
-                    node.data[nmos::fields::interfaces] = interfaces;
-                });
-            }
+                node.data[nmos::fields::version] = value::string(nmos::make_version());
+            });
         }
 
         // parse an MXL flow definition (JSON) including nvnmos extensions

--- a/src/nvnmos_impl.h
+++ b/src/nvnmos_impl.h
@@ -75,6 +75,8 @@ namespace nvnmos
         const web::json::field_as_string transport_file{ U("transport_file") };
 
         const web::json::field_as_value clocks{ U("clocks") }; // object with clock names as keys
+
+        const web::json::field_as_value interface_bindings{ U("interface_bindings") }; // object with interface names as keys, reference counts as values
     }
 
     // custom SDP attributes


### PR DESCRIPTION
Smoke and scaling measurements for a single `nvnmosd` process: memory usage and
latency of gRPC lifecycle operations and IS-05 activation paths.

And a performance improvement in the update to Node `interfaces`. Also stops updating the Device `senders` and `receivers` arrays which have been deprecated since IS-04 v1.2, nine years ago...