### PR TITLE
docker/gst-nmos-rs: add EXTRA_APT_PACKAGES build-arg for optional plugins

### DIFF
--- a/docker/gst-nmos-rs/Dockerfile
+++ b/docker/gst-nmos-rs/Dockerfile
@@ -9,25 +9,35 @@
 # Build from the repository root:
 #   docker build -f docker/gst-nmos-rs/Dockerfile -t nvnmos-gst .
 #
+# Optional extra distro packages (space-separated apt names), e.g. gst-plugins-bad/-ugly plugins:
+#   docker build -f docker/gst-nmos-rs/Dockerfile -t nvnmos-gst \
+#     --build-arg EXTRA_APT_PACKAGES="gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly" .
+#
 # Run:
 #
 #   docker run --rm -v /path/to/mxl-domain:/mxl/domain:rw nvnmos-gst \
 #     gst-launch-1.0 -e videotestsrc ! ... ! nmossink transport=mxl \
 #       daemon-uri=unix:/tmp/nvnmosd.sock mxl-domain-path=/mxl/domain node-seed=...
 
+# Base image
 ARG BASE_IMAGE=ubuntu:24.04
+
+# Build/install arguments
 ARG DEBIAN_FRONTEND=noninteractive
 ARG PIP_BREAK_SYSTEM_PACKAGES=1
 ARG CONAN_LOCKFILE=src/conan.lock
+ARG RUST_TOOLCHAIN=1.92
 
+# External sources
 ARG MXL_REPO=https://github.com/dmf-mxl/mxl.git
 ARG MXL_REF=81738a15adb55119a6855343bc1053a4389bf6df
 ARG GST_PLUGINS_RS_REPO=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
 ARG GST_PLUGINS_RS_REF=207b1f4eeef4c192696181ce2ddb69da8ff73c8a
 
-ARG RUST_TOOLCHAIN=1.92
+# Final image arguments
 ARG NVNMOS_UID=10001
 ARG NVNMOS_GID=10001
+ARG EXTRA_APT_PACKAGES=
 
 # -----------------------------------------------------------------------------
 # MXL — vcpkg + gst-mxl-rs. libmxl is built once by mxl-sys via cargo (no
@@ -247,6 +257,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG EXTRA_APT_PACKAGES
 ARG NVNMOS_UID
 ARG NVNMOS_GID
 
@@ -268,6 +279,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     gstreamer1.0-tools \
+    ${EXTRA_APT_PACKAGES} \
     && rm -rf /var/lib/apt/lists/*
 
 # nss-mdns communicates with avahi-daemon via a Unix socket at this compiled-in path.

--- a/docker/gst-nmos-rs/README.md
+++ b/docker/gst-nmos-rs/README.md
@@ -29,13 +29,21 @@ The nvnmos tree is taken from the build context (`COPY src/`, `COPY rust/` via t
 |----------|---------|-------------|
 | `BASE_IMAGE` | `ubuntu:24.04` | Base image for all stages; controls runtime compatibility. |
 | `CONAN_LOCKFILE` | `src/conan.lock` | Input lockfile for `conan install`. Pass an empty value to resolve the latest compatible graph instead. |
+| `RUST_TOOLCHAIN` | `1.92` | Rust toolchain for all Rust stages in this image. Matches [`rust/rust-toolchain.toml`](../../rust/rust-toolchain.toml); gst-plugins-rs MSRV is **1.92**. Workspace MSRV is **1.85** in [`rust/Cargo.toml`](../../rust/Cargo.toml). |
 | `MXL_REPO` | `https://github.com/dmf-mxl/mxl.git` | MXL source repository (`libmxl`, `gst-mxl-rs`). |
 | `MXL_REF` | `81738a15adb55119a6855343bc1053a4389bf6df` | Pinned MXL commit (`81738a1`, tip of `release/v1.1` at time of writing). Use a full 40-character SHA or a branch/tag name. |
 | `GST_PLUGINS_RS_REPO` | `https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git` | gst-plugins-rs source for `transport=udp2`. |
 | `GST_PLUGINS_RS_REF` | `207b1f4eeef4c192696181ce2ddb69da8ff73c8a` | Pinned gst-plugins-rs commit (`udpsrc2` landed after tag `0.15.2`). Builds `gst-plugin-udp` + `gst-plugin-rtp`. Use a full 40-character SHA or a branch/tag name. |
-| `RUST_TOOLCHAIN` | `1.92` | Rust toolchain for all Rust stages in this image. Matches [`rust/rust-toolchain.toml`](../../rust/rust-toolchain.toml); gst-plugins-rs MSRV is **1.92**. Workspace MSRV is **1.85** in [`rust/Cargo.toml`](../../rust/Cargo.toml). |
 | `NVNMOS_UID` | `10001` | Fixed runtime user UID (`nvnmos`). |
 | `NVNMOS_GID` | `10001` | Fixed runtime group GID (`nvnmos`). |
+| `EXTRA_APT_PACKAGES` | *(empty)* | Optional space-separated apt package names added in the final image stage (e.g. `gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly`). Installed to the default GStreamer plugin path. |
+
+Example with extra plugins:
+
+```bash
+docker build -f docker/gst-nmos-rs/Dockerfile -t nvnmos-gst \
+  --build-arg EXTRA_APT_PACKAGES="gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly" .
+```
 
 ## Run
 


### PR DESCRIPTION
…gins

Allow advanced users to install extra distro packages (e.g. gstreamer1.0-plugins-bad/-ugly) in the final image stage without forking the `Dockerfile`. Reorganise global `ARG` comments for clarity.