### PR TITLE
nvnmosd: trim glibc heap after node teardown on Linux

### DIFF
--- a/doc/designs/nvnmosd/README.md
+++ b/doc/designs/nvnmosd/README.md
@@ -201,6 +201,19 @@ State is only modified through methods on `State`, all called under the daemon-w
 
 `dispatch_activation` is the only entry point reached from a libnvnmos worker thread; the others all run on the gRPC service's tokio executor. Holding the same mutex across both means the `AckActivation` handler can never observe a `pending_activations` entry that hasn't been published yet, even though the libnvnmos worker is blocked on the channel during the round-trip.
 
+#### glibc heap trim (Linux)
+
+After tearing down libnvnmos resources, glibc may retain freed pages in the process heap. `nvnmosd` optionally calls `malloc_trim(0)` to return unused heap to the kernel. Implementation lives in [`rust/nvnmosd/src/malloc_trim.rs`](../../../rust/nvnmosd/src/malloc_trim.rs); hooks run **after** the daemon mutex is released.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NVNMOSD_MALLOC_TRIM` | on (unset = enabled) | Set to `0`, `false`, `off`, or `no` to disable all trim hooks. |
+| `NVNMOSD_MALLOC_INFO` | off | Set to `1` / `true` / `on` to log full glibc `malloc_info` XML at `debug` before and after each trim. The normal `info` line logs only whether `malloc_trim` released pages (`released=true/false`). |
+
+When trim is enabled, the daemon calls `malloc_trim` after `RemoveResource`, `CloseSession`, or `RemoveNode` when the affected node has **no registered senders/receivers** — including when the node itself is torn down as part of that RPC (last session on a session-refcounted node, or `RemoveNode` on a persistent node). Trim is **not** invoked on every `RemoveResource`; only when the node's resource count drops to zero (or the node is removed).
+
+`malloc_trim` can briefly contend on glibc allocator locks (other threads may hitch) but does not hold the daemon mutex.
+
 ## Element design
 
 ### Pad config

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1128,6 +1128,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
  "nvnmos",
  "nvnmos-rpc",
  "tokio",

--- a/rust/nvnmosd/Cargo.toml
+++ b/rust/nvnmosd/Cargo.toml
@@ -32,3 +32,6 @@ anyhow.workspace = true
 clap.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"

--- a/rust/nvnmosd/src/main.rs
+++ b/rust/nvnmosd/src/main.rs
@@ -20,6 +20,7 @@
 #![allow(clippy::result_large_err)]
 
 mod log_bridge;
+mod malloc_trim;
 mod state;
 
 use std::path::PathBuf;
@@ -78,6 +79,22 @@ impl Daemon {
         // inconsistency that triggered the original panic.
         self.state.lock().expect("daemon state mutex poisoned")
     }
+
+    /// Trim when a node was removed or has no senders/receivers left.
+    fn maybe_malloc_trim(&self, node_seed: &str, via: &'static str, node_removed: bool) {
+        if !malloc_trim::trim_enabled() {
+            return;
+        }
+        let should_trim = if node_removed {
+            true
+        } else {
+            let state = self.lock_state();
+            state.resource_count_for_node(node_seed) == 0
+        };
+        if should_trim {
+            malloc_trim::run(via, node_seed);
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -121,6 +138,7 @@ impl NvnmosDaemon for Daemon {
             node_id = %outcome.node_id,
             "RemoveNode",
         );
+        self.maybe_malloc_trim(&req.node_seed, "remove_node", true);
         Ok(Response::new(Empty {}))
     }
 
@@ -181,6 +199,7 @@ impl NvnmosDaemon for Daemon {
             node_destroyed = outcome.node_destroyed,
             "CloseSession",
         );
+        self.maybe_malloc_trim(&outcome.node_seed, "close_session", outcome.node_destroyed);
         Ok(Response::new(Empty {}))
     }
 
@@ -261,6 +280,7 @@ impl NvnmosDaemon for Daemon {
             side = outcome.side.label(),
             "RemoveResource",
         );
+        self.maybe_malloc_trim(&outcome.node_seed, "remove_resource", false);
         Ok(Response::new(Empty {}))
     }
 

--- a/rust/nvnmosd/src/malloc_trim.rs
+++ b/rust/nvnmosd/src/malloc_trim.rs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Optional glibc `malloc_trim` after node teardown (Linux only).
+//!
+//! Controlled by `NVNMOSD_MALLOC_TRIM` (default on). Full `malloc_info` XML dumps
+//! are opt-in via `NVNMOSD_MALLOC_INFO=1`.
+
+use std::sync::OnceLock;
+
+const ENABLE_TOKENS: &[&str] = &["1", "true", "TRUE", "yes", "YES", "on", "ON"];
+const DISABLE_TOKENS: &[&str] = &["0", "false", "FALSE", "off", "OFF", "no", "NO"];
+
+/// How an env var is interpreted when unset vs when set to a known token.
+enum EnvDefault {
+    /// Unset → enabled; known disable tokens → disabled; anything else → enabled.
+    OptOut,
+    /// Unset → disabled; known enable tokens → enabled; anything else → disabled.
+    OptIn,
+}
+
+fn read_env_bool(name: &str, default: EnvDefault) -> bool {
+    match std::env::var(name) {
+        Ok(value) => {
+            let value = value.trim();
+            match default {
+                EnvDefault::OptOut => !DISABLE_TOKENS.contains(&value),
+                EnvDefault::OptIn => ENABLE_TOKENS.contains(&value),
+            }
+        }
+        Err(_) => matches!(default, EnvDefault::OptOut),
+    }
+}
+
+/// True unless `NVNMOSD_MALLOC_TRIM` is set to a disabling value (`0`, `false`, `off`, `no`).
+pub fn trim_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| read_env_bool("NVNMOSD_MALLOC_TRIM", EnvDefault::OptOut))
+}
+
+fn info_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| read_env_bool("NVNMOSD_MALLOC_INFO", EnvDefault::OptIn))
+}
+
+/// Run `malloc_trim` when enabled. `via` names the RPC that triggered the check
+/// (`close_session`, `remove_resource`, or `remove_node`). Safe to call from any
+/// thread; does not hold daemon state.
+pub fn run(via: &'static str, node_seed: &str) {
+    if !trim_enabled() {
+        return;
+    }
+    run_impl(via, node_seed);
+}
+
+#[cfg(target_os = "linux")]
+fn run_impl(via: &str, node_seed: &str) {
+    if info_enabled() {
+        log_malloc_info(via, "before");
+    }
+
+    // SAFETY: glibc allocator API; no Rust invariants to uphold.
+    let released = unsafe { libc::malloc_trim(0) != 0 };
+
+    if info_enabled() {
+        log_malloc_info(via, "after");
+    }
+
+    tracing::info!(
+        via,
+        node_seed,
+        released,
+        "malloc_trim"
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn log_malloc_info(via: &str, phase: &str) {
+    // SAFETY: open_memstream/malloc_info/free are standard glibc extensions.
+    unsafe {
+        let mut buf: *mut libc::c_char = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let stream = libc::open_memstream(&mut buf, &mut len);
+        if stream.is_null() {
+            tracing::warn!(via, phase, "malloc_info: open_memstream failed");
+            return;
+        }
+        if libc::malloc_info(0, stream) != 0 {
+            libc::fclose(stream);
+            libc::free(buf.cast());
+            tracing::warn!(via, phase, "malloc_info failed");
+            return;
+        }
+        libc::fclose(stream);
+        if buf.is_null() {
+            return;
+        }
+        let info = std::ffi::CStr::from_ptr(buf).to_string_lossy();
+        tracing::debug!(via, phase, malloc_info = %info, "malloc_info");
+        libc::free(buf.cast());
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_impl(_via: &str, node_seed: &str) {
+    tracing::debug!(
+        node_seed,
+        "malloc_trim skipped (not Linux)"
+    );
+}

--- a/rust/nvnmosd/src/state.rs
+++ b/rust/nvnmosd/src/state.rs
@@ -590,6 +590,14 @@ impl State {
         })
     }
 
+    /// Count live senders/receivers registered on `node_seed`.
+    pub fn resource_count_for_node(&self, node_seed: &str) -> usize {
+        self.resources
+            .values()
+            .filter(|resource| resource.node_seed == node_seed)
+            .count()
+    }
+
     /// Create a persistent Node for `seed`.
     ///
     /// Errors:


### PR DESCRIPTION
Return freed heap pages to the kernel when a node is removed or has no senders/receivers left, controlled by NVNMOSD_MALLOC_TRIM (default on). Addresses https://github.com/NVIDIA/nvnmos/pull/30#issuecomment-4634420666.