### PR TITLE
ci: pin Windows Conan profile for VS 2026 runner migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,19 @@ jobs:
 
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
+      - name: Prepare Conan profile (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # windows-2025 is migrating to Visual Studio 2026 (MSVC 195)
+          # Conan Center prebuilt binaries target MSVC 193/194.
+          # Pin MSVC 194 so conan install downloads packages instead of
+          # building from source. See actions/runner-images#14017.
+          $profile = conan profile path default
+          (Get-Content $profile) `
+            -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
+            -replace '^compiler\.version=.*$', 'compiler.version=194' |
+            Set-Content $profile
       - name: Install dependencies
         run: |
           conan install src \

--- a/.github/workflows/conan-canary.yml
+++ b/.github/workflows/conan-canary.yml
@@ -32,6 +32,15 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
+      - name: Prepare Conan profile (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $profile = conan profile path default
+          (Get-Content $profile) `
+            -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
+            -replace '^compiler\.version=.*$', 'compiler.version=194' |
+            Set-Content $profile
       - name: Install dependencies without lockfile
         id: conan_install
         run: |
@@ -101,6 +110,15 @@ jobs:
           git clone --depth 1 https://github.com/sony/nmos-cpp.git "${parent}/nmos-cpp"
       - name: Install Conan
         run: pip install conan~=2.2 && conan profile detect
+      - name: Prepare Conan profile (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $profile = conan profile path default
+          (Get-Content $profile) `
+            -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
+            -replace '^compiler\.version=.*$', 'compiler.version=194' |
+            Set-Content $profile
       - name: Install dependencies without lockfile
         id: conan_install
         run: |

--- a/README.md
+++ b/README.md
@@ -309,19 +309,23 @@ os=Linux
 ```PowerShell
 pip install conan~=2.2 --upgrade
 conan profile detect
+notepad (conan profile path default)
 ```
 
-The detected profile is displayed, along with some `WARN` messages.
-For example, the following profile has been tested.
+You may wish to edit the detected profile.
+Conan Center prebuilt binaries target MSVC 193/194, not 195 (Visual Studio 2026).
+Pin MSVC 194 so `conan install` downloads packages instead of building from source, with `compiler.version=194` and `compiler.cppstd=17`.
+
+The following settings have been tested.
 
 ```ini
 [settings]
 arch=x86_64
 build_type=Release
 compiler=msvc
-compiler.cppstd=14
+compiler.cppstd=17
 compiler.runtime=dynamic
-compiler.version=193
+compiler.version=194
 os=Windows
 ```
 


### PR DESCRIPTION
GitHub-hosted windows-2025 runners are moving to Visual Studio 2026 (compiler.version=195), which has no matching Conan Center binaries. Pin MSVC 194 and C++17 after profile detect so conan install downloads prebuilt packages instead of failing in source builds.

https://github.com/actions/runner-images/issues/14017