### PR TITLE
gst-nmos-rs: enrich audio essence caps with channel-mask and channel-order

### DIFF
--- a/rust/gst-nmos-rs/src/essence_caps.rs
+++ b/rust/gst-nmos-rs/src/essence_caps.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GStreamer essence caps helpers shared by the MXL (`flow_def`) and
+//! SDP transport paths.
+
+use gstreamer as gst;
+
+/// Build GStreamer essence caps from parsed transport state: optional
+/// fields are filled in where absent (audio `channel-mask` and
+/// `channel-order`; video and ANC pass through unchanged).
+///
+/// `raw_caps` is the minimal essence shape (from [`crate::flow_def::caps_from`]
+/// or SDP parse). When `rtp_caps` is supplied, audio `channel-order`
+/// is taken from the fmtp slot on the companion `application/x-rtp`
+/// caps; otherwise audio defaults use channel count (`M` / `ST` / `Uxx`).
+pub(crate) fn caps_from(raw_caps: &gst::Caps, rtp_caps: Option<&gst::Caps>) -> gst::Caps {
+    if raw_caps
+        .structure(0)
+        .is_some_and(|s| s.name() == "audio/x-raw")
+    {
+        let channel_order = rtp_caps
+            .and_then(|rtp| rtp.structure(0))
+            .and_then(channel_order_from_rtp_structure);
+        audio_caps_from(raw_caps, channel_order.as_deref())
+    } else {
+        raw_caps.clone()
+    }
+}
+
+fn audio_caps_from(caps: &gst::Caps, channel_order: Option<&str>) -> gst::Caps {
+    let Some(s) = caps.structure(0) else {
+        return caps.clone();
+    };
+    debug_assert_eq!(s.name(), "audio/x-raw");
+    let needs_mask = s.get::<gst::Bitmask>("channel-mask").is_err();
+    let needs_order = s.get::<&str>("channel-order").is_err();
+    if !needs_mask && !needs_order {
+        return caps.clone();
+    }
+    let channels = s.get::<i32>("channels").unwrap_or(1);
+    let mut out = caps.clone();
+    let out_mut = out.make_mut();
+    let Some(s) = out_mut.structure_mut(0) else {
+        return out;
+    };
+    if needs_mask {
+        if let Some(mask) = default_channel_mask(channels) {
+            s.set("channel-mask", mask);
+        }
+    }
+    if needs_order {
+        let order = channel_order
+            .map(str::to_owned)
+            .unwrap_or_else(|| default_smpte2110_channel_order(channels));
+        s.set("channel-order", &order);
+    }
+    out
+}
+
+/// Default SMPTE ST 2110-30 `channel-order` fmtp for a channel count
+/// when none is supplied: `M` for mono, `ST` for stereo, and the
+/// Undefined group `Uxx` for all other layouts (3–64 channels).
+pub(crate) fn default_smpte2110_channel_order(channels: i32) -> String {
+    match channels {
+        1 => "SMPTE2110.(M)".to_owned(),
+        2 => "SMPTE2110.(ST)".to_owned(),
+        n if (3..=64).contains(&n) => format!("SMPTE2110.(U{n:02})"),
+        _ => "SMPTE2110.(U01)".to_owned(),
+    }
+}
+
+/// Read `channel-order` from parsed `application/x-rtp` caps (the
+/// fmtp `channel-order=` slot from SDP).
+pub(crate) fn channel_order_from_rtp_structure(s: &gst::StructureRef) -> Option<String> {
+    s.get::<&str>("channel-order")
+        .ok()
+        .map(str::to_owned)
+}
+
+fn default_channel_mask(channels: i32) -> Option<gst::Bitmask> {
+    if !(1..=64).contains(&channels) {
+        return None;
+    }
+    let mask = if channels == 64 {
+        u64::MAX
+    } else {
+        (1u64 << channels) - 1
+    };
+    Some(gst::Bitmask::new(mask))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    fn init_gst() {
+        let _ = gst::init();
+    }
+
+    fn raw_audio_caps(format: &str, rate: i32, channels: i32) -> gst::Caps {
+        gst::Caps::from_str(&format!(
+            "audio/x-raw,format={format},rate={rate},channels={channels},layout=interleaved",
+        ))
+        .expect("audio caps")
+    }
+
+    #[test]
+    fn default_smpte2110_channel_order_uses_m_st_or_uxx() {
+        assert_eq!(default_smpte2110_channel_order(1), "SMPTE2110.(M)");
+        assert_eq!(default_smpte2110_channel_order(2), "SMPTE2110.(ST)");
+        assert_eq!(default_smpte2110_channel_order(3), "SMPTE2110.(U03)");
+        assert_eq!(default_smpte2110_channel_order(6), "SMPTE2110.(U06)");
+        assert_eq!(default_smpte2110_channel_order(8), "SMPTE2110.(U08)");
+    }
+
+    #[test]
+    fn caps_from_leaves_video_unchanged() {
+        init_gst();
+        let caps = gst::Caps::from_str(
+            "video/x-raw,format=UYVY,width=1920,height=1080,framerate=25/1",
+        )
+        .expect("video caps");
+        let out = caps_from(&caps, None);
+        assert_eq!(out.to_string(), caps.to_string());
+    }
+
+    #[test]
+    fn caps_from_adds_sequential_channel_mask_for_audio() {
+        init_gst();
+        let caps = raw_audio_caps("S24BE", 48_000, 6);
+        let out = caps_from(&caps, None);
+        let s = out.structure(0).expect("structure");
+        assert_eq!(
+            s.get::<gst::Bitmask>("channel-mask").unwrap(),
+            gst::Bitmask::new((1u64 << 6) - 1),
+        );
+    }
+
+    #[test]
+    fn caps_from_preserves_explicit_channel_mask() {
+        init_gst();
+        let caps = gst::Caps::from_str(
+            "audio/x-raw,format=S24BE,rate=48000,channels=6,layout=interleaved,\
+             channel-mask=(bitmask)0x000000000000000f",
+        )
+        .expect("caps");
+        let out = caps_from(&caps, None);
+        let s = out.structure(0).expect("structure");
+        assert_eq!(
+            s.get::<gst::Bitmask>("channel-mask").unwrap(),
+            caps.structure(0).unwrap().get::<gst::Bitmask>("channel-mask").unwrap(),
+        );
+    }
+}

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -136,6 +136,7 @@ use gstreamer as gst;
 
 mod daemon;
 mod domain;
+mod essence_caps;
 mod flow_def;
 mod iface;
 mod inner;

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -619,14 +619,14 @@ impl NmosSrc {
                         format,
                         transport_file,
                     } => {
-                        let advertise_caps =
-                            mxl_receiver_advertise_caps(transport_file.as_deref())?;
+                        let capssetter_caps =
+                            mxl_capssetter_caps(transport_file.as_deref())?;
                         {
                             let chain = inner::build_mxlsrc(
                                 domain_path,
                                 flow_id,
                                 *format,
-                                advertise_caps.as_ref(),
+                                capssetter_caps.as_ref(),
                             )?;
                             let settings = self.settings.lock().unwrap();
                             inner::apply_mxl_src_inner_properties(
@@ -644,13 +644,13 @@ impl NmosSrc {
                         media,
                         transport_file,
                     } => {
-                        let advertise_caps =
-                            udp_receiver_advertise_caps(transport_file.as_deref(), media);
+                        let capssetter_caps =
+                            udp_capssetter_caps(transport_file.as_deref(), media);
                         {
                             let chain = inner::build_udpsrc(
                                 media,
                                 *variant,
-                                advertise_caps.as_ref(),
+                                capssetter_caps.as_ref(),
                             )?;
                             let settings = self.settings.lock().unwrap();
                             inner::apply_udp_src_inner_properties(
@@ -663,16 +663,9 @@ impl NmosSrc {
                             chain.bin
                         }
                     }
-                    TransportConfig::NvDsUdp {
-                        media,
-                        transport_file,
-                    } => {
-                        let caps = nvdsudp_receiver_caps(
-                            transport_file.as_deref(),
-                            media,
-                        );
+                    TransportConfig::NvDsUdp { media, .. } => {
                         {
-                            let chain = inner::build_nvdsudpsrc(media, &caps)?;
+                            let chain = inner::build_nvdsudpsrc(media, &media.raw_caps)?;
                             let settings = self.settings.lock().unwrap();
                             inner::apply_nvdsudp_src_inner_properties(
                                 &CAT,
@@ -887,7 +880,7 @@ impl NmosSrc {
             InnerConfig::Real(TransportConfig::Mxl {
                 domain_path, flow_id, format, transport_file,
             }) => {
-                let advertise_caps = match mxl_receiver_advertise_caps(transport_file.as_deref()) {
+                let capssetter_caps = match mxl_capssetter_caps(transport_file.as_deref()) {
                     Ok(c) => c,
                     Err(e) => {
                         return ActivationOutcome::Failed {
@@ -898,7 +891,7 @@ impl NmosSrc {
                     }
                 };
                 let settings = self.settings.lock().unwrap();
-                match inner::build_mxlsrc(domain_path, flow_id, *format, advertise_caps.as_ref()) {
+                match inner::build_mxlsrc(domain_path, flow_id, *format, capssetter_caps.as_ref()) {
                     Ok(chain) => {
                         inner::apply_mxl_src_inner_properties(
                             &CAT,
@@ -921,10 +914,10 @@ impl NmosSrc {
                 media,
                 transport_file,
             }) => {
-                let advertise_caps =
-                    udp_receiver_advertise_caps(transport_file.as_deref(), media);
+                let capssetter_caps =
+                    udp_capssetter_caps(transport_file.as_deref(), media);
                 let settings = self.settings.lock().unwrap();
-                match inner::build_udpsrc(media, *variant, advertise_caps.as_ref()) {
+                match inner::build_udpsrc(media, *variant, capssetter_caps.as_ref()) {
                     Ok(chain) => {
                         inner::apply_udp_src_inner_properties(
                             &CAT,
@@ -942,13 +935,9 @@ impl NmosSrc {
                     }
                 }
             }
-            InnerConfig::Real(TransportConfig::NvDsUdp {
-                media,
-                transport_file,
-            }) => {
-                let caps = nvdsudp_receiver_caps(transport_file.as_deref(), media);
+            InnerConfig::Real(TransportConfig::NvDsUdp { media, .. }) => {
                 let settings = self.settings.lock().unwrap();
-                match inner::build_nvdsudpsrc(media, &caps) {
+                match inner::build_nvdsudpsrc(media, &media.raw_caps) {
                     Ok(chain) => {
                         inner::apply_nvdsudp_src_inner_properties(
                             &CAT,
@@ -1041,23 +1030,18 @@ fn install_initial_fake_chain(bin: &gst::Bin) -> Result<gst::GhostPad, glib::Boo
     Ok(ghost)
 }
 
-/// Reverse-map a resolved transport file into essence caps that
-/// the bin should advertise on its ghost src pad. `None` is
-/// returned when no transport file is in play (the fake chain is
-/// in use until an IS-05 activation supplies one); the caller then
-/// builds a bare `mxlsrc` whose broad pad template propagates.
-fn derive_advertise_caps(
+/// Flow-def transport file → enriched essence caps (for capssetter / fake chain).
+fn caps_from_flow_def(
     transport_file: Option<&str>,
 ) -> Result<Option<gst::Caps>, anyhow::Error> {
     let Some(text) = transport_file.filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
-    let caps = crate::flow_def::caps_from(text).map_err(|e| {
-        anyhow::anyhow!(
-            "deriving essence caps from transport file for ghost-pad advertisement: {e}",
-        )
+    let raw_caps = crate::flow_def::caps_from(text).map_err(|e| {
+        anyhow::anyhow!("caps from flow-def transport file: {e}")
     })?;
-    gst::info!(CAT, "nmossrc: advertising caps `{caps}` from transport file");
+    let caps = crate::essence_caps::caps_from(&raw_caps, None);
+    gst::info!(CAT, "nmossrc: caps `{caps}` from transport file");
     Ok(Some(caps))
 }
 
@@ -1078,53 +1062,46 @@ fn intermediate_fake_src_caps(
 ) -> Result<Option<gst::Caps>, anyhow::Error> {
     match &plan.inner {
         InnerConfig::Real(TransportConfig::Mxl { transport_file, .. }) => {
-            if mxl_receiver_skips_capssetter(transport_file.as_deref()) {
-                Ok(None)
-            } else {
-                mxl_receiver_advertise_caps(transport_file.as_deref())
-            }
+            mxl_capssetter_caps(transport_file.as_deref())
         }
         InnerConfig::Real(TransportConfig::Udp {
             transport_file,
             media,
             ..
-        }) => Ok(udp_receiver_advertise_caps(transport_file.as_deref(), media)),
+        }) => Ok(udp_capssetter_caps(transport_file.as_deref(), media)),
         InnerConfig::Real(TransportConfig::NvDsUdp { media, .. }) => {
-            Ok(Some(nvdsudp_receiver_caps(None, media)))
+            // No capssetter hop on nvdsudp — essence caps are set on nvdsudpsrc.
+            Ok(Some(media.raw_caps.clone()))
         }
         _ => fake_caps_from_settings(snapshot),
     }
 }
 
-/// True when the MXL receiver inner chain should omit `capssetter` and
-/// use bare `mxlsrc` so runtime caps come from the filesystem flow.
-/// Reads the wide caps tag from the effective configuring transport file
-/// (post-splice at NULL→READY, or the daemon activation file).
-fn mxl_receiver_skips_capssetter(transport_file: Option<&str>) -> bool {
-    transport_file
-        .filter(|s| !s.is_empty())
-        .and_then(|text| {
-            crate::flow_def::indicates_wide_receiver_caps(text)
-                .map_err(|e| {
-                    gst::warning!(
-                        CAT,
-                        "nmossrc: could not read wide caps tag from transport file \
-                         for inner-chain decision: {e:#}",
-                    );
-                })
-                .ok()
+/// Whether an MXL `flow_def` transport file carries the wide Receiver
+/// Caps tag (`urn:x-nvnmos:tag:caps`). Mirrors
+/// [`crate::sdp::indicates_wide_receiver_caps`] for SDP.
+fn mxl_indicates_wide_receiver_caps(text: &str) -> bool {
+    crate::flow_def::indicates_wide_receiver_caps(text)
+        .map_err(|e| {
+            gst::warning!(
+                CAT,
+                "nmossrc: could not read wide caps tag from transport file: {e:#}",
+            );
         })
         .unwrap_or(false)
 }
 
-/// MXL receiver inner-chain caps advertisement. When the effective
-/// transport file indicates wide Receiver Caps, omit `capssetter` so
-/// runtime caps come from the filesystem flow via `mxlsrc`; otherwise
-/// pin configuring essence caps from the same file.
-fn mxl_receiver_advertise_caps(
+/// Caps for the optional MXL inner `capssetter`. When the effective
+/// transport file indicates wide Receiver Caps, return `None` so runtime
+/// caps come from the filesystem flow via bare `mxlsrc`; otherwise pin
+/// configuring essence caps from the same file.
+fn mxl_capssetter_caps(
     transport_file: Option<&str>,
 ) -> Result<Option<gst::Caps>, anyhow::Error> {
-    if mxl_receiver_skips_capssetter(transport_file) {
+    if transport_file
+        .filter(|s| !s.is_empty())
+        .is_some_and(mxl_indicates_wide_receiver_caps)
+    {
         gst::debug!(
             CAT,
             "nmossrc: wide MXL receiver — bare mxlsrc (no capssetter); \
@@ -1132,25 +1109,15 @@ fn mxl_receiver_advertise_caps(
         );
         return Ok(None);
     }
-    derive_advertise_caps(transport_file)
+    caps_from_flow_def(transport_file)
 }
 
-/// UDP receiver inner-chain caps advertisement. When the effective
+/// Caps for the optional UDP inner `capssetter`. When the effective
 /// transport file (activation SDP from libnvnmos, or the post-splice
-/// configuring SDP) carries `a=x-nvnmos-caps:`, omit `capssetter` so
-/// runtime caps come from the live RTP flow; otherwise pin essence
+/// configuring SDP) carries `a=x-nvnmos-caps:`, return `None` so
+/// runtime caps come from the live RTP depay; otherwise pin essence
 /// caps parsed from the same SDP.
-/// Essence caps for `nvdsudpsrc.caps` (Mode 3). Always uses
-/// [`UdpMedia::raw_caps`] — wide receivers still need explicit
-/// essence caps on the Rivermax source.
-fn nvdsudp_receiver_caps(
-    _transport_file: Option<&str>,
-    media: &crate::session::udp::types::UdpMedia,
-) -> gst::Caps {
-    media.raw_caps.clone()
-}
-
-fn udp_receiver_advertise_caps(
+fn udp_capssetter_caps(
     transport_file: Option<&str>,
     media: &crate::session::udp::types::UdpMedia,
 ) -> Option<gst::Caps> {
@@ -1188,7 +1155,7 @@ fn fake_caps_from_settings(
         return Ok(Some(caps.clone()));
     }
     if !settings.transport_file.is_empty() {
-        return derive_advertise_caps(Some(&settings.transport_file));
+        return caps_from_flow_def(Some(&settings.transport_file));
     }
     if !settings.transport_file_path.is_empty() {
         let text = std::fs::read_to_string(&settings.transport_file_path).map_err(|e| {
@@ -1197,7 +1164,7 @@ fn fake_caps_from_settings(
                 settings.transport_file_path
             )
         })?;
-        return derive_advertise_caps(Some(&text));
+        return caps_from_flow_def(Some(&text));
     }
     Ok(None)
 }
@@ -1310,7 +1277,7 @@ mod tests {
     }
 
     #[test]
-    fn mxl_wide_receiver_skips_capssetter_advertise_caps() {
+    fn mxl_wide_receiver_skips_capssetter() {
         use crate::flow_def::{FlowDefOverrides, splice_overrides};
         use crate::types::CapsMode;
         let _ = gst::init();
@@ -1338,19 +1305,19 @@ mod tests {
         )
         .expect("wide splice");
         assert!(
-            mxl_receiver_advertise_caps(Some(&spliced_wide))
+            mxl_capssetter_caps(Some(&spliced_wide))
                 .unwrap()
                 .is_none(),
             "post-splice wide transport file must skip capssetter",
         );
         assert!(
-            mxl_receiver_advertise_caps(Some(wide_file))
+            mxl_capssetter_caps(Some(wide_file))
                 .unwrap()
                 .is_none(),
             "activation/configuring file with wide caps tag must skip capssetter",
         );
         assert!(
-            mxl_receiver_advertise_caps(Some(narrow_file))
+            mxl_capssetter_caps(Some(narrow_file))
                 .unwrap()
                 .is_some(),
             "narrow transport file still uses capssetter",
@@ -1364,7 +1331,7 @@ mod tests {
         )
         .expect("narrow splice");
         assert!(
-            mxl_receiver_advertise_caps(Some(&spliced_narrow))
+            mxl_capssetter_caps(Some(&spliced_narrow))
                 .unwrap()
                 .is_some(),
             "post-splice narrow transport file must use capssetter",
@@ -1372,7 +1339,7 @@ mod tests {
     }
 
     #[test]
-    fn udp_wide_receiver_skips_capssetter_advertise_caps() {
+    fn udp_wide_receiver_skips_capssetter() {
         let _ = gst::init();
         const NARROW_SDP: &str = concat!(
             "v=0\r\n",
@@ -1398,11 +1365,11 @@ mod tests {
         let narrow_media = crate::sdp::parse_sdp(NARROW_SDP).expect("parse narrow");
         let wide_media = crate::sdp::parse_sdp(WIDE_SDP).expect("parse wide");
         assert!(
-            udp_receiver_advertise_caps(Some(NARROW_SDP), &narrow_media).is_some(),
+            udp_capssetter_caps(Some(NARROW_SDP), &narrow_media).is_some(),
             "narrow SDP must pin capssetter",
         );
         assert!(
-            udp_receiver_advertise_caps(Some(WIDE_SDP), &wide_media).is_none(),
+            udp_capssetter_caps(Some(WIDE_SDP), &wide_media).is_none(),
             "wide SDP (a=x-nvnmos-caps) must skip capssetter",
         );
     }

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -525,6 +525,7 @@ fn parse_media_essence(msg: &SDPMessage, media: &SDPMediaRef) -> Result<ParsedMe
             "format dispatch above never produces FlowFormat::Unspecified"
         ),
     };
+    let raw_caps = crate::essence_caps::caps_from(&raw_caps, Some(&rtp_caps));
 
     Ok(ParsedMediaEssence {
         format,
@@ -1364,7 +1365,17 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         FlowFormat::Audio => {
             let (ptime_ns, maxptime_ns) = resolve_audio_ptime(input.transport_caps);
             let resolved = resolved_audio_caps(input.essence_caps, input.transport_caps)?;
-            rtp_caps_from_raw_audio(&resolved, payload_type, ptime_ns, maxptime_ns)?
+            let channel_order = input
+                .transport_caps
+                .and_then(|c| c.structure(0))
+                .and_then(crate::essence_caps::channel_order_from_rtp_structure);
+            rtp_caps_from_raw_audio(
+                &resolved,
+                payload_type,
+                ptime_ns,
+                maxptime_ns,
+                channel_order.as_deref(),
+            )?
         }
         FlowFormat::Data => rtp_caps_from_raw_data(input.essence_caps, payload_type)?,
         FlowFormat::Unspecified => {
@@ -1372,12 +1383,14 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         }
     };
 
+    let raw_caps = crate::essence_caps::caps_from(input.essence_caps, Some(&rtp_caps));
+
     let media = UdpMedia {
         format,
         primary: udp_leg_from_input(input),
         secondary: None,
         rtp_caps,
-        raw_caps: input.essence_caps.clone(),
+        raw_caps,
     };
 
     let origin_address = if input.interface_ip.is_empty() {
@@ -2154,6 +2167,7 @@ fn rtp_caps_from_raw_audio(
     payload_type: u8,
     ptime_ns: u64,
     maxptime_ns: Option<u64>,
+    channel_order: Option<&str>,
 ) -> Result<gst::Caps, SdpError> {
     let s = raw_caps
         .structure(0)
@@ -2192,8 +2206,16 @@ fn rtp_caps_from_raw_audio(
         let maxptime = format_ptime_ns_as_ms(max);
         caps_text.push_str(&format!(",a-maxptime=(string){maxptime}"));
     }
-    gst::Caps::from_str(&caps_text)
-        .map_err(|e| SdpError::UnsupportedEssence(format!("constructing rtp caps: {e}")))
+    let mut caps = gst::Caps::from_str(&caps_text)
+        .map_err(|e| SdpError::UnsupportedEssence(format!("constructing rtp caps: {e}")))?;
+    let order = channel_order
+        .map(str::to_owned)
+        .unwrap_or_else(|| crate::essence_caps::default_smpte2110_channel_order(channels));
+    let caps_mut = caps.make_mut();
+    if let Some(s) = caps_mut.structure_mut(0) {
+        s.set("channel-order", &order);
+    }
+    Ok(caps)
 }
 
 /// Build an `application/x-rtp,...` caps describing an RFC 8331 /
@@ -2820,6 +2842,11 @@ mod tests {
             "0.125",
             "ptime rides on rtp caps as `a-ptime` for the depayloader and SDP round-trip",
         );
+        assert_eq!(
+            rtp_s.get::<&str>("channel-order").unwrap(),
+            "SMPTE2110.(ST)",
+            "fmtp channel-order lands on rtp caps from parse",
+        );
 
         let raw_s = media.raw_caps.structure(0).expect("raw caps");
         assert_eq!(raw_s.name().as_str(), "audio/x-raw");
@@ -2827,6 +2854,15 @@ mod tests {
         assert_eq!(raw_s.get::<i32>("rate").unwrap(), 48_000);
         assert_eq!(raw_s.get::<i32>("channels").unwrap(), 2);
         assert_eq!(raw_s.get::<&str>("layout").unwrap(), "interleaved");
+        assert!(
+            raw_s.get::<gst::Bitmask>("channel-mask").is_ok(),
+            "parse path adds a default channel-mask for downstream elements",
+        );
+        assert_eq!(
+            raw_s.get::<&str>("channel-order").unwrap(),
+            "SMPTE2110.(ST)",
+            "fmtp channel-order is copied onto audio/x-raw for payloader/depayloader",
+        );
         assert!(
             raw_s.get::<&str>("ptime").is_err() && raw_s.get::<&str>("a-ptime").is_err(),
             "ptime must not leak onto audio/x-raw caps",
@@ -4539,7 +4575,7 @@ mod tests {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None).expect("synth");
+            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "audio");
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "L24");
@@ -4558,7 +4594,7 @@ mod tests {
         init_gst();
         let raw = raw_audio_caps("S16BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None).expect("synth");
+            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "L16");
     }
@@ -4567,7 +4603,7 @@ mod tests {
     fn rtp_caps_from_raw_audio_emits_decimal_ptime_for_sub_millisecond() {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
-        let rtp = rtp_caps_from_raw_audio(&raw, 97, 125_000, None).expect("synth");
+        let rtp = rtp_caps_from_raw_audio(&raw, 97, 125_000, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(
             s.get::<&str>("a-ptime").unwrap(),
@@ -4581,7 +4617,7 @@ mod tests {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, Some(4_000_000))
+            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, Some(4_000_000), None)
                 .expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("a-maxptime").unwrap(), "4");
@@ -4592,7 +4628,7 @@ mod tests {
         init_gst();
         let raw = raw_audio_caps("S32LE", 48_000, 2);
         let err =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None).expect_err("reject");
+            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect_err("reject");
         assert!(matches!(err, SdpError::UnsupportedEssence(ref m) if m.contains("S32LE")));
     }
 
@@ -4601,14 +4637,35 @@ mod tests {
         init_gst();
         let original = raw_audio_caps("S24BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&original, 97, defaults::AUDIO_PTIME_NS, None).expect("synth");
-        let round_tripped = raw_caps_from_rtp_audio(&rtp).expect("parse back");
+            rtp_caps_from_raw_audio(&original, 97, defaults::AUDIO_PTIME_NS, None, None)
+                .expect("synth");
+        let round_tripped = crate::essence_caps::caps_from(
+            &raw_caps_from_rtp_audio(&rtp).expect("parse back"),
+            Some(&rtp),
+        );
         let rt = round_tripped.structure(0).expect("rt raw");
         let orig = original.structure(0).expect("orig");
         assert_eq!(rt.name(), orig.name());
         assert_eq!(rt.get::<&str>("format"), orig.get::<&str>("format"));
         assert_eq!(rt.get::<i32>("rate"), orig.get::<i32>("rate"));
         assert_eq!(rt.get::<i32>("channels"), orig.get::<i32>("channels"));
+        assert!(
+            rt.get::<gst::Bitmask>("channel-mask").is_ok(),
+            "round-trip parse adds default channel-mask",
+        );
+    }
+
+    #[test]
+    fn rtp_caps_from_raw_audio_emits_default_channel_order_for_six_channels() {
+        init_gst();
+        let raw = raw_audio_caps("S24BE", 48_000, 6);
+        let rtp =
+            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
+        let s = rtp.structure(0).expect("rtp");
+        assert_eq!(
+            s.get::<&str>("channel-order").unwrap(),
+            "SMPTE2110.(U06)",
+        );
     }
 
     // -- rtp_caps_from_raw_data
@@ -4989,6 +5046,10 @@ mod tests {
         assert!(text.contains("m=audio 5004 RTP/AVP 97"));
         assert!(text.contains("a=rtpmap:97 L24/48000/2"));
         assert!(text.contains("a=ptime:1"), "default 1ms ptime:\n{text}");
+        assert!(
+            text.contains("channel-order=SMPTE2110.(ST)"),
+            "synthesised stereo SDP must include default channel-order:\n{text}",
+        );
         assert!(
             !text.contains("a=maxptime"),
             "maxptime omitted when unset:\n{text}",


### PR DESCRIPTION
Add essence_caps module for shared audio `channel-mask` and `channel-order` defaults at SDP parse and `UdpMedia` build time.

Also rename MXL/UDP inner `capssetter` helpers to `mxl_capssetter_caps` and `udp_capssetter_caps` (nvdsudp sets essence directly on `nvdsudpsrc` with no `capssetter` hop).
