### PR TITLE
gst-nmos-rs: add RTP deferred sender registration

### DIFF
--- a/doc/designs/gst-nmos-rs-nvdsudp-plan.md
+++ b/doc/designs/gst-nmos-rs-nvdsudp-plan.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # `gst-nmos-rs` — `transport=nvdsudp` (DeepStream `nvdsudpsrc` / `nvdsudpsink`)
 
-Design and implementation record for Phase 2 of the NMOS daemon + GStreamer plugin work: `nmossrc` / `nmossink` wired to DeepStream's Rivermax-backed `nvdsudp*` elements when `transport=nvdsudp`. The software path is landed in `gst-nmos-rs`; Rivermax hardware soak remains outstanding. This document is scoped to that increment only; it assumes Phase 1 (`mxl`, anchor + block-probe chain swap, `transport-properties`, OSS `udp` / `udp2`) is already landed.
+Design and implementation record for Phase 2 of the NMOS daemon + GStreamer plugin work: `nmossrc` / `nmossink` wired to DeepStream's Rivermax-backed `nvdsudp*` elements when `transport=nvdsudp`. The software path is landed in `gst-nmos-rs`; Rivermax hardware soak remains outstanding. This document is scoped to that increment only; it assumes Phase 1 (`mxl`, anchor + block-probe chain swap, `transport-properties`, `udp` / `udp2`) is already landed.
 
 Parent context: [`nvnmosd/README.md`](nvnmosd/README.md) (architecture, transport table, essence-on-pad contract), [`gst-nmos-rs-inner-properties-plan.md`](gst-nmos-rs-inner-properties-plan.md) (`transport-properties` lifecycle).
 
@@ -56,7 +56,7 @@ Proto mapping treats `NvDsUdp` as RTP (`transport_to_proto` → `ProtoTransport:
 
 ### Topology
 
-Unlike OSS UDP, there is **no wrapper sub-bin with a payloader/depayloader**. Each side is depth-1, analogous to MXL:
+Unlike the GStreamer RTP/UDP plugins, there is **no wrapper sub-bin with a payloader/depayloader**. Each side is depth-1, analogous to MXL:
 
 ```text
 nmossink ghost(sink) → anchor → nvdsudpsink
@@ -161,7 +161,7 @@ From SDP / caps:
 4. `src.header-size = 12`
 5. `src.payload-multiple`: default to `max(1, round(16 ms / ptime_ms))` (16 ms buffer cadence from 2ch/48k example) unless user overrides in `transport-properties`.
 
-Supported formats: `S24BE` (L24), `S16BE` (L16) — matching current OSS UDP scope.
+Supported formats: `S24BE` (L24), `S16BE` (L16) — matching current scope with the GStreamer RTP/UDP plugins.
 
 ### ANC / ST 2110-40
 
@@ -171,7 +171,7 @@ uses `m=video` + `encoding-name=SMPTE291` per RFC 8331. Auto packetization:
 `header-size=20` on `nvdsudpsrc` only (HDS for RFC 8331); ANC RTP packet sizes
 are variable — `payload-size` is left at plugin defaults. No `packets-per-line`.
 GPU Direct is disabled for ANC in the plugin. Override via
-`transport-properties` when needed. OSS `udp` / `udp2` use `rtpsmpte291pay` /
+`transport-properties` when needed. `udp` / `udp2` use `rtpsmpte291pay` /
 `rtpsmpte291depay` from `gst-plugins-rs`.
 
 ### Interaction with `transport-properties`
@@ -197,7 +197,7 @@ If user pre-sets `payload-size` / `packets-per-line` in `transport-properties`, 
 
 When building SDP from caps (`from_caps`), set:
 
-- `TP=2110TPN` (narrow traffic profile) — parent design and `sdp.rs` comment; today omitted for OSS transports.
+- `TP=2110TPN` (narrow traffic profile) — parent design and `sdp.rs` comment; today omitted for `udp` / `udp2` transports.
 - Keep `PM=2110GPM`, `SSN=…`, `colorimetry`, etc. as today.
 
 Cross-check `caps` vs `transport-file` unchanged.
@@ -234,7 +234,7 @@ At `validate_and_open` (NULL→READY), after config resolution:
 ensure_factory("nvdsudpsink") // or nvdsudpsrc on nmossrc
 ```
 
-Clear error: install DeepStream gst-nvdsudp plugin + Rivermax SDK; ConnectX-5+; `CAP_NET_RAW` on the host binary. Do **not** silently fall back to OSS `udp`.
+Clear error: install DeepStream gst-nvdsudp plugin + Rivermax SDK; ConnectX-5+; `CAP_NET_RAW` on the host binary. Do **not** silently fall back to `udp` / `udp2`.
 
 ### `nmossink/imp.rs` / `nmossrc/imp.rs`
 
@@ -303,7 +303,7 @@ Implemented as `gst-nmos-rs: implement transport=nvdsudp via DeepStream Mode 3`:
 - `factory_find_nvdsudpsink` — skip if not installed.
 - `build_nvdsudpsink_sets_host_port_local_iface` — read back GObject properties.
 - `nmossink_nvdsudp_transport_properties_roundtrip` — `buffer-size` or `gpu-id` if set.
-- `activation_single_leg_video` — `nmossink` + `nmossrc`, IS-05 PATCH, essences match OSS smoke layout but `transport=nvdsudp`.
+- `activation_single_leg_video` — `nmossink` + `nmossrc`, IS-05 PATCH, essences match `udp` / `udp2` smoke layout but `transport=nvdsudp`.
 - `receiver_use_rtp_timestamp_default` — read back from built `nvdsudpsrc`.
 
 ### Manual soak (Rivermax host)

--- a/doc/designs/nvnmosd/README.md
+++ b/doc/designs/nvnmosd/README.md
@@ -218,7 +218,7 @@ When trim is enabled, the daemon calls `malloc_trim` after `RemoveResource`, `Cl
 
 ### Pad config
 
-The `nmossrc`/`nmossink` elements expose **essence** on their external pads (`video/x-raw`, `audio/x-raw`, `meta/x-st-2038`), never the wire form. Depayloaders / payloaders are added internally when needed (for `udpsrc` / `udpsink` paths); for `mxlsrc`/`mxlsink` and `nvdsudpsrc`/`nvdsudpsink` no extra (de)payloader is needed because those inner elements already operate on essence buffers. The choice of wire transport is something the element *configures*, not something it exposes — so a `gst-launch-1.0` user sees the same essence-shaped pad regardless of whether the inner chain is MXL, RTP via Rivermax, or RTP via OSS.
+The `nmossrc`/`nmossink` elements expose **essence** on their external pads (`video/x-raw`, `audio/x-raw`, `meta/x-st-2038`), never the wire form. Depayloaders / payloaders are added internally when needed (for `udpsrc` / `udpsink` paths); for `mxlsrc`/`mxlsink` and `nvdsudpsrc`/`nvdsudpsink` no extra (de)payloader is needed because those inner elements already operate on essence buffers. The choice of wire transport is something the element *configures*, not something it exposes — so a `gst-launch-1.0` user sees the same essence-shaped pad regardless of whether the inner chain is MXL, RTP via Rivermax, or RTP via GStreamer RTP/UDP plugins.
 
 #### Connection / Node
 
@@ -235,7 +235,7 @@ Each value names the inner GStreamer element family the user is signing up for, 
 |---|---|---|---|---|
 | `mxl` | `mxlsrc` | `mxlsink` | 1 | MXL shared-memory; requires `mxl-domain-id`. |
 | `nvdsudp` | `nvdsudpsrc` | `nvdsudpsink` | 2 | RFC 4175 / ST 2110 via the DeepStream `nvdsudp*` elements (built on Rivermax SDK); high-precision packet pacing. Required for ST 2022-7. |
-| `udp` | `udpsrc` + `rtp*depay` | `rtp*pay` + `udpsink` | 3 | RFC 4175 / ST 2110 via OSS GStreamer `udp*` + RTP (de)payloaders; no perfect pacing. Cannot support ST 2022-7. |
+| `udp` | `udpsrc` + `rtp*depay` | `rtp*pay` + `udpsink` | 3 | RFC 4175 / ST 2110 via GStreamer RTP/UDP plugins; no perfect pacing. Cannot support ST 2022-7. |
 
 Required property on both `nmossrc` and `nmossink`. The element refuses an unsupported transport value with a clear error at element-construction time. The `transport` value also gates which per-transport defaults the element applies (notably `TP=2110TPN` for `nvdsudp` vs `TP=2110TPW` for `udp`, per *Defaults the element synthesises*).
 
@@ -277,7 +277,7 @@ For RTP, the element fills the SDP from essence caps + per-format defaults + per
 - **`colorimetry`** — from `video/x-raw, colorimetry=` if present (mapped to the ST 2110 form, e.g. `bt709` → `BT709`); otherwise `BT709`.
 - **`PM` (Packing Mode)** — `2110GPM`. `2110BPM` requires explicit override.
 - **`SSN`** — by essence: `ST2110-20:2017` / `ST2110-30:2017` / `ST2110-40:2018` / `ST2110-22:2022`.
-- **`TP` (Traffic Profile)** — by `transport`: `nvdsudp` (Rivermax-paced) → `2110TPN` (narrow); `udp` (OSS) → `2110TPW` (wide).
+- **`TP` (Traffic Profile)** — by `transport`: `nvdsudp` (Rivermax-paced) → `2110TPN` (narrow); `udp` / `udp2` → `2110TPW` (wide).
 
 For MXL the per-format mapping to `flow_def.json` is derivable from essence caps in the same way; `transport-caps` is essentially unused.
 
@@ -324,7 +324,7 @@ gst-launch-1.0 \
 
 (`caps` not strictly required here — upstream caps from the `videotestsrc!filter` already specify v210 1080p30000/1001, and deferred mode picks them up at READY → PAUSED.)
 
-A minimal RTP sender via OSS `udpsink` — no `transport-caps` needed, the element synthesises the SDP from upstream caps and defaults:
+A minimal RTP sender via `udpsink` — no `transport-caps` needed, the element synthesises the SDP from upstream caps and defaults:
 
 ```bash
 gst-launch-1.0 \
@@ -413,7 +413,7 @@ Our design separates these problems by phase rather than trying to solve them al
 
 - **Phase 1 (MXL).** Problem (B) probably doesn't apply — `mxlsrc` reads from MXL shared memory and is not (we expect) the providing clock for the pipeline. We can avoid pausing the top-level pipeline entirely, and the workflow reduces to: divert via input-selector → flush-start downstream → lock-state + NULL the inner mxlsrc → (re)build for the new MXL flow → unlock-state + sync-state-with-parent → switch input-selector → flush-stop. The two MR fixes (locked-state on disable; downstream flush dance) are adopted from day one. If `mxlsrc` supports switching the flow id at runtime via a `GST_PARAM_MUTABLE_PLAYING` property, we may be able to skip the tear-down step entirely; that's an `mxlsrc` capability check, not a design choice for `nmossrc`.
 - **Phase 2 (`nvdsudpsrc`).** Problem (B) may return when `use-rtp-timestamp` makes `nvdsudpsrc` the pipeline clock provider. The `nvdsudp` software path is landed; the open design question is whether pausing the top-level pipeline stays inside `nmossrc` (matching the prior art) or moves up the stack to somewhere with a global view of which receivers share a pipeline — defer until Rivermax hardware soak.
-- **Phase 3+ (OSS `udpsrc` payloaders).** Lighter clock-provider story than `nvdsudpsrc`; revisit whether (B) applies on a case-by-case basis.
+- **Phase 3+ (`udpsrc` + depayloaders).** Lighter clock-provider story than `nvdsudpsrc`; revisit whether (B) applies on a case-by-case basis.
 
 **Will multi-element composition change the calculus?** Possibly, and worth flagging explicitly. In `nvdsnmosbin` all receivers are pads on one bin, so they unavoidably share a top-level pipeline — `find_top_level_pipeline` always lands on the user's pipeline and the pause/resume blast radius is fixed by that topology. With independent `nmossrc` elements the application *chooses* the blast radius:
 
@@ -474,17 +474,17 @@ A `timestamp-mode` property (passthrough vs. regenerated wire timestamps) was sk
 
 - **Phase 0 — Daemon + test client**. Build the foundation: `nvnmos-sys` (FFI bindings to `libnvnmos`), `nvnmos-rpc` (proto + generated stubs), and `nvnmosd` itself. The Phase 0 daemon is **Linux-first**, supports **multi-Node**, uses **UDS for local IPC (plain TCP `localhost` as a portable fallback)**, and implements **`SyncResourceState`** from the start — real (non-gst-launch) clients will need the out-of-band data-plane sync path, and bolting it on later complicates the daemon's threading model. Alongside the daemon, build a **Rust test client modelled on the existing `nvnmos-example`** (the C app in `src/main.c`): opens a session, registers a few MXL and RTP senders/receivers, drives through the same interactive stages (remove some, add back, observe activations, deactivate, destroy session), and exercises `OpenSession` / `AddSender` / `AddReceiver` / `SubscribeActivations` / `AckActivation` / `SyncResourceState` end-to-end. This proves the daemon works without GStreamer in the loop, and gives us a regression harness for every subsequent phase. (A C++ test client could be added later but isn't part of Phase 0. Cross-host TCP + TLS and Windows/macOS daemon targets are deferred to Phase N.)
 - **Phase 1 — MXL (all essences)**: `nmossrc` + `nmossink` for the full set of MXL flows `gst-mxl-rs` already supports — `video/x-raw` v210, `audio/x-raw` F32LE, and `meta/x-st-2038` ANC (what MXL flow_def.json calls `video/smpte291`). Single Node, gst-launch demoable. No nvdsudp involvement (so no Rivermax requirement). All three routes from the Pad config section are live (`transport-file`, property route, deferred mode on `nmossink`); `transport-caps` is typically empty for MXL.
-- **Phase 2 — ST 2110 via nvdsudp** (**software landed** in `gst-nmos-rs`; Rivermax hardware soak outstanding): ST 2110-20 video, ST 2110-30 audio, and ST 2110-40 ANC (`meta/x-st-2038`) via DeepStream `nvdsudpsrc` / `nvdsudpsink` Mode 3 (`transport=nvdsudp`). OSS `udp` / `udp2` ANC uses `rtp*pay` / `rtp*depay`. Property-route SDP synthesis, `TP=2110TPN`, temp SDP files for `nvdsudpsink`, and IS-05 activation are implemented — see [`gst-nmos-rs-nvdsudp-plan.md`](../gst-nmos-rs-nvdsudp-plan.md). End-to-end `receiver-caps-mode=wide` renegotiation remains a follow-up.
-- **Phase 3 — OSS `udpsrc`/`udpsink`** with payloaders (**software landed**). Same NMOS surface, different inner chain.
+- **Phase 2 — ST 2110 via nvdsudp** (**software landed** in `gst-nmos-rs`; Rivermax hardware soak outstanding): ST 2110-20 video, ST 2110-30 audio, and ST 2110-40 ANC (`meta/x-st-2038`) via DeepStream `nvdsudpsrc` / `nvdsudpsink` Mode 3 (`transport=nvdsudp`). `udp` / `udp2` ANC uses `rtp*pay` / `rtp*depay`. Property-route SDP synthesis, `TP=2110TPN`, temp SDP files for `nvdsudpsink`, and IS-05 activation are implemented — see [`gst-nmos-rs-nvdsudp-plan.md`](../gst-nmos-rs-nvdsudp-plan.md). End-to-end `receiver-caps-mode=wide` renegotiation remains a follow-up.
+- **Phase 3 — `udpsrc`/`udpsink`** with (de)payloaders (**software landed**). Same NMOS surface, different inner chain.
 - **Phase 4 — `video/x-jxsv` (ST 2110-22)** once nvdsudp changes merge. **`video/v210a`** stub if GStreamer support is still missing.
-- **Phase 5 — ST 2022-7** redundancy (**software landed** in `gst-nmos-rs` for `transport=nvdsudp`; dual-`m=` transport-file passthrough + inner `st2022-7-streams`; not available on OSS `udp`/`udpsink` — see [`gst-nmos-rs-st2022-7-dual-leg-plan.md`](../gst-nmos-rs-st2022-7-dual-leg-plan.md)).
+- **Phase 5 — ST 2022-7** redundancy (**software landed** in `gst-nmos-rs` for `transport=nvdsudp`; dual-`m=` transport-file passthrough + inner `st2022-7-streams`; not available on `udpsink` — see [`gst-nmos-rs-st2022-7-dual-leg-plan.md`](../gst-nmos-rs-st2022-7-dual-leg-plan.md)).
 - **Phase N — deferred**: cross-host gRPC + TLS; Windows + macOS daemon targets (Phase 0 designs to keep these tractable but doesn't ship them); optional non-gRPC fallback (JSON-RPC over WebSocket) only if there's a concrete adoption blocker.
 
 ## Risks called out
 
 - **Connection API responsiveness**: slow elements stall PATCH responses. Mitigation: tight default `AckActivation` timeout; document the failure mode.
 - **Daemon discovery**: `daemon-uri` property with a sensible default. Document; don't auto-spawn.
-- **Daemon reconnect**: long-lived `SubscribeActivations` streams must reconnect cleanly across daemon restarts. Session id durable across reconnects; daemon keeps session state until explicit close or TTL.
+- **Daemon reconnect / session liveness**: clients must call `CloseSession` on teardown; there is no GC today. Aspirational: durable `session_handle` across client reconnect and daemon restart with TTL.
 - **Inner-sink state under gating**: the originally-planned `output-selector` pattern removes the inner sink from the data path on deactivation. We still need to confirm per-transport that `nvdsudpsink`/`mxlsink` cleanly handle being de-pathed at runtime; if either disagrees, fall back to keeping it on the path with `fakesink sync=true async=false` *downstream* of the inner sink instead of *replacing* it (slightly more expensive, more conservative). (Phase 1 update: the as-built mechanism tears down and rebuilds the inner sink across activations rather than de-pathing it; this has been validated against `mxlsink`. Phase 2 must still validate the same against `nvdsudpsink`. See [*Phase 1 as-built: anchor + block-probe*](#phase-1-as-built-anchor--block-probe).)
 - **Cross-platform paths**: UDS on Linux/macOS, named pipe on Windows, TCP fallback. gRPC supports all three.
 - **NvNmos C-API thread safety**: confirmed thread-safe — every state mutation in `nvnmos_impl.cpp` takes `model.write_lock()` before touching the nmos-cpp model. The daemon can call NvNmos from any worker thread; no daemon-side serialisation needed.

--- a/doc/designs/nvnmosd/README.md
+++ b/doc/designs/nvnmosd/README.md
@@ -34,7 +34,7 @@ To cover:
 We pick an out-of-process design after considering the in-process bin alternative:
 
 - **Daemon `nvnmosd`** wraps NvNmos and owns one or more NMOS Nodes. Survives pipeline restarts. Hosts multiple pipelines and multiple client processes under one or more shared Nodes.
-- **`nmossrc` and `nmossink`** are single-pad Rust GStreamer elements. Each opens a session with `nvnmosd`, registers its `transport-file`, subscribes to activations, and wraps an inner transport src/sink:
+- **`nmossrc` and `nmossink`** are single-pad Rust GStreamer elements. Each opens a session with `nvnmosd`, adds its Sender or Receiver from the transport file (or synthesised flow_def), subscribes to activations, and wraps an inner transport src/sink:
   - MXL: `mxlsrc` / `mxlsink` from `gst-mxl-rs` (Rust).
   - ST 2110 with Rivermax: `nvdsudpsrc` / `nvdsudpsink` (C, DeepStream).
   - ST 2110 without Rivermax: `udpsrc` / `udpsink` + appropriate RTP (de)payloaders.
@@ -105,7 +105,7 @@ service NvnmosDaemon {
   // Many sessions across many client processes may share a Node by
   // node_seed. The session handle distinguishes them so that the daemon
   // can refcount Node lifetime correctly, route activations only to the
-  // session that registered the affected resource, and drop the right
+  // session that added the affected resource, and drop the right
   // resources when a stream dies.
   rpc OpenSession(OpenSessionRequest) returns (OpenSessionResponse);
   rpc CloseSession(CloseSessionRequest) returns (Empty);
@@ -283,20 +283,20 @@ For MXL the per-format mapping to `flow_def.json` is derivable from essence caps
 
 #### Deferred mode (`nmossink` only)
 
-If neither `transport-file` nor `caps` is provided, `nmossink` defers NMOS registration to **READY → PAUSED** and derives `caps` from a `gst_pad_peer_query_caps` against upstream. Standard GStreamer caps negotiation does the work; the user can constrain with `capsfilter ! nmossink` the way they would with any other sink. `sender-name` (and `iface-ip` or `mxl-domain-id` as relevant) is still required as a property because it's not derivable from the pipeline. `nmossrc` cannot use deferred mode — there is no peer to query.
+If neither `transport-file` nor `caps` is provided, `nmossink` defers AddSender to **READY → PAUSED** and derives `caps` from a `gst_pad_peer_query_caps` against upstream. Standard GStreamer caps negotiation does the work; the user can constrain with `capsfilter ! nmossink` the way they would with any other sink. `sender-name` (and `iface-ip` or `mxl-domain-id` as relevant) is still required as a property because it's not derivable from the pipeline. `nmossrc` cannot use deferred mode — there is no peer to query.
 
-**No data needs to flow for the sender to register.** Caps negotiation in GStreamer is a query-based mechanism (pad template caps + `peer_query_caps`), not a buffer-driven one. For a typical flow-transform pipeline `nmossrc ! transform ! nmossink`:
+**No data needs to flow for the sender to be added.** Caps negotiation in GStreamer is a query-based mechanism (pad template caps + `peer_query_caps`), not a buffer-driven one. For a typical flow-transform pipeline `nmossrc ! transform ! nmossink`:
 
 - `nmossrc`'s source-pad caps are fixed from its `transport-file` at NULL→READY (these are the caps the receiver *would* receive, known the moment the session is opened — independent of whether the receiver has been activated by a controller or whether any data has arrived on the wire).
 - They propagate downstream during READY→PAUSED.
-- The deferred `nmossink`'s peer query lands on those caps and registers the sender with the daemon.
+- The deferred `nmossink`'s peer query lands on those caps and runs `AddSender` against the daemon.
 - The pipeline reaches PAUSED as part of any normal `set_state(PLAYING)` transition — typically in milliseconds, well before the receiver is activated or starts producing buffers.
 
 Both endpoints are at IS-04 by the time the pipeline is up, and there is no Catch-22 (PAUSED ≠ streaming-to-network). The internal gating mechanism (Phase 1 as-built: the inner chain is a `fakesink` behind the anchor while deactivated — see [*Phase 1 as-built: anchor + block-probe*](#phase-1-as-built-anchor--block-probe); originally planned as `output-selector → fakesink`, per *Sink deactivation*) keeps the inner wire sink out of the data path until an IS-05 activation arrives.
 
-**Where deferred mode does break:** any chain where an intermediate element determines its output caps from buffer content — `h264parse` needing SPS/PPS, decoders inferring colorimetry from packet headers, etc. The peer query at PAUSED can't fix caps if upstream hasn't seen data. For those pipelines, declare `caps` explicitly on `nmossink` (Route B) and the sender registers at NULL→READY instead, alongside the receiver.
+**Where deferred mode does break:** any chain where an intermediate element determines its output caps from buffer content — `h264parse` needing SPS/PPS, decoders inferring colorimetry from packet headers, etc. The peer query at PAUSED can't fix caps if upstream hasn't seen data. For those pipelines, declare `caps` explicitly on `nmossink` (Route B) and the sender is added at NULL→READY instead, alongside the receiver.
 
-**Timing subtlety to be aware of.** In deferred mode the sender registers one state transition after the receiver (PAUSED vs READY). A controller polling IS-04 during the narrow window between NULL→READY and READY→PAUSED will see the receiver listed but not the sender. Harmless in practice (the window is tens to hundreds of milliseconds for a normal pipeline startup), but if a deployment cares — for instance because a discovery scan is running in parallel with pipeline startup — declare `caps` explicitly and registration moves to READY for both.
+**Timing subtlety to be aware of.** In deferred mode the sender is added one state transition after the receiver (PAUSED vs READY). A controller polling IS-04 during the narrow window between NULL→READY and READY→PAUSED will see the receiver listed but not the sender. Harmless in practice (the window is tens to hundreds of milliseconds for a normal pipeline startup), but if a deployment cares — for instance because a discovery scan is running in parallel with pipeline startup — declare `caps` explicitly and AddSender / AddReceiver both run at READY.
 
 #### Narrow vs wide caps (`receiver-caps-mode`)
 
@@ -376,7 +376,7 @@ ST 2022-7 NIC selection, jitter-buffer overrides, and similar per-transport knob
 
 - Pad set is **fixed at PLAYING**. Adding/removing elements (and thus NMOS resources) is supported while the pipeline is NULL, not while running.
 - **NULL → READY**: open daemon session, subscribe to activations. Register the resource here too if `transport-file` or `caps` is present (Routes A / B / C).
-- **READY → PAUSED**: per-transport prep on inner src/sink. For `nmossink` in deferred mode, this is where `caps` is derived from upstream peer caps query and the resource registered with the daemon.
+- **READY → PAUSED**: per-transport prep on inner src/sink. For `nmossink` in deferred mode, this is where `caps` is derived from upstream peer caps query and `AddSender` runs against the daemon.
 - **PAUSED → PLAYING**: live data flow begins (see Source behaviour below). Wire transmission gated by activation regardless of pipeline state.
 
 ### Sink (`nmossink`) deactivation
@@ -510,7 +510,7 @@ State refers to GStreamer element state; "Activated" tracks the latest IS-05 act
 | State        | Activated | `nmossink` data path                                   | `nmossrc` data path                                                       | Notes |
 |---           |---        |---                                                     |---                                                                        |---|
 | `NULL`       | n/a       | (no resource)                                          | (no resource)                                                             | Pre-`OpenSession` |
-| `READY`      | unknown   | selector built; selector → blackhole                   | input-selector built; input-selector → disabled_pad; no inner src yet     | Session open; resource registered if `transport-file`/`caps` known |
+| `READY`      | unknown   | selector built; selector → blackhole                   | input-selector built; input-selector → disabled_pad; no inner src yet     | Session open; resource added if `transport-file`/`caps` known |
 | `PAUSED`     | unknown   | as `READY` (deferred mode resolves `caps` here)        | as `READY`                                                                | Caps negotiation completes; no wire I/O |
 | `PLAYING`    | inactive  | selector → blackhole                                   | input-selector → disabled_pad; inner src absent or `locked_state=TRUE` at NULL | No wire I/O for this element; siblings unaffected |
 | `PLAYING`    | active    | selector → inner sink                                  | inner src built+linked via `sync_state_with_parent`; input-selector → receiver_pad | Wire I/O on |

--- a/rust/gst-nmos-rs/README.md
+++ b/rust/gst-nmos-rs/README.md
@@ -26,15 +26,15 @@ Both elements:
 | `registration-url` | string | optional | Fixed IS-04 Registration API URL (`http://host[:port]/x-nmos/registration/v<X.Y>[/]`). Parsed into `network_services.registration_*`; invalid URLs are logged and ignored. Empty (the default) leaves libnvnmos on DNS-SD discovery based on `host-name`. Honoured only by the `OpenSession` that creates the Node. |
 | `system-url`     | string  | optional  | Fixed IS-09 System API URL (`http://host[:port]/x-nmos/system/v<X.Y>[/]`). Parsed into `network_services.system_*`; invalid URLs are logged and ignored. Honoured only when `registration-url` is also set (libnvnmos ignores a standalone System API). Honoured only by the `OpenSession` that creates the Node. |
 | `transport`      | enum    | required  | Inner data path family: `mxl` (MXL shared-memory, the `mxlsrc` / `mxlsink` chain), `udp` (ST 2110 over RTP/UDP via gst-plugins-good `udpsrc` / `udpsink` + the `rtp*pay` / `rtp*depay` line-up), `udp2` (same but preferring gst-plugins-rs's `udpsrc2` + `rtp*pay2` / `rtp*depay2` where available, falling back to gst-plugins-good per-element), `nvdsudp` (ST 2110 via DeepStream `nvdsudpsrc` / `nvdsudpsink` — Rivermax kernel-bypass, built-in RTP (de)payload, Mode 3; requires ConnectX-5+ and the Rivermax SDK). |
-| `transport-file` | string  | route-dependent | Literal contents of the NvNmos transport file the daemon will register with the resource and re-publish into IS-05: MXL `flow_def` JSON for `transport=mxl`, SDP text for `transport=udp` / `udp2` / `nvdsudp`. Pass text, not a path. Convenient for programmatic callers; gst-launch users want `transport-file-path` instead. Mutually exclusive with `transport-file-path`. May be substituted by `caps` (+ `mxl-flow-id` on MXL, or `transport-caps` and the IS-05 endpoint properties — `destination-ip` / `destination-port` / `interface-ip` / `multicast-ip` / `source-ip` / `source-port` — on RTP) on either element. |
+| `transport-file` | string  | route-dependent | Literal contents of the NvNmos transport file the daemon attaches via AddSender / AddReceiver: MXL `flow_def` JSON for `transport=mxl`, SDP text for `transport=udp` / `udp2` / `nvdsudp`. Pass text, not a path. Convenient for programmatic callers; gst-launch users want `transport-file-path` instead. Mutually exclusive with `transport-file-path`. May be substituted by `caps` (+ `mxl-flow-id` on MXL, or `transport-caps` and the IS-05 endpoint properties — `destination-ip` / `destination-port` / `interface-ip` / `multicast-ip` / `source-ip` / `source-port` — on RTP) on either element. |
 | `transport-file-path` | string | route-dependent | Filesystem path read at NULL→READY into `transport-file`. Convenience for `gst-launch-1.0`, whose pipeline parser doesn't cope with multi-line / quote-heavy property values. Mutually exclusive with `transport-file`. |
-| `label`          | string  | optional  | NMOS label for this Sender/Receiver (not the Node). Overrides the transport file's top-level `label` when both are supplied. |
-| `description`    | string  | optional  | NMOS description for this Sender/Receiver. Overrides the transport file's top-level `description` when both are supplied. |
-| `caps`           | GstCaps | required when `transport-file*` is unset | Essence caps. Supported shapes: `video/x-raw,format=…,width=…,height=…,framerate=…[,interlace-mode=…]` (MXL: `v210`; RTP/UDP: RFC 4175 8-bit `UYVY` and 10-bit `UYVP`); `audio/x-raw,format=…,rate=…,channels=…` (MXL: `F32LE`; RTP/UDP: ST 2110-30 `S24BE` (L24) and `S16BE` (L16)); `meta/x-st-2038,framerate=…` (the framerate must be present — set it upstream with a `capsfilter caps="meta/x-st-2038,framerate=30/1"` if needed). On both elements, drives `transport-file` synthesis when `transport-file*` is unset: on `transport=mxl` a MXL `flow_def` JSON document (requires `mxl-flow-id`); on `transport=udp` / `udp2` an SDP description (requires the relevant IS-05 endpoint properties — `destination-ip` etc.). On `nmossrc` the synthesised file describes the essence shape this Receiver accepts, which the daemon advertises as BCP-004-01 narrow Receiver Caps on IS-04 (with `urn:x-nvnmos:tag:caps` driven by `receiver-caps-mode` to indicate narrow vs wide). On `nmossrc` with `transport=mxl`, the media-type structure name (`video/x-raw` / `audio/x-raw` / `meta/x-st-2038`) also picks the `mxlsrc.{video,audio,data}-flow-id=` slot. Cross-checked against the transport file's `format` (MXL) / `m=` line (SDP) when both are supplied. |
+| `label`          | string  | optional  | NMOS label for this Sender/Receiver (not the Node). Overrides the transport file when both are supplied (MXL `flow_def` top-level `label`; SDP `s=` line). |
+| `description`    | string  | optional  | NMOS description for this Sender/Receiver. Overrides the transport file when both are supplied (MXL `flow_def` top-level `description`; SDP `i=` line). |
+| `caps`           | GstCaps | required when `transport-file*` is unset | Essence caps. Supported shapes: `video/x-raw,format=…,width=…,height=…,framerate=…[,interlace-mode=…]` (MXL: `v210`; RTP/UDP: RFC 4175 8-bit `UYVY` and 10-bit `UYVP`); `audio/x-raw,format=…,rate=…,channels=…` (MXL: `F32LE`; RTP/UDP: ST 2110-30 `S24BE` (L24) and `S16BE` (L16)); `meta/x-st-2038,framerate=…` (the framerate must be present — set it upstream with a `capsfilter caps="meta/x-st-2038,framerate=30/1"` if needed). On both elements, drives `transport-file` synthesis when `transport-file*` is unset: on `transport=mxl` a MXL `flow_def` JSON document (requires `mxl-flow-id`); on `transport=udp` / `udp2` an SDP description (requires the relevant IS-05 endpoint properties — `destination-ip` etc.). On `nmossrc` the synthesised configuring file describes the essence shape: narrow receivers advertise BCP-004-01 Receiver Caps on IS-04; wide receivers advertise none (`receiver-caps-mode` controls the marker — `urn:x-nvnmos:tag:caps` on MXL, `a=x-nvnmos-caps:` on RTP/UDP). On `nmossrc` with `transport=mxl`, the media-type structure name (`video/x-raw` / `audio/x-raw` / `meta/x-st-2038`) also picks the `mxlsrc.{video,audio,data}-flow-id=` slot. Cross-checked against the transport file's `format` (MXL) / `m=` line (SDP) when both are supplied. |
 | `transport-caps` | GstCaps | optional  | RTP-only transport-layer overrides applied to the synthesised or supplied SDP, expressed as an `application/x-rtp` caps structure. Recognised fields: `payload` (dynamic RTP payload type, 96–127), `clock-rate` (audio only — video / ANC are pinned to 90000), `ptime` / `maxptime` (audio packetisation interval in ms, packed into SDP `a=ptime:` / `a=maxptime:`). Ignored on `transport=mxl`. |
 | `transport-properties` | GstStructure | optional | Overrides applied to the inner source or sink (`udpsrc` / `udpsink` / `nvdsudpsrc` / `nvdsudpsink` / `mxlsrc` / `mxlsink`) every time the data-path chain is built. Pass a `GstStructure` whose fields are GObject property names on that inner element — for example `properties,buffer-size=26214400` or `properties,gpu-id=0`. The structure name is not interpreted. Takes effect on the next chain build, not immediately on the one currently in the chain. Unknown fields log a warning and are skipped. |
 | `mxl-domain-path` | string | required for MXL | Local filesystem path identifying the MXL Domain on this host; fed into the inner `mxlsink` / `mxlsrc` `domain=` property. If a `domain_def.json` is present in the directory its `id` is used to populate or cross-check `mxl-domain-id` (mismatch is an error — this is host-level identity). |
-| `auto-activate`  | boolean | optional, default `false` | When `false` the element registers the resource so it appears on IS-04 and IS-05 but leaves the inner data path on the fake chain until an IS-05 PATCH activates it (`master_enable: true` on `/single/{senders,receivers}/{id}/active`). When `true` the element brings the inner `mxlsink` / `mxlsrc` up immediately once the configuring flow_def has been resolved at NULL→READY (or, for a deferred-mode sender, at READY→PAUSED) *and* calls `SyncResourceState` to push the daemon's IS-04/IS-05 view to active — i.e. it's a no-controller shortcut for development pipelines and for setups where flow identity comes entirely from properties / `transport-file*`. Orthogonal to how the flow_def itself becomes available: property override of `mxl-flow-id`, supplied `transport-file*`, and caps→flow_def synthesis all feed the same gate. |
+| `auto-activate`  | boolean | optional, default `false` | When `false` the element adds the Sender or Receiver to the daemon so it appears on IS-04 and IS-05 but leaves the inner data path on the fake chain until an IS-05 PATCH activates it (`master_enable: true` on `/single/{senders,receivers}/{id}/active`). When `true` the element brings the inner transport src/sink up immediately once the configuring transport file has been resolved at NULL→READY (or, for a deferred-mode sender, at READY→PAUSED) *and* calls `SyncResourceState` to push the daemon's IS-04/IS-05 view to active — i.e. it's a no-controller shortcut for development pipelines and for setups where flow identity comes entirely from properties / `transport-file*`. Orthogonal to how the transport file itself becomes available: property override of `mxl-flow-id`, supplied `transport-file*`, and caps-driven synthesis (MXL `flow_def` or SDP) all feed the same gate. |
 
 `nmossink`-only:
 
@@ -56,7 +56,7 @@ Both elements:
 | `receiver-name`   | string | required  | NMOS Receiver name within the Node (`x-nvnmos-name` SDP attribute or `urn:x-nvnmos:tag:name` flow-def tag). Unique among Receivers on the Node; a Sender on the same Node may share the same name. Overrides the transport file's name tag when both are supplied. |
 | `mxl-domain-id`  | string  | required for MXL (may be omitted if `mxl-domain-path` supplies it) | MXL Domain ID (UUID) carried in the MXL `flow_def` tags as `urn:x-nvnmos:tag:mxl-domain-id`. If `mxl-domain-path` points at a directory containing a `domain_def.json` (AMWA BCP-007-03 WIP) the file's `id` is used to populate this property when unset, or cross-checked against it when both are supplied (mismatch is an error — this is host-level identity). Overrides the transport file's tag when both are supplied. |
 | `mxl-flow-id`    | string  | optional  | MXL Flow ID (UUID). Fed into the matching `mxlsrc.{video,audio,data}-flow-id=` slot picked from `caps` and used as the `flow_def` top-level `id` when synthesising a transport file from `caps`. Overrides the transport file's top-level `id` when both are supplied — same property-override rule as `label` / `description`. |
-| `receiver-caps-mode` | enum (`auto`/`narrow`/`wide`) | optional | Controls whether the Receiver published to IS-04 advertises narrow or wide Receiver Caps, via the presence of the `urn:x-nvnmos:tag:caps` flow-def tag (libnvnmos's rule: present + non-empty array means wide; absent or empty means narrow). `auto` (default) leaves the tag untouched in the spliced transport file: narrow when the transport file is present and the tag is absent, wide when the tag is already there. `narrow` strips the tag if present; `wide` ensures it is present with a non-empty marker. |
+| `receiver-caps-mode` | enum (`auto`/`narrow`/`wide`) | optional | Controls whether the Receiver published to IS-04 advertises BCP-004-01 Receiver Caps (narrow) or none (wide). On MXL, wide is indicated by the `urn:x-nvnmos:tag:caps` flow-def tag (libnvnmos's rule: present + non-empty array means wide; absent or empty means narrow). On RTP/UDP, wide is indicated by the media-level `a=x-nvnmos-caps:` attribute. `auto` (default) leaves the marker untouched in the spliced transport file. `narrow` strips it if present; `wide` ensures it is present with a non-empty marker. |
 | `source-ip`       | string | optional, RTP transports only | IS-05 receiver `transport_params.source_ip`. **Different semantics from the sender-side property of the same name**: SSM include-source — the remote sender's IP. Drives the configuring SDP `a=source-filter:` include-source. On the `udp2` variant (gst-plugins-rs `udpsrc2`) this translates to `source-filter`; on the `udp` variant (gst-plugins-good `udpsrc`) it translates to `multicast-source`. Empty = unset (any-source multicast / unicast). RTP-only. |
 | `interface-ip`    | string | optional, RTP transports only | IS-05 receiver `transport_params.interface_ip`. Local NIC IP used for the IGMP join; resolved to an interface name and fed into `udpsrc.multicast-iface`. Also emitted in the configuring SDP as `a=x-nvnmos-iface-ip:`. Empty = unset (let the kernel pick). RTP-only. |
 | `multicast-ip`    | string | optional, RTP transports only | IS-05 receiver `transport_params.multicast_ip`. Multicast group to join. Becomes `udpsrc.address` and the SDP `c=` line address. Empty = unset (unicast reception). RTP-only. |
@@ -93,7 +93,7 @@ v210 video to receive an audio flow is ack-failed.
 The element separates "is the resource visible to NMOS controllers?"
 from "is the data path live?":
 
-- **Resource registration** (`AddSender` / `AddReceiver`) happens
+- **Adding resources** (`AddSender` / `AddReceiver`) happens
   at NULL→READY whenever a configuring transport file (MXL
   `flow_def` JSON or SDP) is in play — supplied via
   `transport-file*`, synthesised from `caps` plus the
@@ -108,8 +108,8 @@ from "is the data path live?":
   `udpsink` + RTP payloader / `udpsrc` + RTP depayloader on
   `udp` / `udp2`) only goes live when `auto-activate=true` *or*
   when an IS-05 activation arrives. With the default
-  `auto-activate=false` the element registers the resource but
-  leaves the inner on the fake chain; the daemon's
+  `auto-activate=false` the element adds the Sender or Receiver to
+  the daemon but leaves the inner on the fake chain; the daemon's
   `/single/{senders,receivers}/{id}/active` shows
   `master_enable: false` until an external controller PATCHes the
   resource. Setting `auto-activate=true` is the no-controller
@@ -210,12 +210,12 @@ GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
     nmossink transport=mxl node-seed=demo sender-name=sender1 mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8
 ```
 
-Expected: `session opened ... no resource registered; inner data path:
+Expected: `session opened ... no resource added; inner data path:
 fake (...)` then `session closed`. The daemon logs the matching
 `OpenSession`, `SubscribeActivations`, and `CloseSession` calls.
 
 Add `transport-file-path=...` (or `mxl-flow-id=` directly) plus
-`mxl-domain-path=` to register the Sender via `AddSender`, then add
+`mxl-domain-path=` to add the Sender via `AddSender`, then add
 `auto-activate=true` to also instantiate a real `mxlsink` and have
 the element call `SyncResourceState` so the daemon's
 `/single/senders/{id}/active` is in sync without an IS-05 PATCH:
@@ -230,7 +230,7 @@ GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
              auto-activate=true
 ```
 
-Expected: the element additionally logs `resource registered:
+Expected: the element additionally logs `resource added:
 resource_handle=... resource_id=...; inner data path: mxl
 (domain_path=..., flow_id=..., format=...)`. The daemon logs the
 matching `AddSender`. An IS-05 PATCH activation against this
@@ -287,7 +287,7 @@ GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
 ```
 
 Expected: `nmossink: synthesised flow_def from caps` then the usual
-`resource registered`, `inner data path: mxl (…)`, and the daemon's
+`resource added`, `inner data path: mxl (…)`, and the daemon's
 matching `AddSender`. The synthesised JSON follows the MXL SDK
 reference flow shapes in [`mxl/lib/tests/data/`](https://github.com/dmf-mxl/mxl/tree/main/lib/tests/data).
 Fields included:
@@ -306,7 +306,7 @@ Fields included:
   `frame_width` / `frame_height`. Use `transport-file` if you need
   BT2020 / a different layout.
 
-Finally, `nmossink` can also defer registration to `READY→PAUSED`
+Finally, `nmossink` can also defer AddSender to `READY→PAUSED`
 and pick up the caps from upstream — useful when the upstream
 element fixes caps for the sink anyway (a `capsfilter`, a parser,
 or another negotiation point):
@@ -323,13 +323,13 @@ GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
 ```
 
 Expected: at NULL→READY the element logs `session opened … no
-resource registered`; at READY→PAUSED it logs `deferred mode: peer
-caps fixated to …` then `deferred mode: synthesised flow_def` and
-`deferred registration complete: resource_handle=… resource_id=…;
-inner data path: Mxl(…)`. When upstream can't fix caps — for
-example `fakesrc ! nmossink` — the state change fails with a clear
-`READY→PAUSED deferred registration failed:` error telling the
-user to declare `caps=…` on the element or insert a `capsfilter`
+resource added`; at READY→PAUSED it logs `deferred mode: peer
+caps fixated to …` then `deferred mode: synthesised configuring
+transport file` and `deferred AddSender complete: resource_handle=…
+resource_id=…; inner data path: Mxl(…)`. When upstream can't fix
+caps — for example `fakesrc ! nmossink` — the state change fails
+with a clear `READY→PAUSED deferred AddSender failed:` error telling
+the user to declare `caps=…` on the element or insert a `capsfilter`
 upstream. Receiver-side deferred mode is intentionally out of scope:
 `nmossrc` has no peer to query.
 
@@ -383,7 +383,7 @@ consumer pipeline
 
 A self-contained `gst-launch-1.0` form using `videotestsrc` +
 `audiotestsrc` (so no `appsrc`/`appsink` programming is required;
-this exercises the multi-flow registration path even though it
+this exercises the multi-flow add path even though it
 doesn't drive synthesised ANC) is wired into the interactive
 demo script at [`scripts/gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh):
 Node 1 contributes two MXL Senders (video + audio) and Node 2
@@ -469,13 +469,13 @@ Design notes: [`doc/designs/gst-nmos-rs-nvdsudp-plan.md`](../../doc/designs/gst-
   `AddSender` (on `nmossink`) or `AddReceiver` (on `nmossrc`) so
   the resource is published in IS-04 and reachable by IS-05
   controllers. When neither source provides one the session is
-  opened but no resource is registered; the element awaits an
+  opened but no resource is added; the element awaits an
   IS-05 activation (or, for `nmossink` only, READY→PAUSED
   peer-caps resolution — see the deferred-mode note below).
 - The `auto-activate` boolean property (default `false`) controls
   whether the data path goes live eagerly at NULL→READY or waits for
   an IS-05 PATCH. Default `false` gives canonical NMOS semantics:
-  the resource is registered (visible on IS-04) but the inner
+  the resource is added (visible on IS-04) but the inner
   data path stays on the fake chain until an external controller
   PATCHes `master_enable: true` against the
   `/single/{senders,receivers}/{id}/staged` endpoint. `true` is the
@@ -567,12 +567,15 @@ Design notes: [`doc/designs/gst-nmos-rs-nvdsudp-plan.md`](../../doc/designs/gst-
   `a=source-filter:` line when `source-ip` is set; and for
   receivers an `a=x-nvnmos-iface-ip:` line when `interface-ip`
   is set). On `nmossrc` the synthesised file describes the
-  Receiver's expected essence shape, which the daemon publishes
-  as BCP-004-01 narrow Receiver Caps on IS-04 (with the
-  `urn:x-nvnmos:tag:caps` tag spliced in by `receiver-caps-mode`
-  to indicate narrow vs wide); the live transport file delivered
-  later via IS-05 PATCH replaces only the subscription-relevant
-  fields. When both `transport-file*` and `caps` are set, `caps`
+  Receiver's expected essence shape in the configuring transport file.
+  Narrow receivers: the daemon publishes BCP-004-01 Receiver Caps on
+  IS-04 (`receiver-caps-mode` splices `urn:x-nvnmos:tag:caps` on MXL or
+  `a=x-nvnmos-caps:` on RTP/UDP). Wide receivers: none are advertised.
+  At IS-05 activation, MXL subscription fields (e.g. `mxl-flow-id`) are
+  updated from the activation transport file without changing the IS-04
+  caps advertisement; on RTP/UDP the element builds the data path from
+  the activation SDP in the `ActivationEvent`, not from the configuring
+  SDP supplied at AddReceiver. When both `transport-file*` and `caps` are set, `caps`
   is cross-checked against the file's essence shape rather than
   ignored — see the property interaction matrix in "Property
   interaction with `transport-file`" above.
@@ -583,7 +586,7 @@ Design notes: [`doc/designs/gst-nmos-rs-nvdsudp-plan.md`](../../doc/designs/gst-
   for caps via `gst_pad_peer_query_caps()`, the result is fixated,
   and the caps-driven transport-file builder runs against those
   caps; on success the inner element swaps to the transport-specific
-  real chain and the resource is registered. The transport-specific
+  real chain and the resource is added. The transport-specific
   identity properties must still be set (MXL: `mxl-flow-id` /
   `mxl-domain-id`, or `mxl-domain-path` with a `domain_def.json`;
   RTP: the IS-05 endpoint properties). If the peer returned

--- a/rust/gst-nmos-rs/README.md
+++ b/rust/gst-nmos-rs/README.md
@@ -47,7 +47,7 @@ Both elements:
 | `source-port` | uint (0–65535) | optional, RTP transports only | IS-05 sender `transport_params.source_port`. Local egress port. Drives `udpsink.bind-port` and the SDP `a=x-nvnmos-src-port:` attribute. `0` (the default) = unset; the OS picks an ephemeral port. RTP-only. |
 | `destination-ip` | string | optional, RTP transports only | IS-05 sender `transport_params.destination_ip`. Remote destination (unicast peer or multicast group). Becomes the configuring SDP `c=` line address and `udpsink.host`. Empty = unset (use the transport file's `c=` line if present; else daemon `auto`). RTP-only. |
 | `destination-port` | uint (0–65535) | optional, RTP transports only | IS-05 sender `transport_params.destination_port`. Remote destination port. Becomes the SDP `m=` port slot and `udpsink.port`. `0` (the default) = unset; falls back to the transport file's `m=` port, else to the canonical RTP default 5004 (`nmos-cpp::auto_rtp_port`). RTP-only. |
-| `pay-properties` | GstStructure | optional | Overrides applied to the inner RTP payloader every time the OSS UDP sender chain is built. Same `GstStructure` syntax as `transport-properties`; ignored on `mxl` and `nvdsudp` (a warning is logged if non-empty). Takes effect on the next chain build. |
+| `pay-properties` | GstStructure | optional | Overrides applied to the inner RTP payloader every time the UDP sender chain is built. Same `GstStructure` syntax as `transport-properties`; ignored on `mxl` and `nvdsudp` (a warning is logged if non-empty). Takes effect on the next chain build. |
 
 `nmossrc`-only:
 
@@ -104,9 +104,7 @@ from "is the data path live?":
   session opens with no resource and the data path stays on the
   fake chain until an IS-05 activation supplies one.
 
-- **Inner data path** (real `mxlsink` / `mxlsrc` on MXL, or
-  `udpsink` + RTP payloader / `udpsrc` + RTP depayloader on
-  `udp` / `udp2`) only goes live when `auto-activate=true` *or*
+- **Inner data path** only goes live when `auto-activate=true` *or*
   when an IS-05 activation arrives. With the default
   `auto-activate=false` the element adds the Sender or Receiver to
   the daemon but leaves the inner on the fake chain; the daemon's
@@ -143,7 +141,8 @@ property surface above.
 For an end-to-end demo — three NMOS Nodes (producer, consumer,
 processor) with an interactive menu for IS-05 enable / disable /
 rewire — run [`scripts/gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh).
-Pick the transport family with `DEMO_TRANSPORT`:
+Video essence is matched across transports at **1080p25 10-bit**
+(`v210` on MXL, `UYVP` on UDP). Pick the transport family with `DEMO_TRANSPORT`:
 
 ```sh
 # MXL shared-memory (default)
@@ -156,10 +155,13 @@ DEMO_TRANSPORT=udp ./scripts/gst-nmos-rs-demo.sh
 DEMO_TRANSPORT=udp2 ./scripts/gst-nmos-rs-demo.sh
 ```
 
-On WSL or headless hosts, skip the slow `autoaudiosink` probe:
+On WSL with WSLg, if `autoaudiosink` is silent, export the WSLg Pulse
+socket before launching: `export PULSE_SERVER=unix:/mnt/wslg/PulseServer`
+
+On WSL or headless hosts, there is also the option to use `fakesink`:
 
 ```sh
-AUDIO_SINK=fakesink VIDEO_SINK=fakesink DEMO_TRANSPORT=udp ./scripts/gst-nmos-rs-demo.sh
+DEMO_AUDIO_SINK=fakesink DEMO_VIDEO_SINK=fakesink DEMO_TRANSPORT=udp ./scripts/gst-nmos-rs-demo.sh
 ```
 
 The script builds `nvnmosd` + the plugin, spawns the daemon and several
@@ -193,237 +195,11 @@ Audio (`nmossrc` → `volume` → `nmossink`): receiver and sender disabled
 
 ![Node 3 audio processor pipeline](images/processor-audio.png)
 
-## More Basic Pipelines
+## Pipeline Examples
 
-Without `mxl-domain-path` (and `mxl-flow-id`) the element opens a
-session but its data path stays on the fake chain:
+Copy-paste `gst-launch-1.0` recipes are in [`pipeline-examples.md`](pipeline-examples.md).
 
-```sh
-# terminal 1
-target/debug/nvnmosd
-
-# terminal 2
-export GST_PLUGIN_PATH=/path/to/nvnmos/rust/target/debug:/path/to/mxl/rust/target/debug
-export LD_LIBRARY_PATH=/path/to/mxl-runtime/lib
-GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
-    fakesrc num-buffers=10 ! \
-    nmossink transport=mxl node-seed=demo sender-name=sender1 mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8
-```
-
-Expected: `session opened ... no resource added; inner data path:
-fake (...)` then `session closed`. The daemon logs the matching
-`OpenSession`, `SubscribeActivations`, and `CloseSession` calls.
-
-Add `transport-file-path=...` (or `mxl-flow-id=` directly) plus
-`mxl-domain-path=` to add the Sender via `AddSender`, then add
-`auto-activate=true` to also instantiate a real `mxlsink` and have
-the element call `SyncResourceState` so the daemon's
-`/single/senders/{id}/active` is in sync without an IS-05 PATCH:
-
-```sh
-GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
-    fakesrc num-buffers=10 ! \
-    nmossink transport=mxl node-seed=demo sender-name=sender1 \
-             mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8 \
-             mxl-domain-path=/var/lib/mxl/domain-a \
-             transport-file-path=/tmp/sender1.flow_def.json \
-             auto-activate=true
-```
-
-Expected: the element additionally logs `resource added:
-resource_handle=... resource_id=...; inner data path: mxl
-(domain_path=..., flow_id=..., format=...)`. The daemon logs the
-matching `AddSender`. An IS-05 PATCH activation against this
-resource is dispatched through the element: it logs `applying
-activation … plan inner=Real(Mxl(…)), ack=Success` and (when the
-pipeline is past READY) the swap happens behind a single-shot IDLE
-pad probe before the daemon receives the success ack. A
-deactivation logs `activation is a deactivation … swapping to fake
-chain` and acks success. A PATCH that the element can't honour
-locally (e.g. `mxl-domain-path` is unset on this host, or the
-`mxl-flow-id` property contradicts the activation's transport
-file) is acked back with `success=false` and a `failure_reason`
-that names the specific check that failed.
-
-On `nmossrc` the inner `mxlsrc` also needs to know which media kind
-the flow carries — `video/x-raw` → `video-flow-id`, `audio/x-raw` →
-`audio-flow-id`, `meta/x-st-2038` → `data-flow-id`. Supply it either
-via `caps="…"` (which is also pinned on the ghost source pad so
-downstream sees the concrete essence shape) or via the `format`
-field of the `transport-file`. When both are supplied they must
-agree.
-
-The same `caps` discipline applies to the RTP/UDP transports
-(`transport=udp` / `udp2`, internally `udpsrc ! depayloader ! …`
-on the receiver and `… ! payloader ! udpsink` on the sender): the
-application either declares `caps=…` on `nmossrc` / `nmossink` to
-drive SDP synthesis from properties (combined with the IS-05
-endpoint properties — `destination-ip` / `destination-port` /
-`interface-ip` / `multicast-ip` / `source-ip` / `source-port` —
-and any `transport-caps` overrides), or provides an SDP via
-`transport-file*` (which is then authoritative and the essence
-caps are derived from its `m=` / `rtpmap` / `fmtp` lines).
-
-`transport-file` (literal text) remains available for programmatic
-callers that compute the flow_def in memory; from gst-launch the path
-form is much easier to type because the pipeline parser doesn't have
-to cope with newlines and embedded quotes.
-
-For a sender driven entirely by properties (no `transport-file*`) the
-essence caps can be supplied directly; add `auto-activate=true` to
-let the element activate without an IS-05 controller:
-
-```sh
-GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
-    videotestsrc num-buffers=10 ! \
-    video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001 ! \
-    nmossink transport=mxl node-seed=demo sender-name=sender1 \
-             mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8 \
-             mxl-domain-path=/var/lib/mxl/domain-a \
-             mxl-flow-id=5fbec3b1-1b0f-417d-9059-8b94a47197ed \
-             label="Studio A v210" \
-             caps="video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001" \
-             auto-activate=true
-```
-
-Expected: `nmossink: synthesised flow_def from caps` then the usual
-`resource added`, `inner data path: mxl (…)`, and the daemon's
-matching `AddSender`. The synthesised JSON follows the MXL SDK
-reference flow shapes in [`mxl/lib/tests/data/`](https://github.com/dmf-mxl/mxl/tree/main/lib/tests/data).
-Fields included:
-
-- Caps-driven: `media_type`, `grain_rate` / `sample_rate`, `frame_width` /
-  `frame_height` (video), `channel_count` / `bit_depth` (audio),
-  `interlace_mode` (video, only when caps carry it).
-- Property-driven: `id` (= `mxl-flow-id`), `label` (= `label` property,
-  falls back to `sender-name` when empty), `description` (= `description`
-  property, may be empty), plus three required tags
-  (`urn:x-nmos:tag:grouphint/v1.0` derived from `sender-name`,
-  `urn:x-nvnmos:tag:name` = `sender-name`,
-  `urn:x-nvnmos:tag:mxl-domain-id` = the resolved `mxl-domain-id`).
-- Video-only defaults required by `libnvnmos`: `colorspace` = `BT709`
-  and a Y/Cb/Cr 4:2:2 10-bit `components` triple derived from
-  `frame_width` / `frame_height`. Use `transport-file` if you need
-  BT2020 / a different layout.
-
-Finally, `nmossink` can also defer AddSender to `READY→PAUSED`
-and pick up the caps from upstream — useful when the upstream
-element fixes caps for the sink anyway (a `capsfilter`, a parser,
-or another negotiation point):
-
-```sh
-GST_DEBUG=nmossink:5 gst-launch-1.0 -e \
-    videotestsrc num-buffers=10 ! \
-    video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001 ! \
-    nmossink transport=mxl node-seed=demo sender-name=sender1 \
-             mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8 \
-             mxl-domain-path=/var/lib/mxl/domain-a \
-             mxl-flow-id=5fbec3b1-1b0f-417d-9059-8b94a47197ed \
-             auto-activate=true
-```
-
-Expected: at NULL→READY the element logs `session opened … no
-resource added`; at READY→PAUSED it logs `deferred mode: peer
-caps fixated to …` then `deferred mode: synthesised configuring
-transport file` and `deferred AddSender complete: resource_handle=…
-resource_id=…; inner data path: Mxl(…)`. When upstream can't fix
-caps — for example `fakesrc ! nmossink` — the state change fails
-with a clear `READY→PAUSED deferred AddSender failed:` error telling
-the user to declare `caps=…` on the element or insert a `capsfilter`
-upstream. Receiver-side deferred mode is intentionally out of scope:
-`nmossrc` has no peer to query.
-
-The two pieces compose into the canonical receiver-to-sender shape:
-
-```sh
-GST_DEBUG=nmossrc:5,nmossink:5 gst-launch-1.0 -e \
-    nmossrc transport=mxl node-seed=demo receiver-name=recv1 \
-            mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8 \
-            mxl-domain-path=/var/lib/mxl/domain-a \
-            transport-file-path=/tmp/recv1.flow_def.json \
-            auto-activate=true ! \
-    identity ! \
-    nmossink transport=mxl node-seed=demo sender-name=send1 \
-             mxl-domain-id=1ac254d9-c9be-475a-93a7-f80b9c1063a8 \
-             mxl-domain-path=/var/lib/mxl/domain-a \
-             mxl-flow-id=00000000-0000-0000-0000-00000000abcd \
-             auto-activate=true
-```
-
-Expected: `nmossrc` advertises caps from `recv1.flow_def.json` on
-its ghost src pad; `nmossink` (deferred) peer-queries them through
-`identity` at READY→PAUSED, synthesises its own flow_def from those
-caps, and calls `AddSender`. The daemon log shows both
-`AddReceiver` (from `nmossrc`) and `AddSender` (from the deferred
-`nmossink`) on the same node.
-
-### Multi-Flow Pipelines
-
-Multiple Senders and Receivers can live on the same Node by sharing
-the `node-seed`; the daemon's session index is keyed on
-`(node_seed, side, name)` so distinct `sender-name` / `receiver-name`
-values disambiguate them. The recipe below sets up the canonical
-"video + ANC" producer/consumer pair (modelled on the
-`gst-mxl-rs` `video_data_sync` integration test): the producer runs
-`appsrc` through `st2038extractor` and feeds both branches into
-their own `nmossink`; the consumer reads both flows back through
-their own `nmossrc` and drops them into per-flow `appsink`s.
-
-```text
-producer pipeline
-    appsrc (v210 + GstAncillaryMeta)
-      ! st2038extractor name=ext remove-ancillary-meta=true
-    ext.src    ! queue ! nmossink (sender-name=video-sender, video flow)
-    ext.st2038 ! queue ! nmossink (sender-name=data-sender,  data flow)
-
-consumer pipeline
-    nmossrc (receiver-name=video-receiver, video flow) ! queue ! appsink (v210)
-    nmossrc (receiver-name=data-receiver,  data flow)  ! queue ! appsink (meta/x-st-2038)
-```
-
-A self-contained `gst-launch-1.0` form using `videotestsrc` +
-`audiotestsrc` (so no `appsrc`/`appsink` programming is required;
-this exercises the multi-flow add path even though it
-doesn't drive synthesised ANC) is wired into the interactive
-demo script at [`scripts/gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh):
-Node 1 contributes two MXL Senders (video + audio) and Node 2
-contributes two MXL Receivers (video + audio) to the same Domain,
-all sharing per-node seeds. The rigorous version with real
-`appsrc`/`appsink` plumbing and per-frame index validation lives
-in [`tests/multi_flow_video_data.rs`](tests/multi_flow_video_data.rs)
-and is `#[ignore]`d because it needs the real MXL toolchain.
-
-To opt in to the integration test on a host with `/dev/shm` and
-the full MXL runtime:
-
-```sh
-export NVNMOS_LIB_DIR=/path/to/nvnmos-build/   # contains libnvnmos.so
-export MXL_PLUGIN_DIR=/path/to/mxl/rust/target/debug
-export MXL_RT_LIB_DIR=/path/to/mxl/build/lib
-
-# Build nvnmosd + the gst-nmos-rs plugin.
-cargo build --manifest-path /path/to/nvnmos/rust/Cargo.toml \
-    -p nvnmosd -p gst-nmos-rs
-
-TARGET_DIR=/path/to/nvnmos/rust/target
-
-NVNMOSD_BIN=$TARGET_DIR/debug/nvnmosd \
-GST_PLUGIN_PATH=$TARGET_DIR/debug:$MXL_PLUGIN_DIR \
-LD_LIBRARY_PATH=$NVNMOS_LIB_DIR/lib:$MXL_RT_LIB_DIR \
-cargo test --manifest-path /path/to/nvnmos/rust/Cargo.toml \
-    -p gst-nmos-rs --test multi_flow_video_data \
-    -- --ignored --test-threads=1 --nocapture
-```
-
-The test spawns its own `nvnmosd`, creates a fresh `/dev/shm`
-domain (auto-removed on drop), writes one configuring `flow_def.json`
-per role (sender / receiver) per flow (video / data), runs the
-two pipelines, pulls 30 samples from each consumer `appsink`, and
-asserts that the producer frame index stamped on every v210 buffer
-and every ST 2038 ANC packet appears on both sides — proving the
-two flows traverse the same MXL Domain on the same daemon Node and
-that the per-flow PTS gap between the two flows stays constant
-across the steady-state window.
+Static scripts (no interactive menu): [`scripts/example-pipelines/`](scripts/example-pipelines/).
 
 ## `transport=nvdsudp` (DeepStream Rivermax)
 
@@ -440,13 +216,22 @@ SDP synthesis from `caps` emits `TP=2110TPN` (narrow traffic profile). Use
 `video/x-raw(memory:NVMM),…` in `caps` for GPU Direct; set `gpu-id` via
 `transport-properties`.
 
-**Prerequisites:** DeepStream `gst-nvdsudp` plugin on `GST_PLUGIN_PATH`,
-Rivermax SDK + license, ConnectX-5 or newer NIC, and `CAP_NET_RAW` on the
-host binary (`sudo setcap CAP_NET_RAW=ep $(which gst-launch-1.0)`).
+**Prerequisites:** Install [DeepStream 9.0](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html)
+and the [Rivermax SDK](https://developer.nvidia.com/networking/rivermax)
+following their respective installation guides. You also need a ConnectX-5 or
+newer NIC for real wire traffic, and `CAP_NET_RAW` on the host binary
+(`sudo setcap CAP_NET_RAW=ep $(which gst-launch-1.0)`).
+
+The DeepStream deb ships `nvdsudpsrc` / `nvdsudpsink` as
+`libnvdsgst_udp.so` under
+`/opt/nvidia/deepstream/deepstream-9.0/lib/gst-plugins`. Add that directory
+to `GST_PLUGIN_PATH` and `/opt/nvidia/deepstream/deepstream-9.0/lib` to
+`LD_LIBRARY_PATH` if plugins fail to load (the DeepStream installation guide
+covers the usual setup).
 
 **ST 2022-7 (dual-leg):** supported on `transport=nvdsudp` when configuring
-or activation SDP has two same-essence `m=` lines (separate destination
-addresses). Inactive legs (`a=inactive` / `rtp_enabled: false`) are gated
+SDP has two same-essence `m=` lines (separate destination addresses).
+Inactive legs (`rtp_enabled: false` → `a=inactive`) are gated
 at activation; `nvdsudpsrc` uses comma-separated `st2022-7-streams`,
 `local-iface-ip`, and `source-address`. Dual-leg transport files on
 `udp` / `udp2` are rejected. Caps-only synthesis still emits one `m=`.
@@ -455,162 +240,3 @@ See [`doc/designs/gst-nmos-rs-st2022-7-dual-leg-plan.md`](../../doc/designs/gst-
 **Not yet supported:** `video/x-jxsv`.
 
 Design notes: [`doc/designs/gst-nmos-rs-nvdsudp-plan.md`](../../doc/designs/gst-nmos-rs-nvdsudp-plan.md).
-
-## Status
-
-- `nmossrc` and `nmossink` are registered with their current property
-  surface (visible via `gst-inspect-1.0 nmossink` and `gst-inspect-1.0 nmossrc`).
-- `NULL→READY` opens a session against `nvnmosd` via gRPC over UDS
-  and subscribes to activations; `READY→NULL` closes it.
-- When a transport file is in play — either supplied via
-  `transport-file*` or synthesised from `caps` plus the
-  transport-specific identity properties (`mxl-flow-id` on MXL;
-  the IS-05 endpoint properties on RTP) — the element also calls
-  `AddSender` (on `nmossink`) or `AddReceiver` (on `nmossrc`) so
-  the resource is published in IS-04 and reachable by IS-05
-  controllers. When neither source provides one the session is
-  opened but no resource is added; the element awaits an
-  IS-05 activation (or, for `nmossink` only, READY→PAUSED
-  peer-caps resolution — see the deferred-mode note below).
-- The `auto-activate` boolean property (default `false`) controls
-  whether the data path goes live eagerly at NULL→READY or waits for
-  an IS-05 PATCH. Default `false` gives canonical NMOS semantics:
-  the resource is added (visible on IS-04) but the inner
-  data path stays on the fake chain until an external controller
-  PATCHes `master_enable: true` against the
-  `/single/{senders,receivers}/{id}/staged` endpoint. `true` is the
-  no-controller shortcut: once the configuring transport file has
-  been resolved the element brings the transport-specific real
-  chain up and calls `SyncResourceState` on the daemon so
-  `/single/{senders,receivers}/{id}/active` reflects
-  `master_enable: true` without the IS-05 stream being involved.
-  The gate is orthogonal to how the transport file became
-  available — property overrides (`mxl-flow-id` and friends on
-  MXL; IS-05 endpoint properties on RTP), supplied
-  `transport-file*`, and caps-driven transport-file synthesis all
-  feed the same toggle.
-- Activation events arriving on the subscription drive the inner
-  data path. The element reads the event's transport file (for MXL
-  receivers this is the daemon-spliced internal `flow_def` carrying
-  the PATCHed `mxl_domain_id` / `mxl_flow_id`; for RTP receivers
-  it is the SDP with the PATCHed `c=` / `m=` / endpoint addresses
-  spliced in by the daemon), then swaps the inner element between
-  the real chain (`mxlsink` / `mxlsrc` on MXL; `udpsink` + RTP
-  payloader / `udpsrc` + RTP depayloader on `udp` / `udp2`) and
-  the fake chain. The daemon's view is authoritative for
-  identity — an IS-05 PATCH legitimately replaces the
-  configured-at-startup transport-file identity (`mxl-flow-id` /
-  `mxl-domain-id` on MXL; endpoint IPs / ports on RTP) and the
-  element silently picks up the new values.
-  The essence-shape cross-check still applies, so an activation
-  that tries to push an incompatible essence type at the element
-  (e.g. a v210 video flow at an `nmossrc` configured for audio
-  caps) is ack-failed. Swaps use a single mechanism regardless of
-  pipeline state: a permanent `identity` anchor sits behind a fixed
-  ghost-pad target, the chain (fake or real) lives behind the
-  anchor, and the activation handler runs on a `call_async` worker
-  thread that installs an `IDLE | BLOCK_DOWNSTREAM` probe on the
-  anchor's chain-side pad, unlinks / removes / adds / links the
-  chain behind the anchor, and removes the probe. Sticky events
-  (STREAM_START, CAPS, SEGMENT) re-flow to the new chain on its
-  first buffer push, so the external ghost-pad target never has to
-  be retargeted. For MXL real → real re-activations the handler
-  inserts a fake-chain hop between the two real instances so
-  libmxl's per-process state (`FlowWriter` / `FlowReader`) is
-  fully released before the new one tries to attach (the RTP
-  chains have no equivalent per-process singleton, so they swap
-  directly). The activation is acked back to the daemon as
-  `success=true` when the inner element was successfully brought
-  up (or deactivation completed), and `success=false` with a
-  `failure_reason` when it could not — most commonly because
-  `mxl-domain-path` is unset on this host (MXL only) or the
-  essence-shape cross-check failed.
-- When the resolved configuration pins enough transport-specific
-  identity to build a real chain — for MXL a Domain path *and* a
-  Flow id (plus a recognised essence shape on the receiver,
-  supplied via `caps` or read from the transport file's `format`);
-  for RTP the network endpoints (`destination-ip` /
-  `destination-port` etc.) plus the parsed SDP essence /
-  transport caps — the inner data path is the transport-specific
-  real chain. Otherwise the bin keeps a fake chain so the element
-  remains valid in the pipeline: `fakesink` on `nmossink` (sinks
-  accept ANY caps), and an `appsrc` configured with the
-  best-available essence caps on `nmossrc` (the `caps` property, or
-  caps synthesised from `transport-file*`). The `nmossrc` fake
-  chain is held idle — we never push buffers into the `appsrc`, so
-  its basesrc loop blocks in `create()`, but downstream caps
-  queries are answered against the concrete essence shape so
-  negotiation can complete and the pipeline can reach PLAYING while
-  the bin waits for an IS-05 activation to swap the inner to the
-  real chain. When no caps source is yet available
-  (constructed-time, before any properties have been set) the
-  fake chain is built as a bare `appsrc` without caps; it cannot
-  satisfy caps negotiation in that state, and the NULL→READY
-  transition replaces it with a caps-aware `appsrc` as soon as a
-  caps source becomes available.
-- Both elements support a `caps`-driven transport-file synthesis
-  path: when the user supplies essence caps
-  (`video/x-raw,format=…`, `audio/x-raw,format=…`, or
-  `meta/x-st-2038,framerate=…`) plus the transport-specific
-  identity properties (`mxl-flow-id` on MXL; the IS-05 endpoint
-  properties on RTP) and `sender-name` / `receiver-name`, the
-  element synthesises a transport file and feeds it to
-  `AddSender` / `AddReceiver` as it would a user-supplied one.
-  On `transport=mxl` the synthesised file is a MXL `flow_def`
-  JSON document matching the SDK reference shapes in
-  [`mxl/lib/tests/data/`](https://github.com/dmf-mxl/mxl/tree/main/lib/tests/data).
-  On `transport=udp` / `udp2` it is an SDP description — `v=` /
-  `o=` / `s=` / `i=` / `c=` / `m=` plus `rtpmap` / `fmtp` /
-  `ptime` lines derived from the essence caps, `transport-caps`
-  overrides, and the endpoint properties (including the
-  `a=x-nvnmos-name:` extension and, for senders, an
-  `a=source-filter:` line when `source-ip` is set; and for
-  receivers an `a=x-nvnmos-iface-ip:` line when `interface-ip`
-  is set). On `nmossrc` the synthesised file describes the
-  Receiver's expected essence shape in the configuring transport file.
-  Narrow receivers: the daemon publishes BCP-004-01 Receiver Caps on
-  IS-04 (`receiver-caps-mode` splices `urn:x-nvnmos:tag:caps` on MXL or
-  `a=x-nvnmos-caps:` on RTP/UDP). Wide receivers: none are advertised.
-  At IS-05 activation, MXL subscription fields (e.g. `mxl-flow-id`) are
-  updated from the activation transport file without changing the IS-04
-  caps advertisement; on RTP/UDP the element builds the data path from
-  the activation SDP in the `ActivationEvent`, not from the configuring
-  SDP supplied at AddReceiver. When both `transport-file*` and `caps` are set, `caps`
-  is cross-checked against the file's essence shape rather than
-  ignored — see the property interaction matrix in "Property
-  interaction with `transport-file`" above.
-- `nmossink` also supports a *deferred mode*: when neither
-  `transport-file*` nor `caps` is supplied at NULL→READY the session
-  opens without a resource, and the actual `AddSender` is driven
-  from `READY→PAUSED`. The ghost sink pad's upstream peer is queried
-  for caps via `gst_pad_peer_query_caps()`, the result is fixated,
-  and the caps-driven transport-file builder runs against those
-  caps; on success the inner element swaps to the transport-specific
-  real chain and the resource is added. The transport-specific
-  identity properties must still be set (MXL: `mxl-flow-id` /
-  `mxl-domain-id`, or `mxl-domain-path` with a `domain_def.json`;
-  RTP: the IS-05 endpoint properties). If the peer returned
-  ANY/EMPTY caps or a shape the builder can't accept (e.g.
-  `video/x-raw,format=I420`), the state change fails with a clear
-  message telling the user to declare `caps=…` or insert a
-  `capsfilter` upstream. Receiver-side deferred mode is
-  intentionally out of scope — `nmossrc` has no peer to query.
-- `nmossrc` advertises essence caps on its ghost source pad whenever
-  a transport file is in play. The transport file (`transport-file*`
-  at NULL→READY, or the daemon-spliced internal one at activation) is
-  reverse-mapped to GStreamer caps (`video/x-raw,format=…`,
-  `audio/x-raw,format=…`, `meta/x-st-2038,framerate=…`) and pinned
-  by an internal `mxlsrc ! capsfilter` chain on MXL, or by the
-  RTP depayloader's natural output (extended with a tail
-  `capsfilter` / `capssetter` as needed) on `udp` / `udp2`.
-  Downstream caps queries see the concrete shape the flow will
-  carry — this is what makes the canonical
-  `nmossrc ! transform ! nmossink` pipeline work end-to-end at
-  READY→PAUSED, since the deferred `nmossink`'s upstream peer query
-  lands on those pinned caps and `AddSender` runs against the right
-  transport file. On `transport=mxl`, when no transport file is
-  available (development convenience with `mxl-domain-path` +
-  `mxl-flow-id` + `caps` set but no flow_def supplied), the bare
-  `mxlsrc` is used and its broad pad template propagates; the
-  `caps` media-type still decides which `mxlsrc.{video,audio,data}-flow-id=`
-  slot receives `mxl-flow-id`.

--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -1,0 +1,338 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Pipeline Examples
+
+Copy-paste `gst-launch-1.0` recipes for `nmossrc` / `nmossink`, with matched
+essence across `transport=mxl`, `transport={udp,udp2}`, and `transport=nvdsudp`.
+
+Static scripts and the interactive demo share defaults from
+[`scripts/env.sh`](scripts/env.sh) (flow IDs, RTP/UDP multicast, caps).
+The demo — [`scripts/gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh) —
+sources that file and overrides demo-only knobs (domain path, node seeds).
+
+Property reference and activation semantics: [`README.md`](README.md).
+
+## Prerequisites
+
+**Build and load** (from the nvnmos `rust/` directory):
+
+`cargo build` here produces `nvnmosd` and `libgstnmos.so` only. It does
+**not** build the MXL runtime (`libmxl.so`) or the `gst-mxl-rs` plugin
+(`libgstmxl.so`) — those live in the [mxl](https://github.com/dmf-mxl/mxl)
+repo and are required only for `transport=mxl`.
+
+```sh
+# libnvnmos.so — build via the nvnmos CMake/Conan flow first (see rust/README.md)
+export NVNMOS_LIB_DIR=/path/to/nvnmos/build
+
+cd /path/to/nvnmos/rust
+cargo build -p nvnmosd -p gst-nmos-rs
+export GST_PLUGIN_PATH=/path/to/nvnmos/rust/target/debug
+export LD_LIBRARY_PATH=$NVNMOS_LIB_DIR
+```
+
+For **`transport=mxl`**, also build MXL and extend the plugin / library paths
+(sibling checkout layout assumed by the demo script):
+
+```sh
+MXL_REPO=/path/to/mxl
+cargo build --manifest-path "$MXL_REPO/rust/Cargo.toml" -p gst-mxl-rs
+export GST_PLUGIN_PATH=$GST_PLUGIN_PATH:$MXL_REPO/rust/target/debug
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MXL_REPO/build/Linux-Clang-Debug/lib
+```
+
+`transport={udp,udp2}` needs only the nvnmos build above plus system
+GStreamer plugins (gst-plugins-good; gst-plugins-rs for `udp2`).
+
+**Daemon** (terminal 1 — or use the demo script, which starts its own):
+
+```sh
+/path/to/nvnmos/rust/target/debug/nvnmosd --uds /tmp/nvnmosd.sock
+```
+
+Pipelines below use `daemon-uri=$DEMO_DAEMON_URI` (default
+`unix:/tmp/nvnmosd.sock`) unless noted.
+
+**MXL domain** — example scripts call `bootstrap_mxl_domain` (from
+[`env.sh`](scripts/env.sh)), which creates `domain_def.json` on first use
+or reuses the `id` already stored under `DEMO_MXL_DOMAIN_PATH`. Override the
+path or export `DEMO_MXL_DOMAIN_ID` before the first run; to start fresh,
+remove the domain directory.
+
+```sh
+export DEMO_MXL_DOMAIN_PATH=/dev/shm/gst-nmos-rs-examples
+# optional on first run: export DEMO_MXL_DOMAIN_ID=$(uuidgen)
+```
+
+The example scripts read `DEMO_MXL_*` flow IDs and `DEMO_UDP_*` multicast
+destinations from the environment (see [`scripts/env.sh`](scripts/env.sh)).
+Override any `DEMO_MXL_{VIDEO,AUDIO}_FLOW_ID{1-4}` or
+`DEMO_UDP_{VIDEO,AUDIO}_MCAST_{IP,PORT}{1-4}` before running.
+
+**UDP multicast NIC** — set the interface that can carry multicast:
+
+```sh
+export DEMO_NIC_IP=203.0.113.1   # your high-bandwidth network interface
+# 203.0.113.1 is from RFC 5737 TEST-NET-3 (reserved for documentation).
+```
+
+High-rate ST 2110-20 video (~1 Gbps at 1080p25 UYVP) needs a large
+`udpsrc` / `udpsink` socket buffer on **`transport=udp` / `udp2`**.
+All UDP video examples below set:
+
+```text
+transport-properties="properties,buffer-size=16777216"
+```
+
+(16 MiB — override with `DEMO_UDP_VIDEO_BUFFER_SIZE` in the example
+scripts.) If packets are dropped, raise `net.core.rmem_max` / `wmem_max`:
+
+```sh
+sudo sysctl -w net.core.rmem_max=16777216 net.core.wmem_max=16777216
+```
+
+Pick **`transport=udp`** (gst-plugins-good), **`transport=udp2`**
+(gst-plugins-rs), or **`transport=nvdsudp`** (DeepStream Rivermax).
+Example UDP scripts use `DEMO_UDP_TRANSPORT` for the `transport=` property
+(default `udp`).
+
+## Environment variables
+
+[`env.sh`](scripts/env.sh) exports user-tunable values with the `DEMO_`
+prefix. Example scripts and the interactive demo both source this file.
+
+| Variable | Role |
+|----------|------|
+| `DEMO_DAEMON_SOCK` | gRPC UDS path for `nvnmosd` (default `/tmp/nvnmosd.sock`) |
+| `DEMO_DAEMON_URI` | `unix:` URI derived from `DEMO_DAEMON_SOCK` (used as `daemon-uri=`) |
+| `DEMO_NIC_IP` | Local NIC for UDP IS-05 endpoint props and SDP source-filter |
+| `DEMO_UDP_TRANSPORT` | `transport=` on example pipelines: `udp`, `udp2`, or `nvdsudp` |
+| `DEMO_MXL_DOMAIN_ID` / `DEMO_MXL_DOMAIN_PATH` | MXL shared-memory domain |
+| `DEMO_MXL_{VIDEO,AUDIO}_FLOW_ID{1-4}` | MXL flow identity (paired per index) |
+| `DEMO_UDP_{VIDEO,AUDIO}_MCAST_{IP,PORT}{1-4}` | UDP multicast groups (paired per index) |
+| `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_CAPS` | Primary essence caps |
+| `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_LABEL` | Primary essence name for NMOS `label=` (keep in sync with `*_CAPS`) |
+| `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_CAPS_ALT` | Alternate essence (demo Node 4) |
+| `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_LABEL_ALT` | Alternate essence name for NMOS `label=` (keep in sync with `*_CAPS_ALT`) |
+| `DEMO_UDP_AUDIO_TRANSPORT_CAPS_ALT` | Alt UDP audio `transport-caps` (`a-ptime=0.125` ms; demo Node 4) |
+| `DEMO_UDP_VIDEO_BUFFER_SIZE` | `udpsrc`/`udpsink` socket buffer (`udp`/`udp2` only) |
+| `DEMO_VIDEO_QUEUE_MAX_BUFFERS` | Queue after video `nmossrc` on receiver / flipper paths |
+| `DEMO_AUDIO_QUEUE_MAX_TIME_MS` | Queue after audio `nmossrc` on receiver / flipper paths |
+| `DEMO_{AUDIO,VIDEO}_SINK` | Playback sink elements (e.g. `fakesink`, `autovideosink`; scripts add `videoconvert`/`audioconvert` upstream) |
+
+The interactive demo adds `DEMO_TRANSPORT` (`mxl` \| `udp` \| `udp2` \|
+`nvdsudp`) to select the transport family for the whole topology. Example
+scripts set `transport=mxl` explicitly on MXL recipes and use
+`DEMO_UDP_TRANSPORT` on UDP recipes.
+
+## Shared Essence
+
+By default, essence formats are aligned across transports at
+**1920×1080 @ 25 fps 10-bit 4:2:2** video plus **2 ch @ 48 kHz** audio.
+
+| Flow | MXL caps | UDP caps |
+|------|----------|----------|
+| Video | `DEMO_MXL_VIDEO_CAPS` — 1080p25 `v210` | `DEMO_UDP_VIDEO_CAPS` — 1080p25 `UYVP` |
+| Audio | `DEMO_MXL_AUDIO_CAPS` — 2 ch `F32LE` | `DEMO_UDP_AUDIO_CAPS` — 2 ch `S24BE` |
+| Video (alt) | `DEMO_MXL_VIDEO_CAPS_ALT` — 1080p29.97 `v210` | `DEMO_UDP_VIDEO_CAPS_ALT` — 1080p29.97 `UYVP` |
+| Audio (alt) | `DEMO_MXL_AUDIO_CAPS_ALT` — 8 ch `F32LE` | `DEMO_UDP_AUDIO_CAPS_ALT` — 8 ch `S24BE`; `DEMO_UDP_AUDIO_TRANSPORT_CAPS_ALT` — `ptime=0.125` ms |
+
+Primary caps match the table in [`env.sh`](scripts/env.sh).
+Alternate caps are used by demo **Node 4** for wide-receiver caps
+renegotiation tests (not covered by the static example scripts).
+
+## Scenarios
+
+| Scenario | MXL script | UDP script (`udp` / `udp2` / `nvdsudp`) | Demo script node |
+|----------|------------|-------------------------------------------|------------------|
+| 1080p25 sender | [`1080p25-sender-mxl.sh`](scripts/example-pipelines/1080p25-sender-mxl.sh) | [`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh) | Node 1 video |
+| 1080p25 receiver | [`1080p25-receiver-mxl.sh`](scripts/example-pipelines/1080p25-receiver-mxl.sh) | [`1080p25-receiver-udp.sh`](scripts/example-pipelines/1080p25-receiver-udp.sh) | Node 2 video |
+| Flip / process | [`1080p25-flipper-mxl.sh`](scripts/example-pipelines/1080p25-flipper-mxl.sh) | [`1080p25-flipper-udp.sh`](scripts/example-pipelines/1080p25-flipper-udp.sh) | Node 3 video |
+| Deferred sender | [`1080p25-deferred-sender-mxl.sh`](scripts/example-pipelines/1080p25-deferred-sender-mxl.sh) | [`1080p25-deferred-sender-udp.sh`](scripts/example-pipelines/1080p25-deferred-sender-udp.sh) | — |
+| Multi-flow sender | [`multi-flow-sender-mxl.sh`](scripts/example-pipelines/multi-flow-sender-mxl.sh) | [`multi-flow-sender-udp.sh`](scripts/example-pipelines/multi-flow-sender-udp.sh) | Node 1 (video + audio) |
+| Full lab + IS-05 | — | — | [`gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh) |
+
+### 1080p25 Sender
+
+[`1080p25-sender-mxl.sh`](scripts/example-pipelines/1080p25-sender-mxl.sh) ·
+[`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh)
+
+**MXL** — caps + `mxl-flow-id` synthesis, eager activation:
+
+```sh
+./scripts/example-pipelines/1080p25-sender-mxl.sh
+```
+
+Equivalent one-liner:
+
+```sh
+gst-launch-1.0 -e \
+  videotestsrc pattern=smpte is-live=true ! \
+  video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive ! \
+  nmossink transport=mxl daemon-uri=$DEMO_DAEMON_URI \
+    node-seed=example sender-name=video1 \
+    mxl-domain-id=$DEMO_MXL_DOMAIN_ID \
+    mxl-domain-path=$DEMO_MXL_DOMAIN_PATH \
+    mxl-flow-id=$DEMO_MXL_VIDEO_FLOW_ID1 \
+    caps="video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive" \
+    auto-activate=true
+```
+
+**UDP** — caps + IS-05 endpoint props synthesise configuring SDP:
+
+```sh
+export DEMO_NIC_IP=203.0.113.1   # your high-bandwidth network interface
+./scripts/example-pipelines/1080p25-sender-udp.sh
+```
+
+Equivalent one-liner (`transport=udp2` also works):
+
+```sh
+gst-launch-1.0 -e \
+  videotestsrc pattern=smpte is-live=true ! \
+  video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive ! \
+  nmossink transport=udp daemon-uri=$DEMO_DAEMON_URI \
+    node-seed=example sender-name=video1 \
+    destination-ip=$DEMO_UDP_VIDEO_MCAST_IP1 destination-port=$DEMO_UDP_VIDEO_MCAST_PORT1 source-ip=$DEMO_NIC_IP \
+    transport-properties="properties,buffer-size=16777216" \
+    caps="video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive" \
+    auto-activate=true
+```
+
+### 1080p25 Receiver
+
+[`1080p25-receiver-mxl.sh`](scripts/example-pipelines/1080p25-receiver-mxl.sh) ·
+[`1080p25-receiver-udp.sh`](scripts/example-pipelines/1080p25-receiver-udp.sh)
+
+Start a matching sender first (same flow identity / multicast group).
+
+**MXL:**
+
+```sh
+./scripts/example-pipelines/1080p25-receiver-mxl.sh
+```
+
+**UDP:**
+
+```sh
+./scripts/example-pipelines/1080p25-receiver-udp.sh
+```
+
+Use `DEMO_VIDEO_SINK=fakesink` on headless hosts (element name only;
+scripts add `videoconvert` upstream). Set `DEMO_NIC_IP` to your
+high-bandwidth network interface.
+
+### Flipper (Receive → Process → Re-Transmit)
+
+[`1080p25-flipper-mxl.sh`](scripts/example-pipelines/1080p25-flipper-mxl.sh) ·
+[`1080p25-flipper-udp.sh`](scripts/example-pipelines/1080p25-flipper-udp.sh)
+
+One `node-seed`, two resources: `nmossrc` consumes the inbound flow,
+`nmossink` publishes the processed flow (`DEMO_MXL_VIDEO_FLOW_ID3` / outbound
+multicast group).
+
+For MXL, start [`1080p25-sender-mxl.sh`](scripts/example-pipelines/1080p25-sender-mxl.sh)
+in another terminal first (inbound flow `DEMO_MXL_VIDEO_FLOW_ID1`). For UDP, start
+[`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh)
+before the flipper script.
+
+```sh
+# MXL flipper (after sender is running)
+./scripts/example-pipelines/1080p25-flipper-mxl.sh
+
+# UDP flipper (after sender is running)
+./scripts/example-pipelines/1080p25-flipper-udp.sh
+```
+
+For IS-05-gated activation (resources visible on IS-04 before the data
+path goes live), omit `auto-activate=true` and PATCH
+`/single/{senders,receivers}/{id}/staged` — demo **Node 3** exercises
+this; example scripts use `auto-activate=true` for simplicity.
+
+### Deferred AddSender
+
+[`1080p25-deferred-sender-mxl.sh`](scripts/example-pipelines/1080p25-deferred-sender-mxl.sh) ·
+[`1080p25-deferred-sender-udp.sh`](scripts/example-pipelines/1080p25-deferred-sender-udp.sh)
+
+When neither `transport-file*` nor `caps=` is set on `nmossink`, AddSender
+runs at **READY→PAUSED** from upstream peer caps. Transport-specific identity
+props must still be set (MXL domain + `mxl-flow-id`, or UDP destination
+multicast + `source-ip`).
+
+**MXL:**
+
+```sh
+./scripts/example-pipelines/1080p25-deferred-sender-mxl.sh
+```
+
+**UDP:**
+
+```sh
+./scripts/example-pipelines/1080p25-deferred-sender-udp.sh
+```
+
+Expected log sequence: `no resource added` at NULL→READY, then
+`deferred AddSender complete` at READY→PAUSED (MXL synthesises `flow_def`
+JSON; UDP synthesises configuring SDP).
+
+### Multi-Flow (Video + Audio on One Node)
+
+[`multi-flow-sender-mxl.sh`](scripts/example-pipelines/multi-flow-sender-mxl.sh) ·
+[`multi-flow-sender-udp.sh`](scripts/example-pipelines/multi-flow-sender-udp.sh)
+
+Two `nmossink` elements sharing `node-seed`, distinct
+`sender-name` / flow identity:
+
+```sh
+./scripts/example-pipelines/multi-flow-sender-mxl.sh
+# or
+./scripts/example-pipelines/multi-flow-sender-udp.sh
+```
+
+The rigorous **video + ANC** (`meta/x-st-2038`) integration test with
+real buffer validation is [`tests/multi_flow_video_data.rs`](tests/multi_flow_video_data.rs)
+(`#[ignore]` — needs full MXL toolchain). Opt-in:
+
+```sh
+cargo test -p gst-nmos-rs --test multi_flow_video_data -- --ignored --test-threads=1
+```
+
+## `transport=nvdsudp` (DeepStream Rivermax)
+
+Same IS-05 endpoint properties and `DEMO_UDP_VIDEO_CAPS` essence as `udp` /
+`udp2`; inner chain is `nvdsudpsrc` / `nvdsudpsink` (no `buffer-size` — use
+`transport-properties` for `gpu-id`, thread cores, etc.).
+Prerequisites: Install [DeepStream 9.0](https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html)
+and [Rivermax](https://developer.nvidia.com/networking/rivermax) — see
+[`README.md`](README.md#transportnvdsudp-deepstream-rivermax).
+
+```sh
+export DEMO_NIC_IP=203.0.113.1
+DEMO_UDP_TRANSPORT=nvdsudp ./scripts/example-pipelines/1080p25-sender-udp.sh
+```
+
+Interactive demo:
+
+```sh
+export DEMO_NIC_IP=203.0.113.1
+DEMO_TRANSPORT=nvdsudp ./scripts/gst-nmos-rs-demo.sh
+```
+
+## Interactive Demo
+
+[`gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh)
+
+```sh
+# MXL (default)
+./scripts/gst-nmos-rs-demo.sh
+
+# UDP — same topology, matched 1080p25 essence
+export DEMO_NIC_IP=203.0.113.1   # your high-bandwidth network interface
+DEMO_TRANSPORT=udp ./scripts/gst-nmos-rs-demo.sh
+```
+
+WSL with WSLg audio: `export PULSE_SERVER=unix:/mnt/wslg/PulseServer` before launch.
+Or for headless mode: `DEMO_AUDIO_SINK=fakesink DEMO_VIDEO_SINK=fakesink DEMO_TRANSPORT=udp ./scripts/gst-nmos-rs-demo.sh`

--- a/rust/gst-nmos-rs/scripts/env.sh
+++ b/rust/gst-nmos-rs/scripts/env.sh
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared defaults for the interactive demo and example-pipelines/*.sh.
+# Source from `scripts/example-pipelines/*.sh`:
+#   source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+# Source from `scripts/gst-nmos-rs-demo.sh`:
+#   source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
+#
+# All user-tunable values use the `DEMO_` prefix. The demo script may
+# override paths (domain, node seeds) before sourcing this file.
+#
+# MXL flow IDs — paired video/audio per set (1–4):
+#   NNNNNNNN-aaaa-… = video, NNNNNNNN-bbbb-… = audio (same N prefix per pair).
+# RTP/UDP multicast — paired video/audio per set (1–4), same index as MXL pairs.
+
+# gRPC UDS — must match a running `nvnmosd`.
+export DEMO_DAEMON_SOCK=${DEMO_DAEMON_SOCK:-/tmp/nvnmosd.sock}
+export DEMO_DAEMON_URI="unix:${DEMO_DAEMON_SOCK}"
+
+# Local NIC for RTP/UDP IS-05 endpoint properties and SDP source-filter.
+# Skips loopback (WSL2 can assign a global-scope address on `lo`).
+# Override with DEMO_NIC_IP.
+_default_nic_ip() {
+    local addr
+    if command -v ip >/dev/null 2>&1; then
+        addr=$(ip -4 -o addr show 2>/dev/null \
+            | awk '$2 != "lo" {print $4; exit}' \
+            | cut -d/ -f1)
+    fi
+    if [[ -z "${addr:-}" ]]; then
+        addr=$(hostname -I 2>/dev/null | awk '{print $1}')
+    fi
+    echo "${addr:-127.0.0.1}"
+}
+export DEMO_NIC_IP=${DEMO_NIC_IP:-$(_default_nic_ip)}
+
+# `transport={udp,udp2,nvdsudp}` on nmossrc/nmossink for RTP/UDP (ST 2110).
+# `udp` requires gst-plugins-good, `udp2` also requires gst-plugins-rs.
+# `nvdsudp` requires gst-nvdsudp from DeepStream 9.0 and Rivermax (see README).
+export DEMO_UDP_TRANSPORT=${DEMO_UDP_TRANSPORT:-udp}
+
+# Primary essence: 1080p25 10-bit 4:2:2 video + 2 ch @ 48 kHz audio.
+export DEMO_MXL_VIDEO_CAPS='video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
+export DEMO_UDP_VIDEO_CAPS='video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
+export DEMO_MXL_AUDIO_CAPS='audio/x-raw,format=F32LE,rate=48000,channels=2,layout=interleaved'
+export DEMO_UDP_AUDIO_CAPS='audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved'
+# Truncated human-readable essence name for NMOS `label=` — keep in sync with *_CAPS.
+export DEMO_MXL_VIDEO_LABEL=${DEMO_MXL_VIDEO_LABEL:-1080p25 v210}
+export DEMO_UDP_VIDEO_LABEL=${DEMO_UDP_VIDEO_LABEL:-1080p25 UYVP}
+export DEMO_MXL_AUDIO_LABEL=${DEMO_MXL_AUDIO_LABEL:-48 kHz F32LE 2ch}
+export DEMO_UDP_AUDIO_LABEL=${DEMO_UDP_AUDIO_LABEL:-48 kHz S24BE 2ch}
+
+# Alternate essence (demo Node 4 / wide-receiver CAPS renegotiation tests).
+export DEMO_MXL_VIDEO_CAPS_ALT='video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001,interlace-mode=progressive'
+export DEMO_UDP_VIDEO_CAPS_ALT='video/x-raw,format=UYVP,width=1920,height=1080,framerate=30000/1001,interlace-mode=progressive'
+export DEMO_MXL_AUDIO_CAPS_ALT='audio/x-raw,format=F32LE,rate=48000,channels=8,layout=interleaved'
+export DEMO_UDP_AUDIO_CAPS_ALT='audio/x-raw,format=S24BE,rate=48000,channels=8,layout=interleaved'
+export DEMO_MXL_VIDEO_LABEL_ALT=${DEMO_MXL_VIDEO_LABEL_ALT:-1080p29.97 v210}
+export DEMO_UDP_VIDEO_LABEL_ALT=${DEMO_UDP_VIDEO_LABEL_ALT:-1080p29.97 UYVP}
+export DEMO_MXL_AUDIO_LABEL_ALT=${DEMO_MXL_AUDIO_LABEL_ALT:-48 kHz F32LE 8ch}
+export DEMO_UDP_AUDIO_LABEL_ALT=${DEMO_UDP_AUDIO_LABEL_ALT:-48 kHz S24BE 8ch}
+# ST 2110-30 shorter packet duration for alt UDP audio (Node 4).
+export DEMO_UDP_AUDIO_TRANSPORT_CAPS_ALT='application/x-rtp,a-ptime=(string)0.125'
+
+# UDP multicast destination per flow pair (1–4), mirroring DEMO_MXL_*_FLOW_ID*.
+export DEMO_UDP_VIDEO_MCAST_IP1=${DEMO_UDP_VIDEO_MCAST_IP1:-232.99.99.1}
+export DEMO_UDP_VIDEO_MCAST_PORT1=${DEMO_UDP_VIDEO_MCAST_PORT1:-5004}
+export DEMO_UDP_AUDIO_MCAST_IP1=${DEMO_UDP_AUDIO_MCAST_IP1:-232.99.99.2}
+export DEMO_UDP_AUDIO_MCAST_PORT1=${DEMO_UDP_AUDIO_MCAST_PORT1:-5006}
+export DEMO_UDP_VIDEO_MCAST_IP2=${DEMO_UDP_VIDEO_MCAST_IP2:-232.99.99.7}
+export DEMO_UDP_VIDEO_MCAST_PORT2=${DEMO_UDP_VIDEO_MCAST_PORT2:-5016}
+export DEMO_UDP_AUDIO_MCAST_IP2=${DEMO_UDP_AUDIO_MCAST_IP2:-232.99.99.8}
+export DEMO_UDP_AUDIO_MCAST_PORT2=${DEMO_UDP_AUDIO_MCAST_PORT2:-5018}
+export DEMO_UDP_VIDEO_MCAST_IP3=${DEMO_UDP_VIDEO_MCAST_IP3:-232.99.99.3}
+export DEMO_UDP_VIDEO_MCAST_PORT3=${DEMO_UDP_VIDEO_MCAST_PORT3:-5008}
+export DEMO_UDP_AUDIO_MCAST_IP3=${DEMO_UDP_AUDIO_MCAST_IP3:-232.99.99.4}
+export DEMO_UDP_AUDIO_MCAST_PORT3=${DEMO_UDP_AUDIO_MCAST_PORT3:-5010}
+export DEMO_UDP_VIDEO_MCAST_IP4=${DEMO_UDP_VIDEO_MCAST_IP4:-232.99.99.5}
+export DEMO_UDP_VIDEO_MCAST_PORT4=${DEMO_UDP_VIDEO_MCAST_PORT4:-5012}
+export DEMO_UDP_AUDIO_MCAST_IP4=${DEMO_UDP_AUDIO_MCAST_IP4:-232.99.99.6}
+export DEMO_UDP_AUDIO_MCAST_PORT4=${DEMO_UDP_AUDIO_MCAST_PORT4:-5014}
+
+# MXL domain (see `bootstrap_mxl_domain`).
+export DEMO_MXL_DOMAIN_ID=${DEMO_MXL_DOMAIN_ID:-$(uuidgen)}
+export DEMO_MXL_DOMAIN_PATH=${DEMO_MXL_DOMAIN_PATH:-/dev/shm/gst-nmos-rs-examples}
+
+export DEMO_MXL_VIDEO_FLOW_ID1=${DEMO_MXL_VIDEO_FLOW_ID1:-11111111-aaaa-1111-aaaa-111111111111}
+export DEMO_MXL_AUDIO_FLOW_ID1=${DEMO_MXL_AUDIO_FLOW_ID1:-11111111-bbbb-1111-bbbb-111111111111}
+export DEMO_MXL_VIDEO_FLOW_ID2=${DEMO_MXL_VIDEO_FLOW_ID2:-22222222-aaaa-2222-aaaa-222222222222}
+export DEMO_MXL_AUDIO_FLOW_ID2=${DEMO_MXL_AUDIO_FLOW_ID2:-22222222-bbbb-2222-bbbb-222222222222}
+export DEMO_MXL_VIDEO_FLOW_ID3=${DEMO_MXL_VIDEO_FLOW_ID3:-33333333-aaaa-3333-aaaa-333333333333}
+export DEMO_MXL_AUDIO_FLOW_ID3=${DEMO_MXL_AUDIO_FLOW_ID3:-33333333-bbbb-3333-bbbb-333333333333}
+export DEMO_MXL_VIDEO_FLOW_ID4=${DEMO_MXL_VIDEO_FLOW_ID4:-44444444-aaaa-4444-aaaa-444444444444}
+export DEMO_MXL_AUDIO_FLOW_ID4=${DEMO_MXL_AUDIO_FLOW_ID4:-44444444-bbbb-4444-bbbb-444444444444}
+
+# udpsrc/udpsink socket buffer for video (bytes). Not used with nvdsudp.
+export DEMO_UDP_VIDEO_BUFFER_SIZE=${DEMO_UDP_VIDEO_BUFFER_SIZE:-16777216}
+
+# Queues after nmossrc on receiver / processor branches.
+export DEMO_VIDEO_QUEUE_MAX_BUFFERS=${DEMO_VIDEO_QUEUE_MAX_BUFFERS:-2}
+export DEMO_AUDIO_QUEUE_MAX_TIME_MS=${DEMO_AUDIO_QUEUE_MAX_TIME_MS:-50}
+
+# Playback sink elements (name only — not a chain). Scripts add
+# videoconvert/audioconvert upstream as needed. Override for
+# headless or CI (e.g. DEMO_VIDEO_SINK=fakesink DEMO_AUDIO_SINK=fakesink).
+export DEMO_VIDEO_SINK=${DEMO_VIDEO_SINK:-autovideosink}
+export DEMO_AUDIO_SINK=${DEMO_AUDIO_SINK:-autoaudiosink}
+
+demo_video_queue() {
+    local name=${1:-}
+    if [[ -n "$name" ]]; then
+        echo queue name="$name" \
+            "max-size-buffers=$DEMO_VIDEO_QUEUE_MAX_BUFFERS" \
+            max-size-bytes=0 max-size-time=0
+    else
+        echo queue \
+            "max-size-buffers=$DEMO_VIDEO_QUEUE_MAX_BUFFERS" \
+            max-size-bytes=0 max-size-time=0
+    fi
+}
+
+demo_audio_queue() {
+    local name=${1:-}
+    local max_time_ns=$(( DEMO_AUDIO_QUEUE_MAX_TIME_MS * 1000000 ))
+    if [[ -n "$name" ]]; then
+        echo queue name="$name" \
+            "max-size-time=$max_time_ns" \
+            max-size-buffers=0 max-size-bytes=0
+    else
+        echo queue \
+            "max-size-time=$max_time_ns" \
+            max-size-buffers=0 max-size-bytes=0
+    fi
+}
+
+udp_video_buffer_props() {
+    local t=${1:-${DEMO_TRANSPORT:-${DEMO_UDP_TRANSPORT:-udp}}}
+    case "$t" in
+        udp|udp2)
+            printf 'transport-properties="properties,buffer-size=%s"' \
+                "$DEMO_UDP_VIDEO_BUFFER_SIZE"
+            ;;
+    esac
+}
+
+udp_audio_transport_caps_alt() {
+    local t=${1:-${DEMO_TRANSPORT:-${DEMO_UDP_TRANSPORT:-udp}}}
+    case "$t" in
+        udp|udp2|nvdsudp)
+            printf 'transport-caps="%s"' "$DEMO_UDP_AUDIO_TRANSPORT_CAPS_ALT"
+            ;;
+    esac
+}
+
+is_udp_transport() {
+    case "${1:-${DEMO_TRANSPORT:-${DEMO_UDP_TRANSPORT:-udp}}}" in
+        udp|udp2|nvdsudp) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+require_nvnmosd() {
+    if ! ss -xlpn 2>/dev/null | rg -F "LISTEN" | rg -qF "$DEMO_DAEMON_SOCK"; then
+        echo "[error] $DEMO_DAEMON_SOCK is not listening — start nvnmosd first" >&2
+        exit 1
+    fi
+}
+
+bootstrap_mxl_domain() {
+    mkdir -p "$DEMO_MXL_DOMAIN_PATH"
+    local def="$DEMO_MXL_DOMAIN_PATH/domain_def.json"
+    if [[ -f "$def" ]]; then
+        if command -v jq >/dev/null 2>&1; then
+            local existing_id
+            existing_id=$(jq -r '.id // empty' "$def" 2>/dev/null || true)
+            if [[ -n "$existing_id" ]]; then
+                export DEMO_MXL_DOMAIN_ID="$existing_id"
+                return 0
+            fi
+        fi
+        echo "[warn] $def exists but .id could not be read — using DEMO_MXL_DOMAIN_ID=$DEMO_MXL_DOMAIN_ID" >&2
+        return 0
+    fi
+    printf '{"id":"%s","label":"gst-nmos-rs example domain"}\n' "$DEMO_MXL_DOMAIN_ID" \
+        >"$def"
+}

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-mxl.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+# Deferred AddSender: no `caps=` on nmossink — peer caps at READY→PAUSED
+# drive flow_def synthesis. Domain + flow identity props must still be set.
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_MXL_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-deferred \
+        http-port=18103 \
+        sender-name=video1 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-udp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+# Deferred AddSender: no `caps=` on nmossink — peer caps at READY→PAUSED
+# drive SDP synthesis. Endpoint props must still be set.
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-deferred \
+        http-port=18103 \
+        sender-name=video1 \
+        destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-mxl.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-flipper \
+        http-port=18104 \
+        receiver-name=video-in \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" \
+        caps="$DEMO_MXL_VIDEO_CAPS" \
+        auto-activate=true ! \
+    $(demo_video_queue) ! \
+    videoflip method=horizontal-flip ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-flipper \
+        http-port=18104 \
+        sender-name=video-out \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID3" \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-udp.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+# Processor: receive pair-1 video multicast, flip, re-transmit on pair-3
+# (Node 3 out). Start 1080p25-sender-udp.sh first.
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-flipper \
+        http-port=18104 \
+        receiver-name=video-in \
+        multicast-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        interface-ip="$DEMO_NIC_IP" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_CAPS" \
+        auto-activate=true ! \
+    $(demo_video_queue) ! \
+    videoflip method=horizontal-flip ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-flipper \
+        http-port=18104 \
+        sender-name=video-out \
+        destination-ip="$DEMO_UDP_VIDEO_MCAST_IP3" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT3" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-mxl.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-consumer \
+        http-port=18102 \
+        receiver-name=video2 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" \
+        caps="$DEMO_MXL_VIDEO_CAPS" \
+        label="${DEMO_MXL_VIDEO_LABEL} receiver" \
+        auto-activate=true ! \
+    $(demo_video_queue) ! \
+    videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-consumer \
+        http-port=18102 \
+        receiver-name=video2 \
+        multicast-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        interface-ip="$DEMO_NIC_IP" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_CAPS" \
+        label="${DEMO_UDP_VIDEO_LABEL} receiver" \
+        auto-activate=true ! \
+    $(demo_video_queue) ! \
+    videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-mxl.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_MXL_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-producer \
+        http-port=18101 \
+        sender-name=video1 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" \
+        caps="$DEMO_MXL_VIDEO_CAPS" \
+        label="${DEMO_MXL_VIDEO_LABEL} sender" \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-producer \
+        http-port=18101 \
+        sender-name=video1 \
+        destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_CAPS" \
+        label="${DEMO_UDP_VIDEO_LABEL} sender" \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-receiver-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-receiver-mxl.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal MXL receiver for controller-driven IS-05 activation.
+#
+# AddReceiver at NULL→READY with configuring flow_def from `caps`
+# and `mxl-domain-*` only.
+# Subscription identity (`mxl-flow-id`) and the data path arrive via
+# IS-05 PATCH on /single/receivers/{id}/staged.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-minimal-consumer \
+        http-port=18112 \
+        receiver-name=video1 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        caps="$DEMO_MXL_VIDEO_CAPS" \
+        label="minimal ${DEMO_MXL_VIDEO_LABEL} receiver" \
+        auto-activate=false ! \
+    $(demo_video_queue) ! \
+    videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-receiver-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-receiver-udp.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal RTP/UDP receiver for controller-driven IS-05 activation.
+#
+# AddReceiver at NULL→READY with configuring SDP from `caps` and
+# `interface-ip` only.
+# Subscription identity (e.g., `multicast-ip`, `destination-port`)
+# and the data path arrive via IS-05 PATCH on
+# /single/receivers/{id}/staged.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-consumer \
+        http-port=18112 \
+        receiver-name=video1 \
+        interface-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_CAPS" \
+        label="minimal ${DEMO_UDP_VIDEO_LABEL} receiver" \
+        auto-activate=false ! \
+    $(demo_video_queue) ! \
+    videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-sender-mxl.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal MXL sender for controller-driven IS-05 activation.
+#
+# AddSender at NULL→READY with configuring flow_def from `caps` and
+# `mxl-domain-*` only.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_MXL_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-minimal-producer \
+        http-port=18111 \
+        sender-name=video1 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        caps="$DEMO_MXL_VIDEO_CAPS" \
+        label="minimal ${DEMO_MXL_VIDEO_LABEL} sender" \
+        auto-activate=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-sender-udp.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal RTP/UDP sender for controller-driven IS-05 activation.
+#
+# AddSender at NULL→READY with configuring SDP from `caps` and
+# `source-ip` only.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-producer \
+        http-port=18111 \
+        sender-name=video1 \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_CAPS" \
+        label="minimal ${DEMO_UDP_VIDEO_LABEL} sender" \
+        auto-activate=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-mxl.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+# Two Senders on one Node (video + audio) — mirrors demo Node 1.
+exec gst-launch-1.0 -e \
+    videotestsrc is-live=true ! "$DEMO_MXL_VIDEO_CAPS" ! \
+    nmossink daemon-uri="$DEMO_DAEMON_URI" transport=mxl \
+        node-seed=example-multi sender-name=video1 \
+        http-port=18105 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" caps="$DEMO_MXL_VIDEO_CAPS" \
+        label="${DEMO_MXL_VIDEO_LABEL} sender" auto-activate=true \
+    audiotestsrc wave=sine freq=440 is-live=true ! "$DEMO_MXL_AUDIO_CAPS" ! \
+    nmossink daemon-uri="$DEMO_DAEMON_URI" transport=mxl \
+        node-seed=example-multi sender-name=audio1 \
+        http-port=18105 \
+        mxl-domain-id="$DEMO_MXL_DOMAIN_ID" mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        mxl-flow-id="$DEMO_MXL_AUDIO_FLOW_ID1" caps="$DEMO_MXL_AUDIO_CAPS" \
+        label="${DEMO_MXL_AUDIO_LABEL} sender" auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-udp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    videotestsrc is-live=true ! "$DEMO_UDP_VIDEO_CAPS" ! \
+    nmossink daemon-uri="$DEMO_DAEMON_URI" transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-multi sender-name=video1 \
+        http-port=18105 \
+        destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        source-ip="$DEMO_NIC_IP" $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_CAPS" \
+        label="${DEMO_UDP_VIDEO_LABEL} sender" auto-activate=true \
+    audiotestsrc wave=sine freq=440 is-live=true ! "$DEMO_UDP_AUDIO_CAPS" ! \
+    nmossink daemon-uri="$DEMO_DAEMON_URI" transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-multi sender-name=audio1 \
+        http-port=18105 \
+        destination-ip="$DEMO_UDP_AUDIO_MCAST_IP1" destination-port="$DEMO_UDP_AUDIO_MCAST_PORT1" \
+        source-ip="$DEMO_NIC_IP" caps="$DEMO_UDP_AUDIO_CAPS" \
+        label="${DEMO_UDP_AUDIO_LABEL} sender" auto-activate=true

--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -441,7 +441,7 @@ transport_identity_from_active() {
 # `autoaudiosink` spends up to ~60 s probing PipeWire / PulseAudio /
 # ALSA before falling back, which serialises against every other
 # element in Node 2's pipeline (GStreamer's bin state-change is
-# synchronous) and delays both Node 2 receivers' registration with
+# synchronous) and delays both Node 2 receivers' IS-04 visibility with
 # the daemon by the same ~60 s. If the script prints
 # "[poll] collect_urls: still missing after 90s: receivers/video2@…
 # receivers/audio2@…" or similar, override:
@@ -1192,7 +1192,7 @@ Activation state out of the box:
     so audio + video are flowing already.
 
   Node 3: \`auto-activate=false\` — the Receiver+Sender pairs are
-    registered (visible on IS-04) but the data path stays on the
+    added (visible on IS-04) but the data path stays on the
     caps-aware placeholder (an idle \`appsrc\` advertising the
     user-supplied caps so downstream negotiation completes) until
     you PATCH /staged on the Connection API. Until then no real
@@ -1253,7 +1253,7 @@ environment if a slow host needs more time at startup.
 Example PATCHes (copy/paste):
 
   # ---- Activate Node 3 (Receiver+Sender on each side) ----
-  # By default Node 3 is registered but inactive (auto-activate=false).
+  # By default Node 3 is added but inactive (auto-activate=false).
   # PATCH each /staged endpoint with master_enable=true to bring the
   # video processor live (the inner $LABEL_INNER_CHAIN instantiate
   # and data flows from Node 1 via Node 3's videoflip to Node 3's

--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -18,10 +18,15 @@
 #                                   gst-plugins-rs's `udpsrc2` and
 #                                   `*pay2` / `*depay2` siblings
 #                                   where available.
+#   DEMO_TRANSPORT=nvdsudp          ST 2110 via DeepStream `nvdsudpsrc` /
+#                                   `nvdsudpsink` (Rivermax). Requires
+#                                   DeepStream 9.0 and the Rivermax SDK —
+#                                   see their installation guides.
 #
 # The topology and interactive control loop are identical across
-# transports; only the per-Sender / per-Receiver property surface,
-# the essence caps, and the diagnostics differ. The MXL path uses
+# transports. Video is matched at 1920×1080 @ 25 fps 10-bit 4:2:2
+# (MXL `v210`, UDP `UYVP`); only the per-Sender / per-Receiver property
+# surface and diagnostics differ. The MXL path uses
 # `mxl-domain-id` / `mxl-domain-path` / `mxl-flow-id` to identify
 # Flows; the UDP path uses the IS-05 endpoint properties
 # (`destination-ip` etc. on senders, `multicast-ip` etc. on
@@ -36,8 +41,9 @@
 #
 #   Node 2 (consumer):  one pipeline with two `nmossrc` Receivers (one
 #                       per format) on the same Node, fed to `autoaudiosink`
-#                       and `autovideosink` (override AUDIO_SINK / VIDEO_SINK
-#                       via env for WSL / headless setups). Set
+#                       and `autovideosink` (override DEMO_AUDIO_SINK /
+#                       DEMO_VIDEO_SINK via env for WSL / headless setups).
+#                       Set
 #                       `DEMO_RECEIVER_CAPS_MODE` to `wide` or `narrow`
 #                       (default `auto`) on both receivers.
 #
@@ -85,60 +91,22 @@ set -u
 # the helper functions are in place.
 DEMO_TRANSPORT=${DEMO_TRANSPORT:-mxl}
 
-# Short queues on live paths (nmossrc → processing → nmossink / sinks).
-# Video: buffer count (2 frames @ 59.94 ≈ 33 ms); buffers=1 caused visible skips.
-DEMO_VIDEO_QUEUE_MAX_BUFFERS=${DEMO_VIDEO_QUEUE_MAX_BUFFERS:-2}
-# Audio: time limit — mxlsrc emits ~48 samples/buffer (1 ms @ 48 kHz).
-DEMO_AUDIO_QUEUE_MAX_TIME_MS=${DEMO_AUDIO_QUEUE_MAX_TIME_MS:-50}
-# Local NIC IP used by the UDP path: drives the receiver's
-# `interface-ip` (the IGMP-join interface, resolved to an iface name
-# for `udpsrc.multicast-iface`) and the sender's `source-ip`
-# (`udpsink.bind-address` plus the SDP `a=source-filter:`
-# include-source). Ignored when DEMO_TRANSPORT=mxl. Defaults to the
-# host's first non-loopback IPv4 address (typically `eth0` on
-# WSL / Docker; the primary physical NIC otherwise). libnvnmos
-# walks the host's iface list and skips `lo` when resolving the
-# SDP `a=x-nvnmos-iface-ip` attribute back to an iface, so anything
-# assigned to the loopback iface is rejected — including non-127.x
-# global-scope IPs like WSL2's quirky `10.255.255.254/32` on `lo`.
-_default_nic_ip() {
-    local addr
-    if command -v ip >/dev/null 2>&1; then
-        # `ip -4 -o addr show` prints one line per address; column
-        # 2 is the iface name, column 4 is the CIDR. Skip the
-        # loopback iface explicitly (WSL2 can land a global-scope
-        # IP on `lo`, so `scope global` alone isn't sufficient) and
-        # take the first surviving address.
-        addr=$(ip -4 -o addr show 2>/dev/null \
-            | awk '$2 != "lo" {print $4; exit}' \
-            | cut -d/ -f1)
-    fi
-    if [[ -z "${addr:-}" ]]; then
-        # Fallback: `hostname -I` (space-separated list, already
-        # excludes 127.0.0.1 by `hostname(1)` convention). Safety
-        # net for systems with iproute2 deinstalled / replaced.
-        addr=$(hostname -I 2>/dev/null | awk '{print $1}')
-    fi
-    echo "${addr:-127.0.0.1}"
-}
-DEMO_NIC_IP=${DEMO_NIC_IP:-$(_default_nic_ip)}
-
-# Inner `udpsrc` / `udpsrc2` / `udpsink` SO_RCVBUF / SO_SNDBUF (bytes) on
-# **video** flows only (audio stays at the element default). Applied via
-# nmossrc/nmossink `transport-properties` on UDP transports. Must be <=
-# `net.core.rmem_max` / `wmem_max`; see the sysctl note at demo startup.
-# Default 16 MiB. `DEMO_UDP_BUFFER_SIZE` is a deprecated alias.
-DEMO_UDP_VIDEO_BUFFER_SIZE=${DEMO_UDP_VIDEO_BUFFER_SIZE:-${DEMO_UDP_BUFFER_SIZE:-16777216}}
-
 # Resolve the script's own directory so `REPO` works in any checkout
 # without an env override. Layout assumed: <repo>/rust/gst-nmos-rs/scripts/
-# i.e. three `..` to reach the repo root.
 _SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO=${REPO:-$(cd "$_SCRIPT_DIR/../../.." && pwd)}
 MXL_REPO=${MXL_REPO:-$REPO/../mxl}
 
+# Demo MXL domain — set before sourcing env.sh so `uuidgen` is not used.
+DEMO_MXL_DOMAIN_ID=${DEMO_MXL_DOMAIN_ID:-1ac254d9-c9be-475a-93a7-f80b9c1063a8}
+DEMO_MXL_DOMAIN_PATH=${DEMO_MXL_DOMAIN_PATH:-/dev/shm/gst-nmos-rs-demo}
+
+# Shared flow identity, caps, NIC, and UDP multicast defaults.
+# shellcheck source=env.sh
+source "$_SCRIPT_DIR/env.sh"
+
 # `libnvnmos.so` (consumed by nvnmosd) and the gst-mxl-rs plugin +
-# libmxl.so runtime (consumed by the inner mxlsink/mxlsrc swaps).
+# libmxl.so runtime (required for the MXL inner transport chain).
 LIB=${NVNMOS_LIB_DIR:-$REPO/build}
 MXL_PLUGIN_DIR=${MXL_PLUGIN_DIR:-$MXL_REPO/rust/target/debug}
 MXL_RT_LIB_DIR=${MXL_RT_LIB_DIR:-$MXL_REPO/build/Linux-Clang-Debug/lib}
@@ -200,12 +168,6 @@ _assert_single_nvnmosd_on_sock() {
     fi
 }
 
-# Shared MXL Domain (tmpfs-backed). All three Nodes operate inside
-# it. Only used when DEMO_TRANSPORT=mxl; the bootstrap block below
-# only creates the directory + `domain_def.json` in that case.
-MXL_DOMAIN_ID=1ac254d9-c9be-475a-93a7-f80b9c1063a8
-MXL_DOMAIN_PATH=/dev/shm/gst-nmos-rs-demo
-
 # Three NMOS Nodes (one daemon, three node_seeds, three HTTP ports).
 # Spaced 10 apart deliberately: nmos-cpp's settings normaliser
 # auto-assigns each Node `ws_port = http_port + 1` (IS-07 events ws,
@@ -220,32 +182,9 @@ NODE2_SEED=demo-node2; NODE2_PORT=18021
 NODE3_SEED=demo-node3; NODE3_PORT=18031
 NODE4_SEED=demo-node4; NODE4_PORT=18041
 
-# Per-flow identity. Each Flow has a transport-specific identifier
-# used to wire Senders to their Receiver counterparts:
-#   MXL:  `mxl-flow-id` (UUID), shared between sender + matching receivers.
-#   UDP:  destination multicast group + port, joined by any receiver
-#         that wants to subscribe.
-# The MXL ids and UDP groups / ports stay stable here so the printed
-# curl recipes are deterministic.
-FLOW_VIDEO_NODE1=11111111-aaaa-1111-aaaa-111111111111
-FLOW_AUDIO_NODE1=11111111-bbbb-1111-bbbb-111111111111
-FLOW_VIDEO_NODE3=33333333-aaaa-3333-aaaa-333333333333
-FLOW_AUDIO_NODE3=33333333-bbbb-3333-bbbb-333333333333
-FLOW_VIDEO_NODE4=44444444-aaaa-4444-aaaa-444444444444
-FLOW_AUDIO_NODE4=44444444-bbbb-4444-bbbb-444444444444
-
-# UDP multicast groups + ports, one per flow. Picked from the
-# AD-HOC III administratively-scoped block (232.0.0.0/8 — SSM)
-# so they don't collide with any well-known group. Per-flow ports
-# (rather than a single 5004 across the board) keep wireshark /
-# tcpdump filters one-line and make per-flow log lines easy to
-# tell apart.
-FLOW_VIDEO1_GROUP=232.99.99.1;     FLOW_VIDEO1_PORT=5004
-FLOW_AUDIO1_GROUP=232.99.99.2;     FLOW_AUDIO1_PORT=5006
-FLOW_VIDEO_OUT_GROUP=232.99.99.3;  FLOW_VIDEO_OUT_PORT=5008
-FLOW_AUDIO_OUT_GROUP=232.99.99.4;  FLOW_AUDIO_OUT_PORT=5010
-FLOW_VIDEO4_GROUP=232.99.99.5;     FLOW_VIDEO4_PORT=5012
-FLOW_AUDIO4_GROUP=232.99.99.6;     FLOW_AUDIO4_PORT=5014
+# Per-flow identity — MXL flow IDs and RTP multicast pairs from env.sh.
+# Demo flow handles (`video1`, `video-out`, …) map to pair indices in
+# `transport_sender_props` / `transport_receiver_props` below.
 
 # Node 2 IS-04 Receiver Caps policy (`nmossrc` `receiver-caps-mode`).
 # `auto` (default) leaves the configuring transport file untouched;
@@ -261,31 +200,23 @@ case "$DEMO_RECEIVER_CAPS_MODE" in
         ;;
 esac
 
-# Essence caps. Chosen per transport because each transport has its
-# own GStreamer raw-format vocabulary in this plugin:
-#   MXL: v210 (10-bit 4:2:2 video) + F32LE (32-bit float audio) per
-#        the gst-mxl-rs `video_data_sync` integration test reference.
-#   UDP: UYVY (8-bit 4:2:2 video) + S24BE (L24 audio) per the
-#        rtpvrawdepay / rtpL24depay common case. Resolution is
-#        smaller for UDP so a multicast loopback run stays well
-#        below 1 Gbps (UYVY 1280x720@25 ≈ 368 Mbps; UYVY 192x108@25
-#        ≈ 8 Mbps).
+# Essence caps — local aliases from env.sh (`DEMO_MXL_*` / `DEMO_UDP_*`).
+# Node 4 uses the alternate shapes for wide-receiver tests.
 case "$DEMO_TRANSPORT" in
     mxl)
-        VIDEO_CAPS='video/x-raw,format=v210,width=1920,height=1080,framerate=60000/1001,interlace-mode=progressive'
-        AUDIO_CAPS='audio/x-raw,format=F32LE,rate=48000,channels=2,layout=interleaved'
-        # Node 4: different frame rate + channel count (wide-receiver soak).
-        VIDEO_CAPS_ALT='video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
-        AUDIO_CAPS_ALT='audio/x-raw,format=F32LE,rate=48000,channels=6,layout=interleaved'
+        VIDEO_CAPS=$DEMO_MXL_VIDEO_CAPS
+        AUDIO_CAPS=$DEMO_MXL_AUDIO_CAPS
+        VIDEO_CAPS_ALT=$DEMO_MXL_VIDEO_CAPS_ALT
+        AUDIO_CAPS_ALT=$DEMO_MXL_AUDIO_CAPS_ALT
         ;;
-    udp|udp2)
-        VIDEO_CAPS='video/x-raw,format=UYVY,width=1280,height=720,framerate=25/1,interlace-mode=progressive'
-        AUDIO_CAPS='audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved'
-        VIDEO_CAPS_ALT='video/x-raw,format=UYVY,width=1280,height=720,framerate=30000/1001,interlace-mode=progressive'
-        AUDIO_CAPS_ALT='audio/x-raw,format=S24BE,rate=48000,channels=6,layout=interleaved'
+    udp|udp2|nvdsudp)
+        VIDEO_CAPS=$DEMO_UDP_VIDEO_CAPS
+        AUDIO_CAPS=$DEMO_UDP_AUDIO_CAPS
+        VIDEO_CAPS_ALT=$DEMO_UDP_VIDEO_CAPS_ALT
+        AUDIO_CAPS_ALT=$DEMO_UDP_AUDIO_CAPS_ALT
         ;;
     *)
-        echo "[error] DEMO_TRANSPORT=$DEMO_TRANSPORT not recognised; use one of mxl, udp, udp2"
+        echo "[error] DEMO_TRANSPORT=$DEMO_TRANSPORT not recognised; use one of mxl, udp, udp2, nvdsudp"
         exit 1
         ;;
 esac
@@ -312,25 +243,25 @@ transport_sender_props() {
     case "$DEMO_TRANSPORT" in
         mxl)
             case "$flow" in
-                video1)     flow_id=$FLOW_VIDEO_NODE1 ;;
-                audio1)     flow_id=$FLOW_AUDIO_NODE1 ;;
-                video4)     flow_id=$FLOW_VIDEO_NODE4 ;;
-                audio4)     flow_id=$FLOW_AUDIO_NODE4 ;;
-                video-out)  flow_id=$FLOW_VIDEO_NODE3 ;;
-                audio-out)  flow_id=$FLOW_AUDIO_NODE3 ;;
+                video1)     flow_id=$DEMO_MXL_VIDEO_FLOW_ID1 ;;
+                audio1)     flow_id=$DEMO_MXL_AUDIO_FLOW_ID1 ;;
+                video4)     flow_id=$DEMO_MXL_VIDEO_FLOW_ID4 ;;
+                audio4)     flow_id=$DEMO_MXL_AUDIO_FLOW_ID4 ;;
+                video-out)  flow_id=$DEMO_MXL_VIDEO_FLOW_ID3 ;;
+                audio-out)  flow_id=$DEMO_MXL_AUDIO_FLOW_ID3 ;;
                 *) echo "[error] transport_sender_props: unknown flow $flow" >&2; return 1 ;;
             esac
             printf 'mxl-domain-id=%s mxl-domain-path=%s mxl-flow-id=%s' \
-                "$MXL_DOMAIN_ID" "$MXL_DOMAIN_PATH" "$flow_id"
+                "$DEMO_MXL_DOMAIN_ID" "$DEMO_MXL_DOMAIN_PATH" "$flow_id"
             ;;
-        udp|udp2)
+        udp|udp2|nvdsudp)
             case "$flow" in
-                video1)     group=$FLOW_VIDEO1_GROUP;     port=$FLOW_VIDEO1_PORT ;;
-                audio1)     group=$FLOW_AUDIO1_GROUP;     port=$FLOW_AUDIO1_PORT ;;
-                video4)     group=$FLOW_VIDEO4_GROUP;     port=$FLOW_VIDEO4_PORT ;;
-                audio4)     group=$FLOW_AUDIO4_GROUP;     port=$FLOW_AUDIO4_PORT ;;
-                video-out)  group=$FLOW_VIDEO_OUT_GROUP;  port=$FLOW_VIDEO_OUT_PORT ;;
-                audio-out)  group=$FLOW_AUDIO_OUT_GROUP;  port=$FLOW_AUDIO_OUT_PORT ;;
+                video1)     group=$DEMO_UDP_VIDEO_MCAST_IP1; port=$DEMO_UDP_VIDEO_MCAST_PORT1 ;;
+                audio1)     group=$DEMO_UDP_AUDIO_MCAST_IP1; port=$DEMO_UDP_AUDIO_MCAST_PORT1 ;;
+                video4)     group=$DEMO_UDP_VIDEO_MCAST_IP4; port=$DEMO_UDP_VIDEO_MCAST_PORT4 ;;
+                audio4)     group=$DEMO_UDP_AUDIO_MCAST_IP4; port=$DEMO_UDP_AUDIO_MCAST_PORT4 ;;
+                video-out)  group=$DEMO_UDP_VIDEO_MCAST_IP3; port=$DEMO_UDP_VIDEO_MCAST_PORT3 ;;
+                audio-out)  group=$DEMO_UDP_AUDIO_MCAST_IP3; port=$DEMO_UDP_AUDIO_MCAST_PORT3 ;;
                 *) echo "[error] transport_sender_props: unknown flow $flow" >&2; return 1 ;;
             esac
             # Sender-side IS-05 endpoint properties: destination = the
@@ -350,14 +281,14 @@ transport_receiver_props() {
         mxl)
             transport_sender_props "$flow"
             ;;
-        udp|udp2)
+        udp|udp2|nvdsudp)
             case "$flow" in
-                video1)     group=$FLOW_VIDEO1_GROUP;     port=$FLOW_VIDEO1_PORT ;;
-                audio1)     group=$FLOW_AUDIO1_GROUP;     port=$FLOW_AUDIO1_PORT ;;
-                video4)     group=$FLOW_VIDEO4_GROUP;     port=$FLOW_VIDEO4_PORT ;;
-                audio4)     group=$FLOW_AUDIO4_GROUP;     port=$FLOW_AUDIO4_PORT ;;
-                video-out)  group=$FLOW_VIDEO_OUT_GROUP;  port=$FLOW_VIDEO_OUT_PORT ;;
-                audio-out)  group=$FLOW_AUDIO_OUT_GROUP;  port=$FLOW_AUDIO_OUT_PORT ;;
+                video1)     group=$DEMO_UDP_VIDEO_MCAST_IP1; port=$DEMO_UDP_VIDEO_MCAST_PORT1 ;;
+                audio1)     group=$DEMO_UDP_AUDIO_MCAST_IP1; port=$DEMO_UDP_AUDIO_MCAST_PORT1 ;;
+                video4)     group=$DEMO_UDP_VIDEO_MCAST_IP4; port=$DEMO_UDP_VIDEO_MCAST_PORT4 ;;
+                audio4)     group=$DEMO_UDP_AUDIO_MCAST_IP4; port=$DEMO_UDP_AUDIO_MCAST_PORT4 ;;
+                video-out)  group=$DEMO_UDP_VIDEO_MCAST_IP3; port=$DEMO_UDP_VIDEO_MCAST_PORT3 ;;
+                audio-out)  group=$DEMO_UDP_AUDIO_MCAST_IP3; port=$DEMO_UDP_AUDIO_MCAST_PORT3 ;;
                 *) echo "[error] transport_receiver_props: unknown flow $flow" >&2; return 1 ;;
             esac
             # Receiver-side IS-05 endpoint properties: multicast-ip =
@@ -368,18 +299,6 @@ transport_receiver_props() {
             # the demo since all four senders live on this host).
             printf 'multicast-ip=%s destination-port=%d interface-ip=%s source-ip=%s' \
                 "$group" "$port" "$DEMO_NIC_IP" "$DEMO_NIC_IP"
-            ;;
-    esac
-}
-
-# `transport-properties` for video UDP sockets only. High-rate ST 2110-20
-# needs a large kernel receive buffer; ST 2110-30 audio does not. No-op
-# on MXL. Output is one gst-launch token (quoted value), or empty.
-udp_video_buffer_props() {
-    case "$DEMO_TRANSPORT" in
-        udp|udp2)
-            printf 'transport-properties="properties,buffer-size=%s"' \
-                "$DEMO_UDP_VIDEO_BUFFER_SIZE"
             ;;
     esac
 }
@@ -395,18 +314,8 @@ udp_video_buffer_props() {
 #   MXL:          `flow=11111111-aaaa-1111-aaaa-111111111111`
 #   UDP sender:   `dest=232.99.99.1:5004`
 #   UDP receiver: `join=232.99.99.1:5004`
-# GstQueue after each nmossrc: video by frame count, audio by duration (mxlsrc ~1 ms/buffer).
-_demo_video_queue() {
-    local name=$1
-    echo queue name="$name" "max-size-buffers=$DEMO_VIDEO_QUEUE_MAX_BUFFERS" max-size-bytes=0 max-size-time=0
-}
-
-_demo_audio_queue() {
-    local name=$1
-    local max_time_ns=$(( DEMO_AUDIO_QUEUE_MAX_TIME_MS * 1000000 ))
-    echo queue name="$name" max-size-time="$max_time_ns" max-size-buffers=0 max-size-bytes=0
-}
-
+# GstQueue after each nmossrc: video by frame count, audio by duration
+# (inner source ~1 ms/buffer on MXL; RTP varies by ptime and payload-multiple).
 transport_identity_from_active() {
     local side=$1 body=$2
     case "$DEMO_TRANSPORT" in
@@ -415,7 +324,7 @@ transport_identity_from_active() {
             flow=$(jq -r '.transport_params[0].mxl_flow_id // "n/a"' <<< "$body" 2>/dev/null)
             printf 'flow=%s' "$flow"
             ;;
-        udp|udp2)
+        udp|udp2|nvdsudp)
             local addr port
             case "$side" in
                 sender)
@@ -436,24 +345,11 @@ transport_identity_from_active() {
     esac
 }
 
-# Sinks for Node 2. The defaults (`autoaudiosink` / `autovideosink`)
-# Just Work on a desktop. On WSL or other headless setups
-# `autoaudiosink` spends up to ~60 s probing PipeWire / PulseAudio /
-# ALSA before falling back, which serialises against every other
-# element in Node 2's pipeline (GStreamer's bin state-change is
-# synchronous) and delays both Node 2 receivers' IS-04 visibility with
-# the daemon by the same ~60 s. If the script prints
-# "[poll] collect_urls: still missing after 90s: receivers/video2@…
-# receivers/audio2@…" or similar, override:
-#
-#     AUDIO_SINK=fakesink VIDEO_SINK=fakesink \\
-#         ./gst-nmos-rs-demo.sh
-#
-# (or `AUDIO_SINK=pulsesink`/`VIDEO_SINK=glimagesink` if your distro
-# / WSLg needs an explicit element). `fakesink` skips the probe
-# entirely; the data path still flows, it just isn't played back.
-AUDIO_SINK=${AUDIO_SINK:-autoaudiosink}
-VIDEO_SINK=${VIDEO_SINK:-autovideosink}
+# Node 2 playback sinks: DEMO_AUDIO_SINK / DEMO_VIDEO_SINK in env.sh
+# (element names only; this script adds audioconvert/videoconvert).
+# On WSL or headless hosts `autoaudiosink` can spend ~60 s probing
+# PipeWire / PulseAudio / ALSA — override, e.g.:
+#     DEMO_AUDIO_SINK=fakesink DEMO_VIDEO_SINK=fakesink ./gst-nmos-rs-demo.sh
 
 HOST=${HOST:-localhost}
 
@@ -477,13 +373,12 @@ echo "Node 2 receiver-caps-mode: $DEMO_RECEIVER_CAPS_MODE"
 echo "Queues after each nmossrc: video max-size-buffers=$DEMO_VIDEO_QUEUE_MAX_BUFFERS; audio max-size-time=${DEMO_AUDIO_QUEUE_MAX_TIME_MS}ms (Node 2 consumer + Node 3 processor)"
 
 # Re-create the MXL Domain directory. Only needed when
-# DEMO_TRANSPORT=mxl: the UDP / UDP2 transports go straight from
-# `nmossink` to `udpsink` and don't touch `/dev/shm` at all.
+# DEMO_TRANSPORT=mxl.
 if [[ "$DEMO_TRANSPORT" == mxl ]]; then
-    rm -rf  "$MXL_DOMAIN_PATH"
-    mkdir -p "$MXL_DOMAIN_PATH"
-    cat > "$MXL_DOMAIN_PATH/domain_def.json" <<EOF
-{"id":"$MXL_DOMAIN_ID","label":"gst-nmos-rs demo domain"}
+    rm -rf  "$DEMO_MXL_DOMAIN_PATH"
+    mkdir -p "$DEMO_MXL_DOMAIN_PATH"
+    cat > "$DEMO_MXL_DOMAIN_PATH/domain_def.json" <<EOF
+{"id":"$DEMO_MXL_DOMAIN_ID","label":"gst-nmos-rs demo domain"}
 EOF
 fi
 
@@ -601,7 +496,7 @@ export LD_LIBRARY_PATH="$LIB:$MXL_RT_LIB_DIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH
 
 case "$DEMO_TRANSPORT" in
     udp|udp2)
-        echo "[udp] video socket buffer-size=$DEMO_UDP_VIDEO_BUFFER_SIZE (video flows only; override with DEMO_UDP_VIDEO_BUFFER_SIZE=...)"
+        echo "[udp] video udpsrc buffer-size=$DEMO_UDP_VIDEO_BUFFER_SIZE (video flows only; override with DEMO_UDP_VIDEO_BUFFER_SIZE=...)"
         if [[ -r /proc/sys/net/core/rmem_max ]]; then
             _rmem_max=$(cat /proc/sys/net/core/rmem_max)
             if (( DEMO_UDP_VIDEO_BUFFER_SIZE > _rmem_max )); then
@@ -619,6 +514,19 @@ case "$DEMO_TRANSPORT" in
                 echo "[udp2] install gst-plugins-rs (GStreamer 1.30+) or use DEMO_TRANSPORT=udp"
             fi
         fi
+        ;;
+    nvdsudp)
+        if ! command -v gst-inspect-1.0 >/dev/null 2>&1 \
+            || ! gst-inspect-1.0 nvdsudpsink >/dev/null 2>&1; then
+            echo "[nvdsudp] nvdsudpsink not found (GST_PLUGIN_PATH=${GST_PLUGIN_PATH:-<unset>})"
+            echo "[nvdsudp] install DeepStream 9.0 and Rivermax, then add the DeepStream"
+            echo "[nvdsudp] plugin directory to GST_PLUGIN_PATH (e.g."
+            echo "[nvdsudp] /opt/nvidia/deepstream/deepstream-9.0/lib/gst-plugins)"
+            echo "[nvdsudp] https://docs.nvidia.com/metropolis/deepstream/dev-guide/text/DS_Installation.html"
+            echo "[nvdsudp] https://developer.nvidia.com/networking/rivermax"
+            exit 1
+        fi
+        echo "[nvdsudp] DeepStream nvdsudpsrc / nvdsudpsink available (Rivermax; CAP_NET_RAW may be required)"
         ;;
 esac
 
@@ -652,20 +560,21 @@ _rotate_log() {
 #
 # Sends SIGINT (not SIGTERM) deliberately: `gst-launch-1.0 -e`
 # installs a SIGINT handler that sends EOS through the pipeline and
-# waits for clean shutdown -- which is what gives `mxlsink::stop()`
+# waits for clean shutdown. On MXL, SIGINT gives `mxlsink::stop()`
 # (and through it, `libmxl`'s `releaseWriter` and the `Instance`
 # destructor) a chance to call `deleteFlow`, removing the
-# `.mxl-flow/` directory from `MXL_DOMAIN_PATH`. SIGTERM has no
-# handler in gst-launch, so the kernel terminates the process
-# immediately, the C++ destructors never run, and the flow files
-# stay on disk with stale internal state. A subsequent `launch_*`
-# of the same producer then opens those leaked files via
-# `Instance::createOrOpenDiscreteFlowData`, and the new writer can't
-# produce fresh grains -- which makes every consumer (existing
-# nmossrc, a relaunched Node 2, even a fresh bare mxlsrc preview)
-# see a frozen flow. SIGKILL after the 2s grace remains a safety
-# net for the case where the pipeline is wedged and SIGINT-driven
-# EOS can't drain.
+# `.mxl-flow/` directory from `DEMO_MXL_DOMAIN_PATH`. UDP/nvdsudp
+# also benefit from EOS-driven teardown, but the critical case is
+# MXL flow-file cleanup. SIGTERM has no handler in gst-launch, so
+# the kernel terminates the process immediately, the C++ destructors
+# never run, and the flow files stay on disk with stale internal
+# state. A subsequent `launch_*` of the same producer then opens
+# those leaked files via `Instance::createOrOpenDiscreteFlowData`,
+# and the new writer can't produce fresh grains -- which makes every
+# consumer (existing nmossrc, a relaunched Node 2, even a fresh bare
+# mxlsrc) see a frozen flow. SIGKILL after the 2s grace remains a
+# safety net for the case where the pipeline is wedged and
+# SIGINT-driven EOS can't drain.
 teardown_pipeline() {
     local pid_var_name=$1 label=$2
     local -n pid_ref=$pid_var_name
@@ -781,8 +690,9 @@ launch_node4() {
                     node-seed="$NODE4_SEED" \
                     sender-name=audio4 \
                     $(transport_sender_props audio4) \
+                    $(udp_audio_transport_caps_alt) \
                     caps="$AUDIO_CAPS_ALT" \
-                    label="Node 4 / audio4 (880 Hz sine, 6 ch)" \
+                    label="Node 4 / audio4 (880 Hz sine, 8 ch)" \
                     auto-activate=true \
         > "$LOG_DIR/node4-producer.log" 2>&1 &
     NODE4_PID=$!
@@ -798,8 +708,8 @@ launch_node4() {
 # negotiation completes and the pipeline can reach PLAYING) until the
 # controller PATCHes both Connection API /staged endpoints (the
 # inbound Receiver to attach to Node 1's flow, the outbound Sender to
-# publish the processed flow). Until then the inner mxlsink / mxlsrc
-# are not instantiated and no MXL writes / reads happen on this side.
+# publish the processed flow). Until then the inner transport chain
+# is not instantiated and no real data-path I/O happens on this side.
 # This shows off NMOS PATCH-driven activation vs. the eager
 # `auto-activate=true` shortcut Node 1 and Node 2 use.
 
@@ -824,7 +734,7 @@ launch_node3_video() {
                 caps="$VIDEO_CAPS" \
                 label="Node 3 / video-in" \
                 auto-activate=false ! \
-            $(_demo_video_queue n3-v-in) ! \
+            $(demo_video_queue n3-v-in) ! \
             videoconvert ! videoflip method=horizontal-flip ! videoconvert ! \
                 nmossink \
                     daemon-uri="unix:$SOCK" \
@@ -861,7 +771,7 @@ launch_node3_audio() {
                 caps="$AUDIO_CAPS" \
                 label="Node 3 / audio-in" \
                 auto-activate=false ! \
-            $(_demo_audio_queue n3-a-in) ! \
+            $(demo_audio_queue n3-a-in) ! \
             audioconvert ! volume volume=0.3 ! audioconvert ! \
                 nmossink \
                     daemon-uri="unix:$SOCK" \
@@ -880,8 +790,8 @@ launch_node3_audio() {
 # ---- Node 2: consumer (one pipeline, 2 nmossrcs) ------------------
 #
 # Node 2 is the always-on consumer: auto-activate=true on both
-# Receivers so the inner mxlsrc is built at NULL→READY and the
-# consumer attaches to Node 1's flows immediately (no IS-05 PATCH
+# Receivers so the inner transport chain is built at NULL→READY and
+# the consumer attaches to Node 1's flows immediately (no IS-05 PATCH
 # needed to play back). To re-route to Node 3's processed flows,
 # PATCH the Connection API /staged endpoint of either Receiver with
 # the corresponding Node 3 flow id (see the control commands printed
@@ -891,7 +801,7 @@ launch_node2() {
         echo "[node2] already running (pid $NODE2_PID)"
         return 1
     fi
-    echo "[node2] starting consumer pipeline (nmossrc --> queue(${DEMO_VIDEO_QUEUE_MAX_BUFFERS} buffers) --> ${VIDEO_SINK}; nmossrc --> queue(${DEMO_AUDIO_QUEUE_MAX_TIME_MS}ms) --> ${AUDIO_SINK})"
+    echo "[node2] starting consumer pipeline (nmossrc --> queue(${DEMO_VIDEO_QUEUE_MAX_BUFFERS} buffers) --> ${DEMO_VIDEO_SINK}; nmossrc --> queue(${DEMO_AUDIO_QUEUE_MAX_TIME_MS}ms) --> ${DEMO_AUDIO_SINK})"
     _rotate_log "$LOG_DIR/node2-consumer.log"
     pipeline_dots_prepare_launch node2
     GST_DEBUG=${GST_DEBUG:-nmossrc:3} \
@@ -908,8 +818,8 @@ launch_node2() {
                 caps="$VIDEO_CAPS" \
                 label="Node 2 / video2" \
                 auto-activate=true ! \
-            $(_demo_video_queue n2-v-in) ! \
-                videoconvert ! "$VIDEO_SINK" sync=false \
+            $(demo_video_queue n2-v-in) ! \
+                videoconvert ! "$DEMO_VIDEO_SINK" sync=false \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
                 transport="$DEMO_TRANSPORT" \
@@ -921,8 +831,8 @@ launch_node2() {
                 caps="$AUDIO_CAPS" \
                 label="Node 2 / audio2" \
                 auto-activate=true ! \
-            $(_demo_audio_queue n2-a-in) ! \
-                audioconvert ! "$AUDIO_SINK" sync=false \
+            $(demo_audio_queue n2-a-in) ! \
+                audioconvert ! "$DEMO_AUDIO_SINK" sync=false \
         > "$LOG_DIR/node2-consumer.log" 2>&1 &
     NODE2_PID=$!
 }
@@ -936,7 +846,7 @@ launch_node2() {
 # Node 2 receiver. Useful for isolating whether a "frozen video"
 # symptom is mxlsrc/libmxl-level or nmossrc-level.
 #
-# Use VIDEO_SINK=autovideosink to see a window (the demo default),
+# Use DEMO_VIDEO_SINK=autovideosink to see a window (the default),
 # fakesink for headless capture. The file `bare-preview.log` will
 # contain mxlsrc/basesrc/fakesink chatter.
 launch_bare_preview() {
@@ -948,16 +858,16 @@ launch_bare_preview() {
         echo "[preview] already running (pid $BARE_PREVIEW_PID)"
         return 1
     fi
-    echo "[preview] starting bare mxlsrc -> $VIDEO_SINK"
+    echo "[preview] starting bare mxlsrc -> $DEMO_VIDEO_SINK"
     _rotate_log "$LOG_DIR/bare-preview.log"
     pipeline_dots_prepare_launch bare-preview
     GST_DEBUG=${GST_DEBUG:-mxlsrc:5,basesrc:4} \
         _demo_line_buffered gst-launch-1.0 -e \
             mxlsrc \
-                domain="$MXL_DOMAIN_PATH" \
-                video-flow-id="$FLOW_VIDEO_NODE1" \
+                domain="$DEMO_MXL_DOMAIN_PATH" \
+                video-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" \
                 name=bare-preview ! \
-            videoconvert ! "$VIDEO_SINK" sync=false \
+            videoconvert ! "$DEMO_VIDEO_SINK" sync=false \
         > "$LOG_DIR/bare-preview.log" 2>&1 &
     BARE_PREVIEW_PID=$!
 }
@@ -1041,14 +951,14 @@ resource_url() {
 #
 #   * `autoaudiosink` spending up to ~60 s probing PipeWire /
 #     PulseAudio / ALSA before falling back, on WSL or other
-#     headless setups. Override `AUDIO_SINK=fakesink` (see the
+#     headless setups. Override `DEMO_AUDIO_SINK=fakesink` (see env.sh;
 #     leading-comment knobs) to skip that altogether. Because
 #     GStreamer's bin state-change is synchronous, this delay
 #     gates every other element in Node 2's pipeline — including
 #     both `nmossrc`s — so neither the audio nor the video
 #     receiver registers with the daemon until ~60 s in.
-#   * `mxlsrc` opening Node 1's /dev/shm flow files and blocking
-#     until they exist — fine in practice (Node 1 is started
+#   * On MXL, `mxlsrc` opening Node 1's /dev/shm flow files and
+#     blocking until they exist — fine in practice (Node 1 is started
 #     first + `sleep 2`), but can add a few seconds under load.
 #
 # Each resource that resolves is recorded in `URLS[<key>]`;
@@ -1088,7 +998,7 @@ collect_urls() {
         sleep 0.5
     done
     echo "[warn] collect_urls: still missing after ${WAIT_TIMEOUT}s: ${missing[*]}" >&2
-    echo "[warn]   (if Node 2 endpoints are stuck, try \`AUDIO_SINK=fakesink VIDEO_SINK=fakesink\` to skip the autoaudiosink/autovideosink probe; or bump \`WAIT_TIMEOUT\`)" >&2
+    echo "[warn]   (if Node 2 endpoints are stuck, try \`DEMO_AUDIO_SINK=fakesink DEMO_VIDEO_SINK=fakesink\` to skip the autoaudiosink/autovideosink probe; or bump \`WAIT_TIMEOUT\`)" >&2
     return 1
 }
 echo "[poll] waiting for all 10 IS-04 resources to register (timeout ${WAIT_TIMEOUT}s)..."
@@ -1123,34 +1033,38 @@ URL_NODE3_SENDER_AUDIO=${URLS[node3_sender_audio]:-}
 # in one place. Both transports define every variable in this block.
 case "$DEMO_TRANSPORT" in
     mxl)
-        LABEL_FLOW_VIDEO1="flow $FLOW_VIDEO_NODE1"
-        LABEL_FLOW_AUDIO1="flow $FLOW_AUDIO_NODE1"
-        LABEL_FLOW_VIDEO4="flow $FLOW_VIDEO_NODE4"
-        LABEL_FLOW_AUDIO4="flow $FLOW_AUDIO_NODE4"
-        LABEL_FLOW_VIDEO_OUT="flow $FLOW_VIDEO_NODE3"
-        LABEL_FLOW_AUDIO_OUT="flow $FLOW_AUDIO_NODE3"
+        LABEL_FLOW_VIDEO1="flow $DEMO_MXL_VIDEO_FLOW_ID1"
+        LABEL_FLOW_AUDIO1="flow $DEMO_MXL_AUDIO_FLOW_ID1"
+        LABEL_FLOW_VIDEO4="flow $DEMO_MXL_VIDEO_FLOW_ID4"
+        LABEL_FLOW_AUDIO4="flow $DEMO_MXL_AUDIO_FLOW_ID4"
+        LABEL_FLOW_VIDEO_OUT="flow $DEMO_MXL_VIDEO_FLOW_ID3"
+        LABEL_FLOW_AUDIO_OUT="flow $DEMO_MXL_AUDIO_FLOW_ID3"
         LABEL_INNER_CHAIN="mxlsink / mxlsrc"
         LABEL_PREWIRED="via mxl-flow-id"
-        REROUTE_VIDEO_BODY="{\"transport_params\": [{\"mxl_flow_id\": \"$FLOW_VIDEO_NODE3\"}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
-        REROUTE_AUDIO_BODY="{\"transport_params\": [{\"mxl_flow_id\": \"$FLOW_AUDIO_NODE3\"}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
+        REROUTE_VIDEO_BODY="{\"transport_params\": [{\"mxl_flow_id\": \"$DEMO_MXL_VIDEO_FLOW_ID3\"}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
+        REROUTE_AUDIO_BODY="{\"transport_params\": [{\"mxl_flow_id\": \"$DEMO_MXL_AUDIO_FLOW_ID3\"}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
         ;;
-    udp|udp2)
-        LABEL_FLOW_VIDEO1="dest $FLOW_VIDEO1_GROUP:$FLOW_VIDEO1_PORT"
-        LABEL_FLOW_AUDIO1="dest $FLOW_AUDIO1_GROUP:$FLOW_AUDIO1_PORT"
-        LABEL_FLOW_VIDEO4="dest $FLOW_VIDEO4_GROUP:$FLOW_VIDEO4_PORT"
-        LABEL_FLOW_AUDIO4="dest $FLOW_AUDIO4_GROUP:$FLOW_AUDIO4_PORT"
-        LABEL_FLOW_VIDEO_OUT="dest $FLOW_VIDEO_OUT_GROUP:$FLOW_VIDEO_OUT_PORT"
-        LABEL_FLOW_AUDIO_OUT="dest $FLOW_AUDIO_OUT_GROUP:$FLOW_AUDIO_OUT_PORT"
-        if [[ "$DEMO_TRANSPORT" == udp2 ]] \
+    udp|udp2|nvdsudp)
+        LABEL_FLOW_VIDEO1="dest $DEMO_UDP_VIDEO_MCAST_IP1:$DEMO_UDP_VIDEO_MCAST_PORT1"
+        LABEL_FLOW_AUDIO1="dest $DEMO_UDP_AUDIO_MCAST_IP1:$DEMO_UDP_AUDIO_MCAST_PORT1"
+        LABEL_FLOW_VIDEO4="dest $DEMO_UDP_VIDEO_MCAST_IP4:$DEMO_UDP_VIDEO_MCAST_PORT4"
+        LABEL_FLOW_AUDIO4="dest $DEMO_UDP_AUDIO_MCAST_IP4:$DEMO_UDP_AUDIO_MCAST_PORT4"
+        LABEL_FLOW_VIDEO_OUT="dest $DEMO_UDP_VIDEO_MCAST_IP3:$DEMO_UDP_VIDEO_MCAST_PORT3"
+        LABEL_FLOW_AUDIO_OUT="dest $DEMO_UDP_AUDIO_MCAST_IP3:$DEMO_UDP_AUDIO_MCAST_PORT3"
+        if [[ "$DEMO_TRANSPORT" == nvdsudp ]]; then
+            LABEL_INNER_CHAIN="nvdsudpsink / nvdsudpsrc (DeepStream Rivermax)"
+            LABEL_PREWIRED="via destination multicast group + port (interface $DEMO_NIC_IP)"
+        elif [[ "$DEMO_TRANSPORT" == udp2 ]] \
             && command -v gst-inspect-1.0 >/dev/null 2>&1 \
             && gst-inspect-1.0 udpsrc2 >/dev/null 2>&1; then
             LABEL_INNER_CHAIN="udpsink + RTP payloader / udpsrc2 + RTP depayloader (gst-plugins-rs)"
+            LABEL_PREWIRED="via destination multicast group + port (interface $DEMO_NIC_IP); video udpsrc buffer-size=$DEMO_UDP_VIDEO_BUFFER_SIZE"
         else
             LABEL_INNER_CHAIN="udpsink + RTP payloader / udpsrc + RTP depayloader"
+            LABEL_PREWIRED="via destination multicast group + port (interface $DEMO_NIC_IP); video udpsrc buffer-size=$DEMO_UDP_VIDEO_BUFFER_SIZE"
         fi
-        LABEL_PREWIRED="via destination multicast group + port (interface $DEMO_NIC_IP); video udpsrc buffer-size=$DEMO_UDP_VIDEO_BUFFER_SIZE"
-        REROUTE_VIDEO_BODY="{\"transport_params\": [{\"source_ip\": \"$DEMO_NIC_IP\", \"multicast_ip\": \"$FLOW_VIDEO_OUT_GROUP\", \"interface_ip\": \"$DEMO_NIC_IP\", \"destination_port\": $FLOW_VIDEO_OUT_PORT, \"rtp_enabled\": true}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
-        REROUTE_AUDIO_BODY="{\"transport_params\": [{\"source_ip\": \"$DEMO_NIC_IP\", \"multicast_ip\": \"$FLOW_AUDIO_OUT_GROUP\", \"interface_ip\": \"$DEMO_NIC_IP\", \"destination_port\": $FLOW_AUDIO_OUT_PORT, \"rtp_enabled\": true}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
+        REROUTE_VIDEO_BODY="{\"transport_params\": [{\"source_ip\": \"$DEMO_NIC_IP\", \"multicast_ip\": \"$DEMO_UDP_VIDEO_MCAST_IP3\", \"interface_ip\": \"$DEMO_NIC_IP\", \"destination_port\": $DEMO_UDP_VIDEO_MCAST_PORT3, \"rtp_enabled\": true}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
+        REROUTE_AUDIO_BODY="{\"transport_params\": [{\"source_ip\": \"$DEMO_NIC_IP\", \"multicast_ip\": \"$DEMO_UDP_AUDIO_MCAST_IP3\", \"interface_ip\": \"$DEMO_NIC_IP\", \"destination_port\": $DEMO_UDP_AUDIO_MCAST_PORT3, \"rtp_enabled\": true}], \"master_enable\": true, \"activation\": {\"mode\": \"activate_immediate\"}}"
         ;;
 esac
 
@@ -1169,8 +1083,8 @@ Topology:
     videotestsrc(smpte)  -> nmossink Sender video1 ($LABEL_FLOW_VIDEO1)
 
   Node 2 (port $NODE2_PORT, seed $NODE2_SEED)  -- consumer
-    Receiver audio2  -> $AUDIO_SINK
-    Receiver video2  -> $VIDEO_SINK
+    Receiver audio2  -> $DEMO_AUDIO_SINK
+    Receiver video2  -> $DEMO_VIDEO_SINK
     receiver-caps-mode=$DEMO_RECEIVER_CAPS_MODE on both receivers
 
   Node 3 (port $NODE3_PORT, seed $NODE3_SEED)  -- processor (two gst processes)
@@ -1178,7 +1092,7 @@ Topology:
     Receiver video-in  --(videoflip h-flip)-->   Sender video-out ($LABEL_FLOW_VIDEO_OUT)
 
   Node 4 (port $NODE4_PORT, seed $NODE4_SEED)  -- alternate producer
-    audiotestsrc(880Hz, 6ch) -> nmossink Sender audio4 ($LABEL_FLOW_AUDIO4)
+    audiotestsrc(880Hz, 8ch) -> nmossink Sender audio4 ($LABEL_FLOW_AUDIO4)
     videotestsrc(snow)       -> nmossink Sender video4 ($LABEL_FLOW_VIDEO4)
     (different frame rate + channel count vs Node 1)
 
@@ -1243,7 +1157,7 @@ The most common cause of a missing Node 2 URL is autoaudiosink
 spending up to ~60 s probing PipeWire / PulseAudio / ALSA on
 WSL / headless setups before falling back. Re-run with:
 
-  AUDIO_SINK=fakesink VIDEO_SINK=fakesink ./$(basename "$0")
+  DEMO_AUDIO_SINK=fakesink DEMO_VIDEO_SINK=fakesink ./$(basename "$0")
 
 to skip the probe entirely; the data path still flows end-to-end,
 it just isn't played back locally. Or bump WAIT_TIMEOUT in the
@@ -1530,7 +1444,7 @@ subscription_transport_params() {
         mxl)
             printf '%s' "$sender_transport_params"
             ;;
-        udp|udp2)
+        udp|udp2|nvdsudp)
             jq -c \
                 --arg iface_ip "$DEMO_NIC_IP" \
                 '[ .[] | {
@@ -1796,7 +1710,7 @@ menu_connect_receiver_to_sender() {
 #
 #   * Every Sender + Receiver `/active` and `/staged` as full JSON
 #     (so a later `diff` between snapshot dirs is a one-liner).
-#   * `ls -la $MXL_DOMAIN_PATH` plus a per-flow file inventory
+#   * `ls -la $DEMO_MXL_DOMAIN_PATH` plus a per-flow file inventory
 #     (grain count, newest grain filename). We deliberately do NOT
 #     report mtime-based liveness: libmxl writes grains via mmap on
 #     tmpfs which does not bump the file mtime on every write, so any
@@ -1907,13 +1821,13 @@ diag_snapshot() {
     # state to inspect; the equivalent for those is the per-pipeline
     # log tails captured below.
     if [[ "$DEMO_TRANSPORT" == mxl ]]; then
-        echo "  Flow directories ($MXL_DOMAIN_PATH):"
-        ls -la "$MXL_DOMAIN_PATH" > "$outdir/shm-ls.txt" 2>/dev/null || true
-        if [[ -d "$MXL_DOMAIN_PATH" ]]; then
-            ls -laR "$MXL_DOMAIN_PATH" > "$outdir/shm-ls-R.txt" 2>/dev/null || true
+        echo "  Flow directories ($DEMO_MXL_DOMAIN_PATH):"
+        ls -la "$DEMO_MXL_DOMAIN_PATH" > "$outdir/shm-ls.txt" 2>/dev/null || true
+        if [[ -d "$DEMO_MXL_DOMAIN_PATH" ]]; then
+            ls -laR "$DEMO_MXL_DOMAIN_PATH" > "$outdir/shm-ls-R.txt" 2>/dev/null || true
             local d base grains_dir grain_count newest_grain
             shopt -s nullglob
-            for d in "$MXL_DOMAIN_PATH"/*.mxl-flow; do
+            for d in "$DEMO_MXL_DOMAIN_PATH"/*.mxl-flow; do
                 base=${d##*/}
                 grains_dir="$d/grains"
                 grain_count=0
@@ -1981,10 +1895,10 @@ menu_diag_snapshot() {
 # Teardown + (re)launch as separate operations supports the primary
 # "fresh consumer after producer disable/re-enable" diagnostic:
 # relaunching Node 2 (or the bare preview) after a disable+re-enable
-# cycle of Node 1 tells us whether new mxlsrc instances can attach to
-# the recreated flow (i.e. producer-side recreation is fine; the
+# cycle of Node 1 tells us whether new inner source instances can attach
+# to the recreated flow (i.e. producer-side recreation is fine; the
 # issue is stale reader handles), versus whether even fresh consumers
-# can't attach (i.e. flow-file recreation itself is broken). Keeping
+# can't attach (e.g. MXL flow recreation itself is broken). Keeping
 # the two as separate options also lets the user stop a pipeline,
 # inspect with action 5 / shell tools, and then bring it back without
 # a forced immediate relaunch. Action 8 exports GStreamer pipeline

--- a/rust/gst-nmos-rs/src/daemon.rs
+++ b/rust/gst-nmos-rs/src/daemon.rs
@@ -4,7 +4,7 @@
 //! gRPC client glue for the `nvnmosd` daemon.
 //!
 //! [`Session`] wraps the per-element gRPC state: a `tonic` channel, the
-//! daemon's session handle, an optional registered resource, and a
+//! daemon's session handle, an optional added resource, and a
 //! background task subscribed to [`SubscribeActivations`]. Constructed
 //! at NULL→READY and torn down at READY→NULL by the element's
 //! `change_state` override.
@@ -12,9 +12,9 @@
 //! When [`Session::open`] is called with a non-empty `transport_file`
 //! it also drives `AddSender` / `AddReceiver` (selected by `side`) so
 //! the resource is published in IS-04 immediately. With no
-//! `transport_file` the session is opened but no resource is
-//! registered — a future change will build the transport file from
-//! upstream caps and the element's properties.
+//! `transport_file` the session is opened but no resource is added
+//! yet — deferred AddSender at READY→PAUSED synthesises the
+//! transport file from upstream peer caps and element properties.
 //!
 //! Each `ActivationEvent` arriving on the subscription is routed to
 //! the element-supplied [`ActivationHandler`] (see [`Session::open`]).
@@ -124,11 +124,11 @@ pub(crate) enum DaemonError {
     #[error("RPC error: {0}")]
     Rpc(#[from] Box<tonic::Status>),
     #[error(
-        "session already has a resource registered; deferred registration is a one-shot operation"
+        "session already has a resource added; deferred AddSender is a one-shot operation"
     )]
     AlreadyRegistered,
     #[error(
-        "session has no resource registered yet; auto-activate sync cannot run before AddSender / AddReceiver"
+        "session has no resource added yet; auto-activate sync cannot run before AddSender / AddReceiver"
     )]
     NoResource,
 }
@@ -148,7 +148,7 @@ impl From<tonic::Status> for DaemonError {
 impl Session {
     /// Open a session against the daemon at `daemon_uri` for Node
     /// `node_seed`, subscribe to activations, and (when
-    /// `transport_file` is `Some`) register `name` as a Sender or
+    /// `transport_file` is `Some`) add `name` as a Sender or
     /// Receiver via `AddSender` / `AddReceiver`.
     ///
     /// Only `unix:/path/to/sock` URIs are supported. `NodeConfig` is
@@ -162,7 +162,7 @@ impl Session {
     /// the daemon delivers on this session. See
     /// [`ActivationHandler`].
     ///
-    /// If the resource registration fails the partially-open session
+    /// If the AddSender / AddReceiver fails the partially-open session
     /// is rolled back via `CloseSession` so the daemon doesn't leak
     /// state.
     #[allow(clippy::too_many_arguments)]
@@ -240,12 +240,12 @@ impl Session {
     /// with no resource (because neither `transport-file*` nor `caps`
     /// was supplied), and the actual `AddSender` / `AddReceiver` is
     /// driven later from inside `change_state(ReadyToPaused)` once
-    /// upstream peer caps have negotiated and a flow_def can be
-    /// synthesised.
+    /// upstream peer caps have negotiated and a configuring transport
+    /// file can be synthesised.
     ///
     /// Errors with [`DaemonError::AlreadyRegistered`] if called on a
     /// session that already has a resource (caller bug —
-    /// deferred-mode registration is one-shot).
+    /// deferred-mode AddSender is one-shot).
     pub(crate) async fn add_resource(
         &mut self,
         side: Side,
@@ -286,7 +286,7 @@ impl Session {
     /// already knows; other subscribers learn via IS-04 / IS-05
     /// state).
     ///
-    /// Errors when called on a session with no registered resource
+    /// Errors when called on a session with no added resource
     /// (caller bug — `auto-activate` paths only call this after
     /// `add_resource` succeeded).
     pub(crate) async fn sync_resource_state(

--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -4,10 +4,10 @@
 //! MXL `flow_def` JSON helpers.
 //!
 //! The NvNmos transport file for transport=mxl is a JSON document
-//! whose top-level `id` is the MXL flow id and whose `format` is the
-//! NMOS format URN (`urn:x-nmos:format:video|audio|data`). The
-//! element needs both to configure the inner `mxlsink` / `mxlsrc`
-//! (`mxlsink.flow-id=` and `mxlsrc.{video,audio,data}-flow-id=`).
+//! whose top-level `id` is the MXL flow id (when present) and whose
+//! `format` is the NMOS format URN (`urn:x-nmos:format:video|audio|data`).
+//! At activation time the element consumes `id` to configure the inner
+//! `mxlsink` / `mxlsrc` (`flow-id=` / `{video,audio,data}-flow-id=`).
 //!
 //! [`read_flow_def_meta`] parses the JSON into [`FlowDefMeta`].
 //! [`resolve_mxl_flow_meta`] combines that with the `mxl-flow-id`
@@ -34,12 +34,24 @@
 //! wins silently.
 //!
 //! [`from_caps`] is the reverse path: given GStreamer essence
-//! caps plus property state, emit a `flow_def` JSON document that
-//! satisfies the MXL `FlowParser` (its hard requirements: `id`,
-//! `format`, non-empty `label`, non-empty `tags["urn:x-nmos:tag:grouphint/v1.0"]`,
-//! plus per-format dimensions/rates). Only the caps shapes that
-//! `mxlsink` advertises today are accepted: v210 video, F32LE audio,
-//! ST 2038 ANC.
+//! caps plus property state, emit a configuring `flow_def` JSON
+//! document for **libnvnmos** at AddSender / AddReceiver. libnvnmos
+//! parses this as JSON (via nmos-cpp field accessors) — it does **not**
+//! pass it through the MXL SDK's `FlowParser`. Essence-shape fields
+//! (`grain_rate`, `frame_width`, `frame_height`, `components`, …)
+//! are required by libnvnmos and are derived from `caps`; omitting
+//! `caps` leaves nothing to synthesise. Cosmetic / identity fields
+//! (`format`, non-empty `label`, `tags["urn:x-nmos:tag:grouphint/v1.0"]`,
+//! `urn:x-nvnmos:tag:*`) are also emitted. The top-level `id` is
+//! omitted when `flow_id` is empty so libnvnmos can create the
+//! resource and resolve the MXL flow id at activation (Senders fall
+//! back to the generated NMOS Flow id; Receivers ignore `id` at
+//! AddReceiver). When the inner data path later goes live, `mxlsink`
+//! creates the domain flow via the MXL SDK using its own JSON built
+//! from upstream caps and the `flow-id` property — that is a separate
+//! `FlowParser` path from this configuring document. Only the caps
+//! shapes that `mxlsink` advertises today are accepted: v210 video,
+//! F32LE audio, ST 2038 ANC.
 
 use gstreamer as gst;
 use serde::Deserialize;
@@ -119,8 +131,6 @@ pub(crate) enum FlowDefError {
     // — matching the [`crate::sdp::SdpError`] shape — and lets
     // future cross-helpers (e.g. parse-then-rebuild splice) chain
     // without `map_err` between submodules.
-    #[error("synthesising flow_def from caps requires a non-empty `mxl-flow-id`")]
-    MissingFlowId,
     #[error("synthesising flow_def from caps requires a non-empty `sender-name` / `receiver-name`")]
     MissingName,
     #[error("synthesising flow_def from caps requires a non-empty `mxl-domain-id`")]
@@ -373,13 +383,15 @@ pub(crate) fn indicates_wide_receiver_caps(text: &str) -> Result<bool, FlowDefEr
 /// hold any of these beyond the call.
 #[derive(Debug)]
 pub(crate) struct FlowDefBuildInput<'a> {
-    /// MXL flow id (UUID). Required and non-empty — this is the value
-    /// `mxlsink.flow-id=` / `mxlsrc.{video,audio,data}-flow-id=` ends
-    /// up consuming.
+    /// MXL flow id (UUID). When non-empty, emitted as the top-level
+    /// `id` and later passed to `mxlsink.flow-id=` /
+    /// `mxlsrc.{video,audio,data}-flow-id=`. When empty, omitted from
+    /// the configuring JSON so libnvnmos can register without a
+    /// concrete MXL flow id (the inner chain stays fake until IS-05
+    /// activation supplies one).
     pub(crate) flow_id: &'a str,
-    /// NMOS resource name. Used both as the `<group>` portion of the
-    /// `urn:x-nmos:tag:grouphint/v1.0` tag (required by MXL
-    /// `FlowParser`) and as the value of the
+    /// NMOS resource name. Used as the `<group>` portion of the
+    /// `urn:x-nmos:tag:grouphint/v1.0` tag and as the value of the
     /// `urn:x-nvnmos:tag:name` tag (required by `libnvnmos`).
     /// Required non-empty.
     pub(crate) name: &'a str,
@@ -388,8 +400,9 @@ pub(crate) struct FlowDefBuildInput<'a> {
     /// resolve the IS-05 `mxl_domain_id` transport parameter at
     /// activation time.
     pub(crate) mxl_domain_id: &'a str,
-    /// NMOS `label`. The MXL `FlowParser` rejects an empty label, so
-    /// the builder falls back to `flow_id` when this is empty.
+    /// NMOS `label`. libnvnmos requires a non-empty `label` field in
+    /// the configuring JSON; the builder falls back to `name` when
+    /// this is empty.
     pub(crate) label: &'a str,
     /// NMOS `description`. Optional; omitted from the JSON when empty.
     pub(crate) description: &'a str,
@@ -397,19 +410,19 @@ pub(crate) struct FlowDefBuildInput<'a> {
     pub(crate) caps: &'a gst::Caps,
 }
 
-/// Build an MXL `flow_def` JSON document from essence caps and
-/// property state. The shape matches the reference flows in the MXL
-/// SDK (`mxl/lib/tests/data/{v210,audio,data}_flow.json`).
+/// Build a configuring MXL `flow_def` JSON document from essence caps
+/// and property state for libnvnmos AddSender / AddReceiver. The shape
+/// matches the reference flows in the MXL SDK
+/// (`mxl/lib/tests/data/{v210,audio,data}_flow.json`) closely enough
+/// for nmos-cpp's JSON accessors.
 ///
-/// Only the fields directly derivable from the caps are emitted —
-/// the builder doesn't synthesise `colorspace`, `components`, or
-/// `transfer_characteristic` from `format=v210` alone. The user can
-/// add those by supplying a `transport-file` (which then wins over
-/// the builder).
+/// Per-format essence fields (`grain_rate`, `frame_width`, …) are
+/// taken from `caps` and are **required** by libnvnmos. Fields not
+/// present in the caps (`colorspace`, `components`, … for v210) are
+/// derived deterministically where libnvnmos requires them — see
+/// [`build_video_body`]. Users wanting non-default values should
+/// supply a `transport-file` instead.
 pub(crate) fn from_caps(input: &FlowDefBuildInput<'_>) -> Result<String, FlowDefError> {
-    if input.flow_id.is_empty() {
-        return Err(FlowDefError::MissingFlowId);
-    }
     if input.name.is_empty() {
         return Err(FlowDefError::MissingName);
     }
@@ -449,14 +462,13 @@ pub(crate) fn from_caps(input: &FlowDefBuildInput<'_>) -> Result<String, FlowDef
         .expect("body builders never return Unspecified");
 
     let mut value = serde_json::json!({
-        "id": input.flow_id,
         "format": format_urn,
         "label": label,
         // `description` is `field_as_string` (required) in nmos-cpp;
         // emit the property value as-is, even if it's empty.
         "description": input.description,
         // The three tags consumed by `libnvnmos` (`name`, `mxl-domain-id`)
-        // and by the MXL `FlowParser` (`grouphint`).
+        // and the group-hint tag required in configuring flow_def JSON.
         "tags": {
             "urn:x-nmos:tag:grouphint/v1.0": [grouphint],
             "urn:x-nvnmos:tag:name": [input.name],
@@ -465,6 +477,9 @@ pub(crate) fn from_caps(input: &FlowDefBuildInput<'_>) -> Result<String, FlowDef
         "parents": [],
     });
     let object = value.as_object_mut().unwrap();
+    if !input.flow_id.is_empty() {
+        object.insert("id".to_owned(), serde_json::json!(input.flow_id));
+    }
     for (k, v) in body {
         object.insert(k, v);
     }
@@ -1170,11 +1185,13 @@ mod tests {
     }
 
     #[test]
-    fn missing_flow_id_is_hard_error() {
+    fn omitted_flow_id_omits_top_level_id_for_registration() {
         let caps =
             caps_from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001");
-        let err = from_caps(&input("", "cam-1", &caps)).unwrap_err();
-        assert!(matches!(err, FlowDefError::MissingFlowId), "got: {err:?}");
+        let json = from_caps(&input("", "cam-1", &caps)).expect("registration synthesis");
+        let v = parse(&json);
+        assert!(v.get("id").is_none(), "empty flow_id must omit top-level `id`");
+        assert_eq!(v["format"], "urn:x-nmos:format:video");
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -13,14 +13,21 @@
 //!
 //! * a **fake chain** while no real flow is wired up (`fakesink` for
 //!   sinks, `appsrc` for sources, both idle in PLAYING), or
-//! * a **real chain** for a specific transport (today only MXL:
-//!   `mxlsink` on the sink side; on the source side a sub-bin
-//!   wrapping `mxlsrc ! capssetter`) once enough configuration is
-//!   pinned to instantiate it.
+//! * a **real chain** for the selected transport once enough
+//!   configuration is pinned to instantiate it:
+//!   * **MXL** — `mxlsink` on the sink side; on the source side a
+//!     sub-bin wrapping `mxlsrc ! capssetter` when advertise-caps
+//!     are known ([`build_mxlsink`] / [`build_mxlsrc`]).
+//!   * **UDP** (`udp` / `udp2`) — `rtp*pay ! udpsink` on the sink
+//!     side; `udpsrc ! rtp*depay` (optionally followed by
+//!     `capssetter` on the source side) ([`build_udpsink`] /
+//!     [`build_udpsrc`]).
+//!   * **nvdsudp** — DeepStream `nvdsudpsink` / `nvdsudpsrc`
+//!     ([`build_nvdsudpsink`] / [`build_nvdsudpsrc`]).
 //!
-//! Future transports (NVDS-UDP, plain UDP/RTP, ...) plug in as
-//! additional `build_real_*` factories alongside [`build_mxlsink`]
-//! / [`build_mxlsrc`]; the swap mechanics here are transport-agnostic.
+//! The swap mechanics here are transport-agnostic; each factory
+//! returns a chain element (or small bin) whose sink/src pad is
+//! linked behind the anchor.
 //!
 //! `nmossink` topology (data flows from the ghost into the chain):
 //!
@@ -526,7 +533,7 @@ pub(crate) fn current_chain_is_real(ghost: &gst::GhostPad) -> bool {
 /// looks valid in the pipeline before configuration is complete
 /// (it sinks any caps and drops everything). The `-fake` suffix on
 /// the element name is what [`current_chain_is_real`] checks to
-/// decide whether to insert a fake hop on real → real activations.
+/// decide whether to insert a fake hop into real → real re-activations.
 pub(crate) fn build_fake_sink() -> Result<gst::Element, anyhow::Error> {
     gst::ElementFactory::make("fakesink")
         .name("nmossink-fake")
@@ -540,11 +547,11 @@ pub(crate) fn build_fake_sink() -> Result<gst::Element, anyhow::Error> {
 /// buffers pushed into it. Its basesrc loop blocks in `create()` so
 /// no data flows; when `caps` is `Some` the appsrc also answers
 /// downstream caps queries with a concrete shape so negotiation
-/// completes. Replaced by a real chain (today `mxlsrc` in a
-/// `mxlsrc ! capssetter` sub-bin) once an IS-05 activation pins a
-/// Flow id. The `-fake` suffix on the element name is what
-/// [`current_chain_is_real`] checks to decide whether to insert a
-/// fake hop on real → real activations.
+/// completes. Replaced by the transport-specific real inner source
+/// chain once configuration is complete (via NULL→READY properties
+/// or an IS-05 activation). The `-fake` suffix on the element name
+/// is what [`current_chain_is_real`] checks to decide whether to
+/// insert a fake hop into real → real re-activations.
 ///
 /// When `caps` is `None` (typical at construction time, before any
 /// properties have been set) the appsrc is built without caps;
@@ -722,7 +729,7 @@ pub(crate) fn build_mxlsrc(
     })
 }
 
-/// Build the inner UDP/RTP sink chain for `nmossink`. Always
+/// Build the inner RTP/UDP sink chain for `nmossink`. Always
 /// constructs a sub-bin: `rtp<essence>pay ! udpsink` (or the
 /// gst-plugins-rs `*pay2` family + `udpsink` for [`UdpVariant::V2`])
 /// with the payloader's sink pad ghosted out so the outer
@@ -930,7 +937,7 @@ fn select_rtp_factory(
         (FlowFormat::Audio, "L16") => "rtpL16",
         (FlowFormat::Data, "SMPTE291") => "rtpsmpte291",
         _ => bail!(
-            "unsupported essence for UDP/RTP `{suffix}`: format={format:?}, \
+            "unsupported essence for RTP/UDP `{suffix}`: format={format:?}, \
              encoding-name=`{encoding_name}` (today RFC 4175 `RAW` video, \
              ST 2110-30 `L24` / `L16` audio, and RFC 8331 / ST 2110-40 \
              `SMPTE291` ANC are supported)"
@@ -1055,7 +1062,7 @@ fn multicast_iface_name(destination_ip: &str, interface_ip: Option<&str>) -> Opt
     crate::iface::iface_name_for_ip(iface)
 }
 
-/// Build the inner UDP/RTP source chain for `nmossrc`. Always
+/// Build the inner RTP/UDP source chain for `nmossrc`. Always
 /// constructs a sub-bin:
 /// `udpsrc(caps=rtp_caps) ! rtp<essence>depay [! capsfilter(advertise_caps)]`
 /// (with the udpsrc factory picked via [`select_udpsrc_factory`]
@@ -1082,7 +1089,7 @@ fn multicast_iface_name(destination_ip: &str, interface_ip: Option<&str>) -> Opt
 /// latency cost (an `rtp-latency` element property + an `rtp-stats`
 /// readback or a periodic element `GstMessage`). Strict ST 2110
 /// reception with kernel-bypass + PTP-aligned timing belongs to
-/// `nvdsudpsrc` rather than this OSS chain.
+/// `nvdsudpsrc` rather than this chain.
 ///
 /// `udpsrc.caps` is set to `media.rtp_caps` so downstream caps
 /// queries (and the depayloader's pad negotiation) see the exact
@@ -1252,10 +1259,11 @@ fn nvdsudp_log_cat() -> &'static gst::DebugCategory {
 fn require_nvdsudp_factory(name: &'static str) -> Result<(), anyhow::Error> {
     if gst::ElementFactory::find(name).is_none() {
         return Err(anyhow!(
-            "GStreamer factory `{name}` not found; install DeepStream's \
-             `gst-nvdsudp` plugin (Rivermax SDK + ConnectX-5 or newer NIC), \
-             set `GST_PLUGIN_PATH`, and ensure the host binary has \
-             `CAP_NET_RAW` (e.g. `sudo setcap CAP_NET_RAW=ep $(which gst-launch-1.0)`)"
+            "GStreamer factory `{name}` not found; install DeepStream 9.0 and \
+             Rivermax SDK (see DeepStream installation guide), ensure DeepStream \
+             plugins (e.g. `libnvdsgst_udp.so`) are on `GST_PLUGIN_PATH`, and \
+             ensure the host binary has `CAP_NET_RAW` (e.g. \
+             `sudo setcap CAP_NET_RAW=ep $(which gst-launch-1.0)`)"
         ));
     }
     Ok(())
@@ -1489,8 +1497,8 @@ fn require_mxl_factory(name: &'static str) -> Result<(), anyhow::Error> {
 ///
 /// The ghost pad target is set here and **never changed** by
 /// [`rebuild_chain`]; all subsequent activations swap the fake
-/// chain (or its real successor `mxlsink` / `mxlsrc`) behind the
-/// anchor while the ghost continues to point at the anchor.
+/// chain (or its real successor) behind the anchor while the ghost
+/// continues to point at the anchor.
 pub(crate) fn build_initial(
     bin: &gst::Bin,
     fake_chain: gst::Element,

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -91,8 +91,9 @@
 //! opened without a resource and the actual `AddSender` is driven
 //! from `change_state(ReadyToPaused)`. The ghost sink pad's upstream
 //! peer is queried for caps, the result is fixated and fed to the
-//! shared caps-driven flow_def builder, and on success the inner is
-//! swapped to `mxlsink`. State-change errors propagate when peer
+//! caps-driven transport-file builder (`flow_def` on MXL, SDP on
+//! `udp` / `udp2` / `nvdsudp`), and on success the inner is swapped to
+//! the real transport chain. State-change errors propagate when peer
 //! caps are ANY/EMPTY or unsupported by the builder so the user gets
 //! a clear, pipeline-visible "declare `caps=…` or insert a
 //! `capsfilter`" hint. Receiver-side deferred mode is intentionally
@@ -113,7 +114,7 @@
 //! `nmossrc ! transform ! nmossink` pipeline then resolves end-to-end
 //! at READY→PAUSED: the deferred `nmossink`'s peer_query_caps lands
 //! on the pinned caps and `AddSender` runs against the right
-//! flow_def.
+//! configuring transport file.
 //!
 //! Receiver-side caps→flow_def synthesis is symmetric with the
 //! Sender path: `nmossrc` with `caps` + `mxl-flow-id` (no transport

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -33,15 +33,15 @@
 //! file — the element rewrites the matching field/tag before handing
 //! it to the daemon. Essence-shape properties (`caps`,
 //! `transport-caps`) are **cross-checked** against the file and
-//! mismatch is a hard error. See `flow_def::splice_overrides` for the
-//! splice mechanics and `rust/gst-nmos-rs/README.md` ("Property
-//! interaction with `transport-file`") for the full property matrix.
+//! mismatch is a hard error. See `flow_def::splice_overrides` (MXL)
+//! and `sdp::passthrough_with_overrides` (RTP/UDP) for the splice
+//! mechanics and `rust/gst-nmos-rs/README.md` ("Property interaction
+//! with `transport-file`") for the full property matrix.
 //!
-//! Inner data path: when the resolved configuration pins a Domain
-//! path and a Flow id (plus a Flow format on the receiver), the bin
-//! is *capable* of running the real `mxlsink` / `mxlsrc`. Whether it
-//! does so eagerly is controlled by the `auto-activate` boolean
-//! property:
+//! Inner data path: when the resolved configuration is complete for
+//! the chosen `transport`, the bin is *capable* of running the real
+//! inner transport chain. Whether it does so eagerly is controlled
+//! by the `auto-activate` boolean property:
 //!
 //! - `auto-activate=false` (default, canonical NMOS): the element
 //!   adds the Sender or Receiver to the daemon so it appears on
@@ -64,11 +64,11 @@
 //! depending on `transport`) — all three routes funnel into the same
 //! gate.
 //!
-//! If the resolved configuration is incomplete (no Domain path, no
-//! flow id, or no Flow format on the receiver), the element stays
-//! on the fake chain regardless of `auto-activate` — the gate only
-//! upgrades configurations that *could* run; it never invents
-//! missing pieces.
+//! If the resolved configuration is incomplete for the chosen
+//! `transport` (e.g. missing MXL domain path / flow id, or incomplete
+//! RTP SDP / IS-05 endpoints), the element stays on the fake chain
+//! regardless of `auto-activate` — the gate only upgrades configurations
+//! that *could* run; it never invents missing pieces.
 //!
 //! Fake chain: while the inner is on the fake chain, the bin still
 //! has to look like a valid GStreamer element to the rest of the
@@ -80,8 +80,8 @@
 //! or caps synthesised from `transport-file*`) and `is-live=true`;
 //! we never push buffers into it, so its basesrc loop blocks idle
 //! in `create()` and the bin holds at PLAYING waiting for an IS-05
-//! activation to swap in a real `mxlsrc`. When no caps source is
-//! yet available (constructed-time, before any properties have
+//! activation to swap in the real inner source chain. When no caps
+//! are yet available (constructed-time, before any properties have
 //! been set) the appsrc is built without caps and downstream caps
 //! negotiation will fail; the NULL→READY transition replaces it
 //! with a caps-aware `appsrc` as soon as a caps source is
@@ -129,9 +129,9 @@
 //! usually delivers a full activation SDP in the `ActivationEvent`; the
 //! element builds the inner chain from that file — not from the
 //! configuring SDP passed at AddReceiver. On MXL, when `mxl-flow-id` is
-//! unset there is no stable subscription target yet, so bare `mxlsrc`
-//! is used and its broad pad template propagates until IS-05 activation
-//! supplies one.
+//! unset the element still calls AddSender / AddReceiver (the
+//! synthesised `flow_def` omits top-level `id`) but keeps the fake
+//! inner chain until IS-05 activation supplies the MXL flow id.
 
 use std::sync::LazyLock;
 

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -8,7 +8,7 @@
 //! for the architecture. The elements declare their property surface
 //! and run the session lifecycle: NULL→READY opens a session against
 //! `nvnmosd`, subscribes to activations, and (when `transport-file`
-//! is set) registers the Sender or Receiver via `AddSender` /
+//! is set) adds the Sender or Receiver via `AddSender` /
 //! `AddReceiver`; READY→NULL closes it.
 //!
 //! Each `ActivationEvent` arriving on the subscription is routed
@@ -44,24 +44,25 @@
 //! property:
 //!
 //! - `auto-activate=false` (default, canonical NMOS): the element
-//!   registers the resource so it appears on IS-04 but leaves the
-//!   inner on the fake chain. The daemon's
+//!   adds the Sender or Receiver to the daemon so it appears on
+//!   IS-04 but leaves the inner on the fake chain. The daemon's
 //!   `/single/{senders,receivers}/{id}/active` reports
 //!   `master_enable: false` until an IS-05 PATCH activates it; the
 //!   activation event then flows through `apply_activation` and
 //!   swaps the inner.
 //! - `auto-activate=true`: the element brings the inner up
-//!   immediately from the resolved configuring flow_def and calls
-//!   [`session::sync_active`] (which dispatches the daemon's
+//!   immediately from the resolved configuring transport file and
+//!   calls [`session::sync_active`] (which dispatches the daemon's
 //!   `SyncResourceState` RPC) so the daemon's IS-04/IS-05 view of
 //!   the resource flips to active without requiring an IS-05
 //!   controller. This is a development / no-controller shortcut.
 //!
-//! The toggle is orthogonal to where the configuring flow_def came
-//! from. The flow id may have been supplied by `mxl-flow-id` as a
-//! plain property override, taken from the transport file's
-//! top-level `id`, or produced by caps→flow_def synthesis — all
-//! three routes funnel into the same gate.
+//! The toggle is orthogonal to where the configuring transport file
+//! came from. The flow id may have been supplied by `mxl-flow-id` as a
+//! plain property override, taken from the transport file's top-level
+//! `id`, or produced by caps-driven synthesis (MXL `flow_def` or SDP,
+//! depending on `transport`) — all three routes funnel into the same
+//! gate.
 //!
 //! If the resolved configuration is incomplete (no Domain path, no
 //! flow id, or no Flow format on the receiver), the element stays
@@ -99,36 +100,38 @@
 //! `capsfilter`" hint. Receiver-side deferred mode is intentionally
 //! out of scope (no peer to query).
 //!
-//! `nmossrc` advertises essence caps on its ghost source pad when a
-//! configuring transport file is in play, except for receivers whose
-//! effective transport file indicates wide Receiver Caps: MXL receivers
-//! use the `urn:x-nvnmos:tag:caps` tag (after NULL→READY property
-//! splice, or on the daemon activation file) and use bare `mxlsrc` so
-//! runtime caps come from the filesystem flow_def; UDP receivers use
-//! media-level `a=x-nvnmos-caps:` (spliced at registration or emitted
-//! by libnvnmos on IS-05 activation) and omit the trailing
-//! `capssetter` so runtime caps come from the live RTP flow.
-//! Otherwise the configuring transport file is reverse-mapped and
-//! pinned by an internal `capssetter` so downstream caps queries see
-//! the concrete shape the flow will carry — the canonical
-//! `nmossrc ! transform ! nmossink` pipeline then resolves end-to-end
-//! at READY→PAUSED: the deferred `nmossink`'s peer_query_caps lands
-//! on the pinned caps and `AddSender` runs against the right
-//! configuring transport file.
+//! `nmossrc` pins essence caps on its ghost source pad from the
+//! configuring transport file when the Receiver is *narrow* (BCP-004-01:
+//! Receiver Caps are advertised on IS-04). *Wide* receivers advertise
+//! no Receiver Caps; on MXL the `urn:x-nvnmos:tag:caps` flow_def tag
+//! marks wide and bare `mxlsrc` is used so runtime caps come from the
+//! filesystem flow_def; on RTP/UDP `a=x-nvnmos-caps:` marks wide and the
+//! inner chain omits `capssetter` so runtime caps come from the live RTP
+//! depay. Narrow receivers reverse-map the configuring file and pin
+//! essence caps via an internal `capssetter` so downstream caps queries
+//! see the concrete shape — the canonical `nmossrc ! transform !
+//! nmossink` pipeline then resolves end-to-end at READY→PAUSED: the
+//! deferred `nmossink`'s peer_query_caps lands on the pinned caps and
+//! `AddSender` runs against the right configuring transport file.
 //!
-//! Receiver-side caps→flow_def synthesis is symmetric with the
-//! Sender path: `nmossrc` with `caps` + `mxl-flow-id` (no transport
-//! file) builds a configuring flow_def that the daemon then
-//! advertises as BCP-004-01 narrow Receiver Caps on IS-04, with the
-//! `urn:x-nvnmos:tag:caps` tag spliced by `receiver-caps-mode` to
-//! indicate narrow vs wide. The semantic distinction from a Sender's
-//! flow_def is that a Receiver's configuring file describes "what
-//! this Receiver expects to consume"; the live transport file
-//! arriving via IS-05 PATCH later replaces the subscription fields
-//! (mxl-flow-id, etc.) without overwriting the Receiver Caps
-//! advertisement. When `mxl-flow-id` is unset there is no stable
-//! subscription target yet, so the bare `mxlsrc` is used and its
-//! broad pad template propagates until IS-05 activation supplies one.
+//! Receiver-side caps-driven synthesis is symmetric with the Sender
+//! path: `nmossrc` with `caps` (no transport file) builds a
+//! configuring transport file — MXL `flow_def` or SDP depending on
+//! `transport`. For narrow receivers the daemon advertises BCP-004-01
+//! Receiver Caps on IS-04 from that file; for wide receivers none are
+//! advertised. `receiver-caps-mode` splices the wide/narrow marker:
+//! `urn:x-nvnmos:tag:caps` on MXL, `a=x-nvnmos-caps:` on RTP/UDP.
+//! The configuring file describes the Receiver at AddReceiver time;
+//! IS-05 activation then supplies the real config. On MXL, the
+//! activation transport file (typically synthesized by libnvnmos from
+//! the PATCH) updates subscription fields such as `mxl-flow-id` without
+//! changing the IS-04 caps advertisement. On RTP, activation
+//! usually delivers a full activation SDP in the `ActivationEvent`; the
+//! element builds the inner chain from that file — not from the
+//! configuring SDP passed at AddReceiver. On MXL, when `mxl-flow-id` is
+//! unset there is no stable subscription target yet, so bare `mxlsrc`
+//! is used and its broad pad template propagates until IS-05 activation
+//! supplies one.
 
 use std::sync::LazyLock;
 

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -3,11 +3,12 @@
 
 //! `nmossink` impl: GstBin subclass that opens a session against
 //! `nvnmosd` at NULL→READY and closes it at READY→NULL. The inner
-//! data path is a *real* chain — today a `mxlsink` — when the
-//! resolved configuration pins a Domain path + Flow id; otherwise
-//! the bin keeps a *fake* chain (`fakesink`) so the element looks
-//! valid in the pipeline until an IS-05 activation (or a later
-//! configuration update) supplies the missing pieces.
+//! data path is a *real* transport chain (`mxlsink`, `udpsink` with
+//! RTP payloader, or `nvdsudpsink`) when configuration is complete
+//! for the chosen `transport`; otherwise the bin keeps a *fake* chain
+//! (`fakesink`) so the element looks valid in the pipeline until an
+//! IS-05 activation (or a later configuration update) supplies the
+//! missing pieces.
 //!
 //! Activations arriving on the daemon subscription are dispatched to
 //! [`NmosSink::apply_activation`], which marshals the work onto a
@@ -120,8 +121,8 @@ pub struct NmosSink {
     session: Mutex<Option<Session>>,
     /// Ghost pad that hides the current inner chain behind the bin.
     /// Created at `constructed`; the chain behind it swaps between
-    /// the fake chain and a real `mxlsink` as configuration /
-    /// activations land.
+    /// the fake chain and a real inner transport chain as configuration
+    /// / activations land.
     ghost: Mutex<Option<gst::GhostPad>>,
 }
 
@@ -606,10 +607,10 @@ impl NmosSink {
         inner::rebuild_chain(&CAT, bin, ghost, new_inner, "sink")
     }
 
-    /// True iff the bin's current inner chain is a real chain
-    /// (today only `mxlsink`) — not the fake `fakesink`. Used by
-    /// [`execute_activation_plan`] to insert a fake hop on real → real
-    /// re-activations.
+    /// True iff the bin's current inner chain is a real transport
+    /// chain — not the fake one (`fakesink`). Used by
+    /// [`execute_activation_plan`] to insert a fake hop into
+    /// real → real re-activations.
     fn current_chain_is_real(&self) -> bool {
         self.ghost
             .lock()

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -175,16 +175,7 @@ impl ObjectImpl for NmosSink {
                     .build(),
                 glib::ParamSpecString::builder("sender-name")
                     .nick("NMOS sender name")
-                    .blurb(
-                        "Name for this Sender within the Node (becomes the \
-                         `x-nvnmos-name` SDP attribute or the \
-                         `urn:x-nvnmos:tag:name` flow-def tag in the \
-                         transport file). Unique across Senders on the \
-                         Node; a Receiver on the same Node may share the \
-                         same name (the daemon scopes names by side). \
-                         Overrides the transport file's tag when both \
-                         are supplied.",
-                    )
+                    .blurb(crate::session::SENDER_NAME_BLURB)
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("mxl-domain-id")
@@ -222,33 +213,17 @@ impl ObjectImpl for NmosSink {
                     .build(),
                 glib::ParamSpecString::builder("label")
                     .nick("Label")
-                    .blurb(
-                        "NMOS label for the Sender. Optional. Overrides \
-                         the transport file's top-level `label` when both \
-                         are supplied.",
-                    )
+                    .blurb(crate::session::LABEL_BLURB_SENDER)
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("description")
                     .nick("Description")
-                    .blurb(
-                        "NMOS description for the Sender. Optional. \
-                         Overrides the transport file's top-level \
-                         `description` when both are supplied.",
-                    )
+                    .blurb(crate::session::DESCRIPTION_BLURB_SENDER)
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("transport-file")
                     .nick("Transport file")
-                    .blurb(
-                        "Literal contents of the NvNmos transport file: MXL flow_def \
-                         JSON today; SDP later. The daemon registers it with the \
-                         resource and re-publishes it via IS-05. Pass the text, not a \
-                         path. Convenient for programmatic callers; from gst-launch \
-                         use `transport-file-path` instead. Mutually exclusive with \
-                         `transport-file-path`. When unset and `caps` is supplied the \
-                         element synthesises a flow_def from the essence caps.",
-                    )
+                    .blurb(crate::session::TRANSPORT_FILE_BLURB_SENDER)
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("transport-file-path")
@@ -258,15 +233,7 @@ impl ObjectImpl for NmosSink {
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Caps>("caps")
                     .nick("Essence caps")
-                    .blurb(
-                        "Essence caps used to synthesise the MXL `flow_def` JSON when \
-                         `transport-file` / `transport-file-path` are unset. Supported \
-                         shapes match `mxlsink`'s pad template: `video/x-raw,format=v210,…`, \
-                         `audio/x-raw,format=F32LE,…`, and `meta/x-st-2038,framerate=…`. \
-                         Requires `mxl-flow-id` to be set. Cross-checked against the \
-                         transport file's `format` field when both are supplied — \
-                         mismatch is a hard error.",
-                    )
+                    .blurb(crate::session::CAPS_BLURB_SENDER)
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Caps>("transport-caps")
@@ -541,14 +508,14 @@ impl ElementImpl for NmosSink {
                 // Children transition up first so caps negotiate
                 // (the fake-chain fakesink accepts whatever upstream
                 // proposes); we then query the negotiated peer caps
-                // and, if no resource is yet registered, drive the
+                // and, if no resource is yet added, drive the
                 // deferred AddSender.
                 let res = self.parent_change_state(transition)?;
-                if let Err(e) = self.maybe_register_deferred() {
+                if let Err(e) = self.maybe_add_deferred_sender() {
                     gst::element_imp_error!(
                         self,
                         gst::ResourceError::OpenWrite,
-                        ["nmossink READY\u{2192}PAUSED deferred registration failed: {e:#}"]
+                        ["nmossink READY\u{2192}PAUSED deferred AddSender failed: {e:#}"]
                     );
                     return Err(gst::StateChangeError);
                 }
@@ -598,7 +565,7 @@ impl NmosSink {
         self.swap_inner(bin, &new_inner)?;
         // Reaching the `Real` branch at NULL→READY / READY→PAUSED
         // implies `auto-activate=true` (the `validate_and_open` and
-        // `register_deferred` gates downgrade to a fake chain
+        // `add_deferred_sender` gates downgrade to a fake chain
         // otherwise). Tell the daemon to bring the resource's
         // IS-04/IS-05 view up to match the live data path so
         // external state stays consistent without an external
@@ -652,24 +619,24 @@ impl NmosSink {
     }
 
     /// Drive a deferred `AddSender` from inside
-    /// `change_state(ReadyToPaused)`. Only attempts registration when
+    /// `change_state(ReadyToPaused)`. Only attempts AddSender when
     /// the session is open without a resource and neither
     /// `transport-file*` nor `caps` were supplied at NULL→READY. The
     /// ghost sink pad is queried for the upstream peer's caps, which
-    /// are then fed to the shared caps-driven flow_def builder; on
-    /// success the inner element is swapped to a real `mxlsink`.
+    /// are then fed to the shared caps-driven transport-file builder; on
+    /// success the inner element is swapped to the real transport chain.
     ///
     /// Returns `Ok(())` both when deferred mode is not applicable and
-    /// when registration succeeds. Errors are propagated only on real
+    /// when AddSender succeeds. Errors are propagated only on real
     /// failures (ANY/EMPTY caps, builder rejection, AddSender RPC
     /// failure) so that change_state surfaces a clear,
     /// pipeline-visible error.
-    fn maybe_register_deferred(&self) -> Result<(), anyhow::Error> {
+    fn maybe_add_deferred_sender(&self) -> Result<(), anyhow::Error> {
         let snapshot = self.settings.lock().unwrap().clone();
         let static_inputs_set = !snapshot.transport_file.is_empty()
             || !snapshot.transport_file_path.is_empty()
             || snapshot.caps.is_some();
-        let resource_registered = self
+        let resource_added = self
             .session
             .lock()
             .unwrap()
@@ -677,7 +644,7 @@ impl NmosSink {
             .and_then(|s| s.resource_id().map(|_| ()))
             .is_some();
         let session_open = self.session.lock().unwrap().is_some();
-        if !session_open || resource_registered || static_inputs_set {
+        if !session_open || resource_added || static_inputs_set {
             return Ok(());
         }
 
@@ -691,7 +658,7 @@ impl NmosSink {
         gst::debug!(CAT, imp = self, "deferred mode peer_query_caps -> {peer_caps}");
 
         let common: crate::session::CommonSettings = snapshot.into();
-        let outcome = crate::session::register_deferred(
+        let outcome = crate::session::add_deferred_sender(
             &CAT,
             "nmossink",
             &common,

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -185,16 +185,7 @@ impl ObjectImpl for NmosSrc {
                     .build(),
                 glib::ParamSpecString::builder("receiver-name")
                     .nick("NMOS receiver name")
-                    .blurb(
-                        "Name for this Receiver within the Node (becomes the \
-                         `x-nvnmos-name` SDP attribute or the \
-                         `urn:x-nvnmos:tag:name` flow-def tag in the \
-                         transport file). Unique across Receivers on the \
-                         Node; a Sender on the same Node may share the \
-                         same name (the daemon scopes names by side). \
-                         Overrides the transport file's tag when both \
-                         are supplied.",
-                    )
+                    .blurb(crate::session::RECEIVER_NAME_BLURB)
                     .build(),
                 glib::ParamSpecString::builder("mxl-domain-id")
                     .nick("MXL domain id")
@@ -234,30 +225,15 @@ impl ObjectImpl for NmosSrc {
                     .build(),
                 glib::ParamSpecString::builder("label")
                     .nick("Label")
-                    .blurb(
-                        "NMOS label for the Receiver. Optional. Overrides \
-                         the transport file's top-level `label` when both \
-                         are supplied.",
-                    )
+                    .blurb(crate::session::LABEL_BLURB_RECEIVER)
                     .build(),
                 glib::ParamSpecString::builder("description")
                     .nick("Description")
-                    .blurb(
-                        "NMOS description for the Receiver. Optional. \
-                         Overrides the transport file's top-level \
-                         `description` when both are supplied.",
-                    )
+                    .blurb(crate::session::DESCRIPTION_BLURB_RECEIVER)
                     .build(),
                 glib::ParamSpecString::builder("transport-file")
                     .nick("Transport file")
-                    .blurb(
-                        "Literal contents of the NvNmos transport file: MXL flow_def \
-                         JSON today; SDP later. The daemon registers it with the \
-                         resource and re-publishes it via IS-05. Pass the text, not a \
-                         path. Convenient for programmatic callers; from gst-launch \
-                         use `transport-file-path` instead. Mutually exclusive with \
-                         `transport-file-path`. Required unless `caps` is provided.",
-                    )
+                    .blurb(crate::session::TRANSPORT_FILE_BLURB_RECEIVER)
                     .build(),
                 glib::ParamSpecString::builder("transport-file-path")
                     .nick("Transport file path")
@@ -265,15 +241,7 @@ impl ObjectImpl for NmosSrc {
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Caps>("caps")
                     .nick("Essence caps")
-                    .blurb(
-                        "Essence-shaped pad caps. Required if `transport-file` is not \
-                         provided: the media-type structure name (`video/x-raw` / \
-                         `audio/x-raw` / `meta/x-st-2038`) decides which `mxlsrc` flow-id \
-                         slot receives `mxl-flow-id`. Cross-checked against the \
-                         transport file's `format` field when both are supplied — \
-                         mismatch is a hard error (the caps and the flow's essence shape \
-                         must describe the same thing).",
-                    )
+                    .blurb(crate::session::CAPS_BLURB_RECEIVER)
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Caps>("transport-caps")
                     .nick("Transport caps")
@@ -292,17 +260,14 @@ impl ObjectImpl for NmosSrc {
                 glib::ParamSpecEnum::builder::<CapsMode>("receiver-caps-mode")
                     .nick("Receiver caps mode")
                     .blurb(
-                        "Selects whether the published NMOS Receiver advertises narrow \
-                         or wide Receiver Caps in IS-04. On MXL (`transport=mxl`) this \
-                         is encoded via the `urn:x-nvnmos:tag:caps` flow_def tag; on \
-                         RTP/UDP it is encoded via the media-level SDP \
-                         `a=x-nvnmos-caps` attribute. `auto` (default) leaves both \
-                         untouched in the spliced transport file: the result is narrow \
-                         when the file is present and the marker is absent (or no \
-                         transport file is in play), and wide when the marker is \
-                         already there. `narrow` strips the tag / attribute if \
-                         present. `wide` ensures each is present (libnvnmos's rule \
-                         for wide is \"present + non-empty\").",
+                        "Whether the Receiver advertises BCP-004-01 Receiver Caps \
+                         on IS-04 (narrow) or none (wide). On MXL, wide is \
+                         encoded via `urn:x-nvnmos:tag:caps`; on RTP/UDP via \
+                         media-level `a=x-nvnmos-caps:`. `auto` (default) \
+                         leaves the marker untouched in the spliced transport \
+                         file — narrow when absent (or with no transport file), \
+                         wide when present. `narrow` strips it; `wide` ensures \
+                         it is present (libnvnmos: present + non-empty = wide).",
                     )
                     .default_value(CapsMode::Auto)
                     .build(),

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -3,13 +3,12 @@
 
 //! `nmossrc` impl: GstBin subclass that opens a session against
 //! `nvnmosd` at NULL→READY and closes it at READY→NULL. The inner
-//! data path is a *real* chain — today a `mxlsrc` — when the
-//! resolved configuration pins a Domain path + Flow id + a
-//! recognised essence shape (from `caps` or the transport file's
-//! `format`); otherwise the bin keeps a *fake* chain so the element
-//! looks valid in the pipeline until an IS-05 activation (or a
-//! later configuration update) supplies the missing pieces. The
-//! fake chain is an `appsrc` configured with the best-available
+//! data path is a *real* transport source chain when configuration is
+//! complete for the chosen `transport` (MXL: domain path, flow id, and
+//! format; RTP/UDP: SDP / IS-05 endpoints and format); otherwise the
+//! bin keeps a *fake* chain so the element looks valid in the pipeline
+//! until an IS-05 activation (or a later configuration update) supplies
+//! the missing pieces. The fake chain is an `appsrc` configured with
 //! essence caps (user `caps` property, synthesised from
 //! `transport-file`*); if no caps source is yet available, the
 //! appsrc is built without caps and downstream negotiation will
@@ -131,8 +130,8 @@ pub struct NmosSrc {
     session: Mutex<Option<Session>>,
     /// Ghost pad that hides the current inner chain behind the bin.
     /// Created at `constructed`; the chain behind it swaps between
-    /// the fake chain and a real `mxlsrc` sub-bin as configuration
-    /// / activations land.
+    /// the fake chain and a real inner transport source chain as
+    /// configuration / activations land.
     ghost: Mutex<Option<gst::GhostPad>>,
 }
 
@@ -703,9 +702,9 @@ impl NmosSrc {
         inner::rebuild_chain_with_opts(&CAT, bin, ghost, new_inner, "src", opts)
     }
 
-    /// True iff the bin's current inner chain is a real chain
-    /// (today only the `mxlsrc` sub-bin) — not the fake `appsrc`.
-    /// Used by [`execute_activation_plan`] to insert a fake hop on
+    /// True iff the bin's current inner chain is a real transport
+    /// source chain — not the fake one (`appsrc`). Used by
+    /// [`execute_activation_plan`] to insert a fake hop into
     /// real → real re-activations.
     fn current_chain_is_real(&self) -> bool {
         self.ghost
@@ -847,7 +846,7 @@ impl NmosSrc {
                     }
                     Err(e) => {
                         return ActivationOutcome::Failed {
-                            reason: format!("nmossrc: building inner mxlsrc: {e:#}"),
+                            reason: format!("nmossrc: building inner transport chain: {e:#}"),
                         };
                     }
                 }

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -108,8 +108,10 @@ use crate::types::{CapsMode, FlowFormat};
 /// [`build_sdp`], the per-essence payload-type constants by
 /// [`resolve_payload_type`], [`AUDIO_PTIME_NS`](self::defaults::AUDIO_PTIME_NS)
 /// by [`resolve_audio_ptime`], [`RTP_PORT`](self::defaults::RTP_PORT)
-/// by [`udp_leg_from_input`], [`ORIGIN_ADDRESS`](self::defaults::ORIGIN_ADDRESS)
-/// by [`from_caps`], and the video / ANC constants by
+/// by [`udp_leg_from_input`] (including empty
+/// `destination_ip` → [`UNSPECIFIED_ADDRESS`](self::defaults::UNSPECIFIED_ADDRESS)
+/// on the `c=` line), [`UNSPECIFIED_ADDRESS`] by [`from_caps`]'s
+/// `o=` fallback, and the video / ANC constants by
 /// [`rtp_caps_from_raw_video`] / [`rtp_caps_from_raw_data`].
 pub(crate) mod defaults {
     /// Default RTP payload type for `video/x-raw` (RFC 4175,
@@ -145,14 +147,12 @@ pub(crate) mod defaults {
     /// time — and is the de-facto SMPTE ST 2110 convention.
     pub(crate) const RTP_PORT: u16 = 5004;
 
-    /// `o=` line `<unicast-address>` fallback used before any
-    /// caps negotiation pins a NIC. Per RFC 4566 §5.2 this
-    /// slot may carry any address when the originator's real
-    /// address isn't known; `0.0.0.0` is the canonical
-    /// "unspecified" form. `build_sdp` substitutes the real
-    /// address once an `interface_ip` / `source_ip` property
-    /// or activation SDP resolves one.
-    pub(crate) const ORIGIN_ADDRESS: &str = "0.0.0.0";
+    /// RFC 4566 unspecified IPv4 address (`0.0.0.0`). Synthesis
+    /// fallback when an endpoint IP slot (`o=`, `c=`, …) is not
+    /// set yet; libnvnmos maps this to IS-05 `auto` where
+    /// applicable. Passthrough SDPs are never rewritten to this
+    /// value.
+    pub(crate) const UNSPECIFIED_ADDRESS: &str = "0.0.0.0";
 
     /// TTL applied when the `c=` line address is multicast.
     /// Per RFC 4566 §5.7 the `<addr>/<ttl>` suffix MUST be
@@ -683,7 +683,7 @@ pub(crate) fn normalise_to_single_active_leg(text: &str) -> Result<String, SdpEr
     let origin = msg.origin();
     let origin_address = origin
         .and_then(|o| o.addr())
-        .unwrap_or(defaults::ORIGIN_ADDRESS);
+        .unwrap_or(defaults::UNSPECIFIED_ADDRESS);
     let origin_session_id = origin
         .and_then(|o| o.sess_id())
         .unwrap_or("0");
@@ -1256,10 +1256,9 @@ fn cross_check_transport_caps(media: &UdpMedia, transport_caps: &gst::Caps) -> R
 /// `c=` lines:
 /// * Sender: the egress destination (unicast peer or multicast
 ///   group) — `nmossink`'s `destination-ip` property.
-/// * Receiver: the multicast group to join (or unicast bind
-///   address) — `nmossrc`'s `multicast-ip` property. The two
-///   GObject property names differ but the SDP wire slot is the
-///   same.
+/// * Receiver: the `c=` address — `nmossrc`'s `multicast-ip`
+///   when joining a group, otherwise `interface-ip` for unicast
+///   reception (mirrors nmos-cpp `get_connection_address`).
 ///
 /// `interface_ip` is the local NIC:
 /// * Sender: unused — Senders re-use `source_ip` as the egress
@@ -1395,7 +1394,7 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
 
     let origin_address = if input.interface_ip.is_empty() {
         if input.source_ip.is_empty() {
-            defaults::ORIGIN_ADDRESS
+            defaults::UNSPECIFIED_ADDRESS
         } else {
             input.source_ip
         }
@@ -1596,8 +1595,16 @@ fn udp_leg_from_input(input: &SdpBuildInput<'_>) -> UdpLeg {
         Side::Sender if input.source_port != 0 => Some(input.source_port),
         _ => None,
     };
+    // Unset `destination-ip` / `multicast-ip`: emit
+    // [`defaults::UNSPECIFIED_ADDRESS`] on the `c=` line (synthesis
+    // only — passthrough SDPs are never rewritten here).
+    let destination_ip = if input.destination_ip.is_empty() {
+        defaults::UNSPECIFIED_ADDRESS.to_owned()
+    } else {
+        input.destination_ip.to_owned()
+    };
     UdpLeg {
-        destination_ip: input.destination_ip.to_owned(),
+        destination_ip,
         destination_port,
         interface_ip,
         source_ip,
@@ -2340,15 +2347,11 @@ mod tests {
     }
 
     #[test]
-    fn defaults_origin_address_is_rfc_4566_unspecified() {
-        // RFC 4566 §5.2: any IPv4 address is permitted when
-        // the originator's real address is unknown; `0.0.0.0`
-        // is the canonical "unspecified" form.
-        assert_eq!(defaults::ORIGIN_ADDRESS, "0.0.0.0");
-        // Sanity: parseable as `Ipv4Addr::UNSPECIFIED`.
-        let parsed: std::net::Ipv4Addr = defaults::ORIGIN_ADDRESS
+    fn defaults_unspecified_address_is_ipv4_unspecified() {
+        assert_eq!(defaults::UNSPECIFIED_ADDRESS, "0.0.0.0");
+        let parsed: std::net::Ipv4Addr = defaults::UNSPECIFIED_ADDRESS
             .parse()
-            .expect("ORIGIN_ADDRESS must parse as an Ipv4Addr");
+            .expect("UNSPECIFIED_ADDRESS must parse as an Ipv4Addr");
         assert_eq!(parsed, std::net::Ipv4Addr::UNSPECIFIED);
     }
 
@@ -4902,6 +4905,16 @@ mod tests {
         assert_eq!(leg.source_ip.as_deref(), Some("192.0.2.10"));
         assert_eq!(leg.interface_ip.as_deref(), Some("192.0.2.11"));
         assert_eq!(leg.source_port, None, "Receiver carries no source_port");
+    }
+
+    #[test]
+    fn udp_leg_from_input_empty_destination_ip_falls_back_to_unspecified_address() {
+        init_gst();
+        let essence = raw_audio_caps("S24BE", 48_000, 2);
+        let mut input = build_input(&essence, Side::Sender, None);
+        input.destination_ip = "";
+        let leg = udp_leg_from_input(&input);
+        assert_eq!(leg.destination_ip, defaults::UNSPECIFIED_ADDRESS);
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -396,7 +396,7 @@ pub(crate) struct SdpSession<'a> {
     pub advertise_caps: bool,
     /// When true, emit `a=ts-refclk:ptp=IEEE1588-2008:traceable` on the
     /// media block (Rivermax / `transport=nvdsudp` sender synthesis).
-    /// OSS `udp` / `udp2` and all receivers leave this false.
+    /// `transport=udp` / `udp2` and all receivers leave this false.
     pub emit_ptp_ts_refclk: bool,
 }
 
@@ -1322,7 +1322,7 @@ pub(crate) struct SdpBuildInput<'a> {
     /// `<sess-id>` on the synthesis path.
     pub node_seed: &'a str,
     /// When true, emit `TP=2110TPN` on video fmtp (Rivermax / `nvdsudp`
-    /// narrow traffic profile). OSS `udp` / `udp2` leave this unset.
+    /// narrow traffic profile). `udp` / `udp2` leave this unset.
     pub narrow_traffic_profile: bool,
 }
 
@@ -4961,7 +4961,7 @@ mod tests {
             !text.contains("a=ts-refclk:"),
             "udp sender synthesis must omit ts-refclk:\n{text}",
         );
-        assert!(!text.contains("TP=2110TPN"), "OSS udp must not narrow profile:\n{text}");
+        assert!(!text.contains("TP=2110TPN"), "udp sender must not indicate narrow profile:\n{text}");
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -349,7 +349,7 @@ pub(crate) struct SdpSession<'a> {
     pub name: Option<&'a str>,
     /// Whether to emit a media-level `a=x-nvnmos-caps:<pt>` line
     /// for the resulting Receiver. `true` advertises *wide* caps
-    /// (the daemon registers the IS-04 Receiver with the
+    /// (the daemon adds the IS-04 Receiver with the
     /// format-derived capability constraints omitted, so any
     /// compatible Sender of the same media type can connect);
     /// `false` advertises *narrow* caps (capability constraints
@@ -403,7 +403,7 @@ pub(crate) struct SdpSession<'a> {
 /// Whether an SDP transport file advertises wide Receiver Caps via
 /// media-level `a=x-nvnmos-caps:` (libnvnmos adds this on IS-05
 /// activation for wide receivers; configuring SDPs may carry it when
-/// `receiver-caps-mode=wide` splices it in at registration).
+/// `receiver-caps-mode=wide` splices it in at AddReceiver).
 ///
 /// Both `a=x-nvnmos-caps` (flag form) and `a=x-nvnmos-caps:<pt>`
 /// (property form) signal wide to libnvnmos. Unparseable input is

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -18,8 +18,6 @@ use gstreamer as gst;
 use nvnmos_rpc::v1::Transport as ProtoTransport;
 
 use crate::daemon::{ActivationHandler, ActivationRequest, Session};
-use crate::domain;
-use crate::flow_def::{self, FlowDefBuildInput};
 use crate::runtime::SHARED_RUNTIME;
 use crate::types::{CapsMode, DEFAULT_DAEMON_URI, FlowFormat, Transport};
 
@@ -128,12 +126,87 @@ pub(crate) const MXL_DOMAIN_ID_BLURB: &str =
      supplied. Cross-checked against `domain_def.json` when both \
      are supplied (mismatch is an error). On `nmossrc`, set before \
      NULL\u{2192}READY; on `nmossink` it may also be set in READY \
-     for deferred sender registration.";
+     for deferred AddSender.";
+
+pub(crate) const SENDER_NAME_BLURB: &str =
+    "Name for this Sender within the Node (becomes the \
+     `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` \
+     flow-def tag in the transport file). Unique across Senders on the \
+     Node; a Receiver on the same Node may share the same name (the \
+     daemon scopes names by side). Overrides the transport file's value \
+     when both are supplied.";
+
+pub(crate) const RECEIVER_NAME_BLURB: &str =
+    "Name for this Receiver within the Node (becomes the \
+     `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` \
+     flow-def tag in the transport file). Unique across Receivers on the \
+     Node; a Sender on the same Node may share the same name (the \
+     daemon scopes names by side). Overrides the transport file's value \
+     when both are supplied.";
+
+pub(crate) const LABEL_BLURB_SENDER: &str =
+    "NMOS label for the Sender. Optional. Overrides the transport \
+     file when both are supplied (top-level `label` in an MXL \
+     `flow_def`; SDP `s=` line for RTP/UDP).";
+
+pub(crate) const LABEL_BLURB_RECEIVER: &str =
+    "NMOS label for the Receiver. Optional. Overrides the transport \
+     file when both are supplied (top-level `label` in an MXL \
+     `flow_def`; SDP `s=` line for RTP/UDP).";
+
+pub(crate) const DESCRIPTION_BLURB_SENDER: &str =
+    "NMOS description for the Sender. Optional. Overrides the \
+     transport file when both are supplied (top-level `description` \
+     in an MXL `flow_def`; SDP `i=` line for RTP/UDP).";
+
+pub(crate) const DESCRIPTION_BLURB_RECEIVER: &str =
+    "NMOS description for the Receiver. Optional. Overrides the \
+     transport file when both are supplied (top-level `description` \
+     in an MXL `flow_def`; SDP `i=` line for RTP/UDP).";
 
 pub(crate) const TRANSPORT_FILE_PATH_BLURB: &str =
     "Filesystem path read at NULL\u{2192}READY into `transport-file`. \
      Convenience for gst-launch; mutually exclusive with \
      `transport-file`.";
+
+pub(crate) const TRANSPORT_FILE_BLURB_SENDER: &str =
+    "Literal contents of the NvNmos transport file: MXL `flow_def` JSON \
+     for `transport=mxl`, SDP text for `transport=udp` / `udp2` / \
+     `nvdsudp`. The daemon adds the Sender via AddSender and \
+     re-publishes the transport file on IS-05 activation. Pass the \
+     text, not a path. Convenient for programmatic callers; from \
+     gst-launch use `transport-file-path` instead. Mutually exclusive \
+     with `transport-file-path`. When unset and `caps` is supplied the \
+     element synthesises a configuring transport file from the essence \
+     caps (MXL `flow_def` or SDP, depending on `transport`).";
+
+pub(crate) const TRANSPORT_FILE_BLURB_RECEIVER: &str =
+    "Literal contents of the NvNmos transport file: MXL `flow_def` JSON \
+     for `transport=mxl`, SDP text for `transport=udp` / `udp2` / \
+     `nvdsudp`. The daemon adds the Receiver via AddReceiver and \
+     re-publishes the transport file on IS-05 activation. Pass the \
+     text, not a path. Convenient for programmatic callers; from \
+     gst-launch use `transport-file-path` instead. Mutually exclusive \
+     with `transport-file-path`. Required unless `caps` is provided.";
+
+pub(crate) const CAPS_BLURB_SENDER: &str =
+    "Essence caps for this Sender. Synthesises the configuring transport \
+     file when `transport-file*` is unset (MXL `flow_def` or SDP depending \
+     on `transport`). On `transport=mxl`, requires `mxl-flow-id`; supported \
+     shapes: v210 video, F32LE audio, `meta/x-st-2038` data. On RTP \
+     transports, requires the relevant IS-05 endpoint properties. When \
+     `transport-file*` is also set, the file wins and `caps` are \
+     cross-checked against it — mismatch is a hard error.";
+
+pub(crate) const CAPS_BLURB_RECEIVER: &str =
+    "Essence caps for this Receiver. Required when `transport-file*` is \
+     unset; synthesises the configuring transport file (MXL `flow_def` or \
+     SDP depending on `transport`). On `transport=mxl`, requires \
+     `mxl-flow-id` (media-type structure name picks the matching `mxlsrc` \
+     flow-id slot); supported shapes: v210 video, F32LE audio, \
+     `meta/x-st-2038` data. On RTP transports, requires the relevant IS-05 \
+     endpoint properties. When `transport-file*` is also set, the file wins \
+     and `caps` are cross-checked against it — mismatch is a hard error.";
 
 pub(crate) const TRANSPORT_CAPS_BLURB: &str =
     "Per-transport overrides (SDP fmtp-style). Typically empty for MXL.";
@@ -165,7 +238,7 @@ pub(crate) const AUTO_ACTIVATE_BLURB: &str =
      NULL\u{2192}READY (or READY\u{2192}PAUSED for deferred senders), and call \
      `SyncResourceState` so IS-04/IS-05 show active without an IS-05 PATCH. \
      Does not force PLAYING — child state still follows the bin. Default \
-     `false`: register on IS-04 but keep the fake chain until an external \
+     `false`: add via AddSender / AddReceiver (visible on IS-04) but keep the fake chain until an external \
      IS-05 controller activates the resource.";
 
 /// Snapshot of the properties needed to open a session, taken under
@@ -212,32 +285,35 @@ pub(crate) struct CommonSettings {
     /// against the transport file's top-level `id` when both are
     /// supplied; either source alone is enough.
     pub(crate) mxl_flow_id: String,
-    /// Literal transport file contents (MXL `flow_def` JSON today).
-    /// Convenient for programmatic callers (e.g. Rust/C apps that
-    /// compute the flow_def in memory) but awkward to pass from
-    /// `gst-launch-1.0` because the JSON contains newlines and
-    /// quotes — those callers use `transport_file_path` instead.
+    /// Literal transport file contents: MXL `flow_def` JSON or SDP
+    /// text, depending on `transport`. Convenient for programmatic
+    /// callers; `gst-launch` users typically pass `transport_file_path`
+    /// instead because multi-line JSON / SDP is awkward on the command
+    /// line.
     pub(crate) transport_file: String,
     /// Filesystem path that's read into `transport_file` at
     /// NULL→READY. Mutually exclusive with `transport_file`.
     pub(crate) transport_file_path: String,
-    /// NMOS `label` for the synthesised flow_def. Optional: the
-    /// builder falls back to the flow id when this is empty.
+    /// NMOS `label` spliced into the configuring transport file (MXL
+    /// top-level `label`; SDP `s=`). Optional; overrides a supplied
+    /// file when non-empty. When synthesising from `caps` only, defaults
+    /// to the resource name on MXL and `"nvnmos"` on SDP.
     pub(crate) label: String,
-    /// NMOS `description` for the synthesised flow_def. Optional;
-    /// omitted from the JSON when empty.
+    /// NMOS `description` spliced into the configuring transport file
+    /// (MXL top-level `description`; SDP `i=`). Optional; omitted
+    /// when empty.
     pub(crate) description: String,
     /// Essence caps. On `nmossink`, when no `transport_file*` is
-    /// supplied, the element synthesises a flow_def JSON from these
-    /// caps plus the resolved property state
-    /// (see [`crate::flow_def::from_caps`]). On `nmossrc`,
-    /// the media-type structure name decides which `mxlsrc` flow-id
-    /// slot receives `mxl-flow-id` and the caps are pinned on the
-    /// ghost source pad so downstream caps queries see the concrete
-    /// shape the flow will carry. When `transport_file*` is supplied
-    /// the file is authoritative; for `nmossink` the caps are
-    /// ignored; for `nmossrc` the caps-derived format is
-    /// cross-checked against the file's `format` field.
+    /// supplied, synthesises a configuring transport file (MXL
+    /// `flow_def` via [`crate::flow_def::from_caps`], SDP via
+    /// [`crate::sdp::from_caps`]). On `nmossrc`, the
+    /// media-type structure name decides which `mxlsrc` flow-id slot
+    /// receives `mxl-flow-id` and the caps are pinned on the ghost
+    /// source pad so downstream caps queries see the concrete shape
+    /// the flow will carry. When `transport_file*` is supplied the
+    /// file is authoritative; for `nmossink` the caps are ignored;
+    /// for `nmossrc` the caps-derived format is cross-checked against
+    /// the file's essence fields.
     pub(crate) caps: Option<gst::Caps>,
     /// Per-transport overrides (`application/x-rtp,…` shape for the
     /// RTP transports; typically empty / unused for `mxl`). Carries
@@ -346,14 +422,14 @@ pub(crate) struct CommonSettings {
     /// match via `SyncResourceState`.
     ///
     /// `false` (default) gives canonical NMOS behaviour: the
-    /// element registers the resource (so it appears on IS-04) but
+    /// element adds the Sender or Receiver to the daemon (so it appears on IS-04) but
     /// leaves the data path on the fake chain until an IS-05 PATCH
     /// against `/single/{senders,receivers}/{id}/staged` activates
     /// it. `true` is the "no-controller" shortcut for development
     /// and for pipelines whose flow identity is entirely property /
     /// transport-file driven.
     ///
-    /// The toggle is orthogonal to how the configuring flow_def
+    /// The toggle is orthogonal to how the configuring transport file
     /// itself was obtained (property override of `mxl-flow-id`,
     /// supplied `transport-file*`, or caps→flow_def synthesis): as
     /// long as one of those routes produces a usable flow_def at
@@ -400,7 +476,7 @@ impl Default for CommonSettings {
 /// Outcome of resolving `transport_file` / `transport_file_path`.
 /// `Some(text)` means a non-empty literal was supplied (directly or
 /// loaded from the path); `None` means neither was set and no
-/// resource will be registered.
+/// resource will be added.
 fn resolve_transport_file(
     element: &str,
     settings: &CommonSettings,
@@ -438,7 +514,7 @@ fn resolve_transport_file(
 /// dormant IS-05 state) live in [`InnerConfig::Fake::detail`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FakeKind {
-    /// Not enough state to register or build a real chain yet (e.g.
+    /// Not enough state to add a resource or build a real chain yet (e.g.
     /// MXL sender awaiting peer caps for deferred `AddSender`).
     NotConfigured,
     /// Invalid or inconsistent configuration — cannot honour activation.
@@ -571,13 +647,12 @@ mod mxl;
 pub(crate) mod udp;
 
 pub(crate) use udp::UdpVariant;
-pub(crate) use mxl::decide_inner_config_mxl;
 pub(crate) use udp::{
     decide_inner_config_nvdsudp, decide_inner_config_udp, udp_essence_cross_check_mode,
 };
 
-use mxl::{resolve_activation_inner_mxl, resolve_inner_config_mxl};
-use udp::{register_deferred_rtp, resolve_inner_config_nvdsudp, resolve_inner_config_udp};
+use mxl::{resolve_activation_inner_mxl, resolve_inner_config_mxl, synthesise_deferred_sender_mxl};
+use udp::{resolve_inner_config_nvdsudp, resolve_inner_config_udp, synthesise_deferred_sender_udp};
 
 fn udp_inner_summary(
     family: &str,
@@ -684,8 +759,8 @@ pub(crate) fn validate_and_open(
         .with_context(|| format!("{element}: OpenSession against {}", settings.daemon_uri))?;
 
     let resource_summary = match new_session.resource_id() {
-        Some((handle, id)) => format!("resource registered: resource_handle={handle} resource_id={id}"),
-        None => "no resource registered (transport-file unset)".to_owned(),
+        Some((handle, id)) => format!("resource added: resource_handle={handle} resource_id={id}"),
+        None => "no resource added (transport-file unset)".to_owned(),
     };
     // For MXL, `mxl-domain-id` is already logged at resolution time
     // by `resolve_inner_config_mxl`; for UDP there's no equivalent
@@ -740,7 +815,7 @@ pub(super) fn caps_format(settings: &CommonSettings) -> FlowFormat {
 /// [`InnerConfig::Fake`] so the data path stays inactive until an
 /// IS-05 PATCH activates the resource (the canonical NMOS path).
 ///
-/// The resource registration itself isn't affected — that's driven
+/// The AddSender / AddReceiver itself isn't affected — that's driven
 /// by whether a configuring transport file is in play, not by the
 /// gate — so a resource opened with `auto-activate=false` still
 /// appears on IS-04 immediately, ready to be PATCHed.
@@ -754,21 +829,21 @@ fn apply_auto_activate_gate(inner: InnerConfig, auto_activate: bool) -> InnerCon
     inner
 }
 
-/// Fixate upstream peer caps for deferred sender registration.
+/// Fixate upstream peer caps for deferred AddSender.
 fn prepare_deferred_peer_caps(
     element: &str,
     peer_caps: gst::Caps,
 ) -> Result<gst::Caps, anyhow::Error> {
     if peer_caps.is_empty() {
         bail!(
-            "{element}: deferred registration: upstream peer offered no caps. \
+            "{element}: deferred AddSender: upstream peer offered no caps. \
              Declare `caps=\"…\"` on the element or insert a `capsfilter` \
-             upstream so the element knows what transport file to register."
+             upstream so the element knows what transport file to add."
         );
     }
     if peer_caps.is_any() {
         bail!(
-            "{element}: deferred registration: upstream peer offered ANY caps \
+            "{element}: deferred AddSender: upstream peer offered ANY caps \
              (likely no negotiated caps yet — e.g. `fakesrc` with no upstream \
              capsfilter). Declare `caps=\"…\"` on the element or insert a \
              `capsfilter` upstream so the element knows what transport file to \
@@ -789,7 +864,7 @@ fn prepare_deferred_peer_caps(
 /// MXL senders synthesise a `flow_def` JSON; RTP senders (`udp` /
 /// `udp2` / `nvdsudp`) synthesise SDP. `peer_caps` is what
 /// `gst_pad_peer_query_caps()` returned, before fixation.
-pub(crate) fn register_deferred(
+pub(crate) fn add_deferred_sender(
     cat: &gst::DebugCategory,
     element: &str,
     settings: &CommonSettings,
@@ -797,7 +872,7 @@ pub(crate) fn register_deferred(
     peer_caps: gst::Caps,
 ) -> Result<InnerConfig, anyhow::Error> {
     if settings.side != Side::Sender {
-        bail!("{element}: deferred registration is sender-only");
+        bail!("{element}: deferred AddSender is sender-only");
     }
 
     let fixated = prepare_deferred_peer_caps(element, peer_caps)?;
@@ -806,62 +881,21 @@ pub(crate) fn register_deferred(
         "{element}: deferred mode: peer caps fixated to `{fixated}`",
     );
 
-    match settings.transport {
-        Transport::Mxl => register_deferred_mxl(cat, element, settings, session, &fixated),
+    let (transport_file, inner) = match settings.transport {
+        Transport::Mxl => synthesise_deferred_sender_mxl(element, settings, &fixated)?,
         Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => {
-            register_deferred_rtp(cat, element, settings, session, &fixated)
+            synthesise_deferred_sender_udp(element, settings, &fixated)?
         }
-    }
-}
-
-fn register_deferred_mxl(
-    cat: &gst::DebugCategory,
-    element: &str,
-    settings: &CommonSettings,
-    session: &Mutex<Option<Session>>,
-    fixated: &gst::Caps,
-) -> Result<InnerConfig, anyhow::Error> {
-    let domain_resolution =
-        domain::resolve_mxl_domain_id(&settings.mxl_domain_id, &settings.mxl_domain_path)
-            .with_context(|| {
-                format!("{element}: resolving MXL Domain identity for deferred registration")
-            })?;
-    if domain_resolution.id.is_empty() {
-        bail!(
-            "{element}: deferred registration: `mxl-domain-id` is required \
-             (set the property directly or supply an `mxl-domain-path` whose \
-             `domain_def.json` provides the id)"
-        );
-    }
-
-    let json = flow_def::from_caps(&FlowDefBuildInput {
-        flow_id: &settings.mxl_flow_id,
-        name: &settings.name,
-        mxl_domain_id: &domain_resolution.id,
-        label: &settings.label,
-        description: &settings.description,
-        caps: fixated,
-    })
-    .with_context(|| format!("{element}: synthesising flow_def from peer caps"))?;
-    gst::info!(cat, "{element}: deferred mode: synthesised flow_def");
-
-    let flow = flow_def::resolve_mxl_flow_meta(
-        &settings.mxl_flow_id,
-        FlowFormat::from_caps(fixated),
-        Some(&json),
-    )
-    .with_context(|| {
-        format!("{element}: resolving MXL flow id / format for deferred registration")
-    })?;
-    let inner = apply_auto_activate_gate(
-        decide_inner_config_mxl(settings, &flow, Some(&json)),
-        settings.auto_activate,
+    };
+    gst::info!(
+        cat,
+        "{element}: deferred mode: synthesised configuring transport file",
     );
-    finish_deferred_add_sender(cat, element, session, inner, &json, settings)
+    finish_deferred_add_sender(cat, element, session, inner, &transport_file, settings)
 }
 
 /// Call `AddSender` after deferred synthesis. Shared by MXL and RTP paths.
-pub(super) fn finish_deferred_add_sender(
+fn finish_deferred_add_sender(
     cat: &gst::DebugCategory,
     element: &str,
     session: &Mutex<Option<Session>>,
@@ -878,7 +912,7 @@ pub(super) fn finish_deferred_add_sender(
     // has a session to close whether AddSender succeeded or failed.
     let mut taken = session.lock().unwrap().take().ok_or_else(|| {
         anyhow::anyhow!(
-            "{element}: deferred registration but no open session — was NULL→READY skipped?"
+            "{element}: deferred AddSender but no open session — was NULL→READY skipped?"
         )
     })?;
     let rpc_result = SHARED_RUNTIME.block_on(async {
@@ -887,8 +921,8 @@ pub(super) fn finish_deferred_add_sender(
             taken.add_resource(side, &name, transport, transport_file),
         )
         .await
-        .with_context(|| format!("{element}: AddSender for deferred registration timed out"))?
-        .with_context(|| format!("{element}: AddSender for deferred registration"))
+        .with_context(|| format!("{element}: AddSender (deferred) timed out"))?
+        .with_context(|| format!("{element}: AddSender (deferred)"))
     });
     let summary = taken
         .resource_id()
@@ -899,17 +933,17 @@ pub(super) fn finish_deferred_add_sender(
 
     gst::info!(
         cat,
-        "{element}: deferred registration complete: {summary}; inner data path: {:?}",
+        "{element}: deferred AddSender complete: {summary}; inner data path: {:?}",
         inner,
     );
     Ok(inner)
 }
 
-/// Tell the daemon to sync its IS-04/IS-05 view of the registered
+/// Tell the daemon to sync its IS-04/IS-05 view of the added
 /// resource to "active" (`master_enable: true`) with `transport_file`
 /// as the live configuration. Used by the `auto-activate=true` path
-/// after the element has already swapped its inner `mxlsink` /
-/// `mxlsrc` directly from the resolved configuring flow_def.
+/// after the element has already swapped its inner transport src/sink
+/// directly from the resolved configuring transport file.
 ///
 /// Pass `None` for `transport_file` to sync to "inactive" (the
 /// reverse direction, for symmetry — currently unused; the element
@@ -922,7 +956,7 @@ pub(super) fn finish_deferred_add_sender(
 /// `mxlsrc` without `AddSender` / `AddReceiver` having succeeded
 /// first; in practice unreachable since `decide_inner_config` plus
 /// the `auto-activate` gate only let that happen after a successful
-/// registration). Other RPC failures are returned so the caller can
+/// AddSender / AddReceiver). Other RPC failures are returned so the caller can
 /// log them without forcing the inner swap itself to roll back.
 pub(crate) fn sync_active(
     cat: &gst::DebugCategory,
@@ -1428,13 +1462,13 @@ mod tests {
             )
             .expect("synthesis must succeed")
             .expect("caps + flow id must synthesise");
-            let flow = flow_def::resolve_mxl_flow_meta(
+            let flow = crate::flow_def::resolve_mxl_flow_meta(
                 &s.mxl_flow_id,
                 FlowFormat::Video,
                 Some(&synth),
             )
             .expect("resolve_mxl_flow_meta");
-            let inner = crate::session::decide_inner_config_mxl(&s, &flow, Some(&synth));
+            let inner = mxl::decide_inner_config_mxl(&s, &flow, Some(&synth));
             assert!(
                 matches!(inner, InnerConfig::Real(_)),
                 "fixture must produce Real before the gate"

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -415,7 +415,7 @@ pub(crate) struct CommonSettings {
     /// Ignored on the Sender side (senders use `destination_ip`
     /// for the egress destination on synthesis).
     pub(crate) multicast_ip: String,
-    /// Whether the element brings its inner `mxlsink` / `mxlsrc` up
+    /// Whether the element brings its inner transport src/sink up
     /// immediately at NULL→READY (or, for a deferred-mode sender,
     /// READY→PAUSED) once the configuring transport file has been
     /// resolved, and synchronises the daemon's IS-04/IS-05 state to
@@ -431,11 +431,12 @@ pub(crate) struct CommonSettings {
     ///
     /// The toggle is orthogonal to how the configuring transport file
     /// itself was obtained (property override of `mxl-flow-id`,
-    /// supplied `transport-file*`, or caps→flow_def synthesis): as
-    /// long as one of those routes produces a usable flow_def at
-    /// NULL→READY (or READY→PAUSED for a deferred sender),
-    /// `auto-activate=true` brings the inner up and informs the
-    /// daemon; `auto-activate=false` leaves it for the controller.
+    /// supplied `transport-file*`, or caps→transport-file synthesis):
+    /// as long as one of those routes produces a usable configuring
+    /// transport file (MXL `flow_def` or SDP) at NULL→READY (or
+    /// READY→PAUSED for a deferred sender), `auto-activate=true`
+    /// brings the inner up and informs the daemon;
+    /// `auto-activate=false` leaves it for the controller.
     pub(crate) auto_activate: bool,
 }
 
@@ -519,7 +520,7 @@ pub(crate) enum FakeKind {
     NotConfigured,
     /// Invalid or inconsistent configuration — cannot honour activation.
     Misconfigured,
-    /// Registered and valid, but no live RTP/media path (initial
+    /// Created and valid, but no live RTP/media path (initial
     /// `auto-activate=false`, deactivated, or all SDP legs inactive).
     NotActive,
 }
@@ -546,15 +547,16 @@ impl FakeKind {
 /// `validate_and_open`.
 ///
 /// [`InnerConfig::Real`] carries everything the element needs to
-/// instantiate a real transport chain (today only MXL, captured in
-/// [`TransportConfig::Mxl`]). [`InnerConfig::Fake`] means the
+/// instantiate a real transport chain ([`TransportConfig::Mxl`] or
+/// [`TransportConfig::Udp`]). [`InnerConfig::Fake`] means the
 /// resolved configuration didn't pin enough state to build a real
-/// chain (e.g. no Flow id, no Domain path) and the element keeps
-/// its fake data path in place (`fakesink` on the sink side, an
-/// `appsrc` configured with the resolved essence caps on the
-/// source side — see [`crate::inner`]). A later step
-/// (caps→flow_def, IS-05 activation) will supply the missing pieces
-/// and the bin will swap from fake to real.
+/// chain (e.g. missing MXL domain/flow id, or incomplete RTP
+/// SDP/endpoints) and the element keeps its fake data path in place
+/// (`fakesink` on the sink side, an `appsrc` configured with the
+/// resolved essence caps on the source side — see [`crate::inner`]).
+/// A later step (caps→transport-file synthesis or IS-05 activation)
+/// will supply the missing pieces and the bin will swap from fake to
+/// real.
 #[derive(Debug, Clone)]
 pub(crate) enum InnerConfig {
     Real(TransportConfig),
@@ -568,9 +570,8 @@ pub(crate) enum InnerConfig {
     },
 }
 
-/// Per-transport state needed to build a real chain. New transports
-/// (NVDS-UDP, ...) get their own variants alongside the two
-/// implemented today.
+/// Per-transport state needed to build a real chain: [`Mxl`] for
+/// MXL and [`Udp`] for RTP/UDP (`udp`, `udp2`, and `nvdsudp`).
 #[derive(Debug, Clone)]
 pub(crate) enum TransportConfig {
     Mxl {
@@ -591,9 +592,9 @@ pub(crate) enum TransportConfig {
         /// Receivers whose `mxl-flow-id` will arrive via IS-05 PATCH).
         transport_file: Option<String>,
     },
-    /// OSS UDP/RTP transport. The inner chain is
-    /// `rtp*pay ! udpsink` for senders and
-    /// `udpsrc ! rtp*depay [! capssetter(raw_caps)]` for receivers.
+    /// RTP/UDP transport. The inner chain is `rtp*pay ! udpsink` for
+    /// senders and `udpsrc ! rtp*depay [! capssetter(raw_caps)]` for
+    /// receivers.
     /// Wide receivers (activation SDP carries `a=x-nvnmos-caps:`)
     /// omit `capssetter`; narrow receivers pin configuring essence
     /// caps parsed from the transport file. The exact element factory
@@ -733,7 +734,7 @@ pub(crate) fn validate_and_open(
         }
     };
 
-    inner = apply_auto_activate_gate(inner, settings.auto_activate);
+    inner = apply_auto_activate_policy(cat, element, settings, inner);
 
     let transport = transport_to_proto(settings.transport);
     let side = settings.side;
@@ -809,16 +810,91 @@ pub(super) fn caps_format(settings: &CommonSettings) -> FlowFormat {
         .map(FlowFormat::from_caps)
         .unwrap_or(FlowFormat::Unspecified)
 }
-/// Honour `auto-activate` at setup time. When `auto_activate` is
-/// `false` and `decide_inner_config_mxl` / `decide_inner_config_udp`
-/// would have produced a real transport chain, downgrade to
+/// IS-05 transport parameters that may be omitted at AddSender /
+/// AddReceiver but are required to bring up the inner data path when
+/// `auto-activate=true`.
+pub(super) fn deferred_transport_params(settings: &CommonSettings) -> Vec<&'static str> {
+    match settings.transport {
+        Transport::Mxl => {
+            if settings.mxl_flow_id.is_empty() {
+                vec!["mxl-flow-id"]
+            } else {
+                vec![]
+            }
+        }
+        Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => match settings.side {
+            Side::Sender => {
+                let mut missing = Vec::new();
+                if settings.destination_ip.is_empty() {
+                    missing.push("destination-ip");
+                }
+                if settings.destination_port == 0 {
+                    missing.push("destination-port");
+                }
+                missing
+            }
+            Side::Receiver => {
+                let mut missing = Vec::new();
+                if settings.destination_port == 0 {
+                    missing.push("destination-port");
+                }
+                missing
+            }
+        },
+    }
+}
+
+/// Honour `auto-activate` at setup time and warn when eager activation
+/// was requested but deferred transport parameters are still unset.
+///
+/// When `auto_activate` is `false` and `decide_inner_config_*` would
+/// have produced a real transport chain, downgrade to
 /// [`InnerConfig::Fake`] so the data path stays inactive until an
 /// IS-05 PATCH activates the resource (the canonical NMOS path).
 ///
-/// The AddSender / AddReceiver itself isn't affected — that's driven
-/// by whether a configuring transport file is in play, not by the
-/// gate — so a resource opened with `auto-activate=false` still
-/// appears on IS-04 immediately, ready to be PATCHed.
+/// When `auto_activate` is `true` but wire/MXL flow parameters needed
+/// for the inner chain are still unset, log a warning and keep (or
+/// downgrade to) a fake chain — AddSender / AddReceiver still proceeds
+/// when a configuring transport file is available.
+pub(super) fn apply_auto_activate_policy(
+    cat: &gst::DebugCategory,
+    element: &str,
+    settings: &CommonSettings,
+    inner: InnerConfig,
+) -> InnerConfig {
+    let missing = deferred_transport_params(settings);
+
+    if settings.auto_activate && !missing.is_empty() {
+        gst::warning!(
+            cat,
+            "{element}: auto-activate=true ignored — missing transport properties: {}",
+            missing.join(", "),
+        );
+        if matches!(inner, InnerConfig::Real(_)) {
+            return InnerConfig::Fake {
+                kind: FakeKind::NotActive,
+                detail: format!(
+                    "auto-activate=true but {} unset; waiting for IS-05 PATCH",
+                    missing.join(", "),
+                ),
+            };
+        }
+        return inner;
+    }
+
+    if !settings.auto_activate && matches!(inner, InnerConfig::Real(_)) {
+        return InnerConfig::Fake {
+            kind: FakeKind::NotActive,
+            detail: "auto-activate=false; waiting for IS-05 PATCH to activate".into(),
+        };
+    }
+
+    inner
+}
+
+/// Honour `auto-activate=false` for a fully-resolved inner chain.
+/// Used by unit tests that already supply complete transport state.
+#[cfg(test)]
 fn apply_auto_activate_gate(inner: InnerConfig, auto_activate: bool) -> InnerConfig {
     if !auto_activate && matches!(inner, InnerConfig::Real(_)) {
         return InnerConfig::Fake {
@@ -847,7 +923,7 @@ fn prepare_deferred_peer_caps(
              (likely no negotiated caps yet — e.g. `fakesrc` with no upstream \
              capsfilter). Declare `caps=\"…\"` on the element or insert a \
              `capsfilter` upstream so the element knows what transport file to \
-             register."
+             add."
         );
     }
     let mut fixated = peer_caps;
@@ -855,7 +931,7 @@ fn prepare_deferred_peer_caps(
     Ok(fixated)
 }
 
-/// Register a Sender via the deferred-mode path: synthesise a
+/// Add a Sender via the deferred-mode path: synthesise a
 /// configuring transport file from upstream peer caps and call
 /// `AddSender` against a session that was opened without one. Used by
 /// `nmossink` from inside `change_state(ReadyToPaused)` when neither
@@ -1490,6 +1566,132 @@ mod tests {
                     panic!("auto-activate=false: caps-synthesised flow_id must defer to IS-05")
                 }
             }
+        }
+
+        #[test]
+        fn policy_downgrades_eager_mxl_without_flow_id() {
+            let s = CommonSettings {
+                mxl_flow_id: String::new(),
+                auto_activate: true,
+                ..settings(Side::Sender)
+            };
+            let inner = InnerConfig::Fake {
+                kind: FakeKind::NotActive,
+                detail: "configuring-only".into(),
+            };
+            let after = super::super::apply_auto_activate_policy(&cat(), "nmossink", &s, inner);
+            assert!(matches!(after, InnerConfig::Fake { .. }));
+        }
+
+        #[test]
+        fn policy_downgrades_eager_rtp_sender_without_destination() {
+            let s = CommonSettings {
+                transport: Transport::Udp,
+                side: Side::Sender,
+                auto_activate: true,
+                source_ip: "192.0.2.1".to_owned(),
+                destination_ip: String::new(),
+                destination_port: 0,
+                ..settings(Side::Sender)
+            };
+            let inner = InnerConfig::Real(TransportConfig::Mxl {
+                domain_path: "/var/lib/mxl/domain-a".to_owned(),
+                flow_id: FLOW_ID_A.to_owned(),
+                format: FlowFormat::Video,
+                transport_file: None,
+            });
+            let after = super::super::apply_auto_activate_policy(&cat(), "nmossink", &s, inner);
+            match after {
+                InnerConfig::Fake { kind, detail } => {
+                    assert_eq!(kind, FakeKind::NotActive);
+                    assert!(detail.contains("destination-ip"));
+                }
+                InnerConfig::Real(_) => panic!("must not eager-activate without destination-ip"),
+            }
+        }
+    }
+
+    mod configuring_minimum {
+        use super::*;
+
+        #[test]
+        fn deferred_transport_params_mxl_without_flow_id() {
+            let s = settings(Side::Receiver);
+            assert_eq!(
+                super::super::deferred_transport_params(&s),
+                vec!["mxl-flow-id"]
+            );
+        }
+
+        #[test]
+        fn deferred_transport_params_rtp_sender_wire_endpoints() {
+            let s = CommonSettings {
+                transport: Transport::Udp,
+                side: Side::Sender,
+                source_ip: "192.0.2.1".to_owned(),
+                ..settings(Side::Sender)
+            };
+            assert_eq!(
+                super::super::deferred_transport_params(&s),
+                vec!["destination-ip", "destination-port"]
+            );
+        }
+
+        #[test]
+        fn deferred_transport_params_rtp_receiver_unicast_omits_multicast_ip() {
+            let s = CommonSettings {
+                transport: Transport::Udp,
+                side: Side::Receiver,
+                interface_ip: "192.0.2.1".to_owned(),
+                ..settings(Side::Receiver)
+            };
+            assert_eq!(
+                super::super::deferred_transport_params(&s),
+                vec!["destination-port"]
+            );
+        }
+
+        #[test]
+        fn deferred_transport_params_rtp_receiver_multicast_with_port_is_complete() {
+            let s = CommonSettings {
+                transport: Transport::Udp,
+                side: Side::Receiver,
+                interface_ip: "192.0.2.1".to_owned(),
+                multicast_ip: "239.1.1.1".to_owned(),
+                destination_port: 5004,
+                ..settings(Side::Receiver)
+            };
+            assert!(super::super::deferred_transport_params(&s).is_empty());
+        }
+
+        #[test]
+        fn rtp_sender_caps_synthesis_requires_source_ip() {
+            let s = CommonSettings {
+                transport: Transport::Udp,
+                side: Side::Sender,
+                caps: Some(video_caps()),
+                ..settings(Side::Sender)
+            };
+            let err = super::udp::validate_rtp_configuring_minimum("nmossink", &s).unwrap_err();
+            assert!(
+                err.to_string().contains("source-ip"),
+                "expected source-ip requirement: {err:#}"
+            );
+        }
+
+        #[test]
+        fn rtp_receiver_caps_synthesis_requires_interface_ip() {
+            let s = CommonSettings {
+                transport: Transport::Udp,
+                side: Side::Receiver,
+                caps: Some(video_caps()),
+                ..settings(Side::Receiver)
+            };
+            let err = super::udp::validate_rtp_configuring_minimum("nmossrc", &s).unwrap_err();
+            assert!(
+                err.to_string().contains("interface-ip"),
+                "expected interface-ip requirement: {err:#}"
+            );
         }
     }
 }

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -324,16 +324,20 @@ pub(crate) struct CommonSettings {
     /// [`crate::iface::iface_name_for_ip`] and threaded into
     /// `udpsrc.multicast-iface`). Also emitted in the configuring
     /// SDP as the `a=x-nvnmos-iface-ip:` attribute. Empty string =
-    /// unset. Ignored on the Sender side (senders use `source_ip`
-    /// for the same wire concept).
+    /// unset. When `multicast_ip` is also unset,
+    /// [`receiver_connection_address`](udp::receiver_connection_address)
+    /// uses this for the SDP `c=` line on synthesis and passthrough
+    /// — see that helper's doc for the multicast-file caveat. Ignored
+    /// on the Sender side (senders use `source_ip` for the origin /
+    /// connection slots on synthesis).
     pub(crate) interface_ip: String,
     /// IS-05 RTP receiver transport_params `multicast_ip` —
     /// Receiver-only. Multicast group to join (or empty for
-    /// unicast reception). Becomes the `c=` line address in the
-    /// configuring SDP and the `udpsrc.address` property. Empty
-    /// string = unset (unicast / let the SDP / daemon resolve).
+    /// unicast reception). Takes precedence over `interface_ip` for
+    /// the `c=` line when set. Empty string = unset (unicast / let
+    /// the SDP / daemon resolve).
     /// Ignored on the Sender side (senders use `destination_ip`
-    /// for the same wire concept).
+    /// for the egress destination on synthesis).
     pub(crate) multicast_ip: String,
     /// Whether the element brings its inner `mxlsink` / `mxlsrc` up
     /// immediately at NULL→READY (or, for a deferred-mode sender,
@@ -573,7 +577,7 @@ pub(crate) use udp::{
 };
 
 use mxl::{resolve_activation_inner_mxl, resolve_inner_config_mxl};
-use udp::{resolve_inner_config_nvdsudp, resolve_inner_config_udp};
+use udp::{register_deferred_rtp, resolve_inner_config_nvdsudp, resolve_inner_config_udp};
 
 fn udp_inner_summary(
     family: &str,
@@ -750,49 +754,16 @@ fn apply_auto_activate_gate(inner: InnerConfig, auto_activate: bool) -> InnerCon
     inner
 }
 
-/// Register a Sender via the deferred-mode path: synthesise a
-/// flow_def from upstream peer caps and call `AddSender` against a
-/// session that was opened without one. Used by `nmossink` from
-/// inside `change_state(ReadyToPaused)` when neither `transport-file*`
-/// nor `caps` was set at NULL→READY.
-///
-/// `peer_caps` is what `gst_pad_peer_query_caps()` returned, before
-/// fixation. The helper fixates internally and rejects ANY / EMPTY
-/// caps with a clear, user-facing error message telling them to
-/// declare `caps=…` or insert a `capsfilter` upstream — that's the
-/// same recipe the plan doc spells out for pipelines where the peer
-/// query can't fix caps (h264parse pre-data, etc.).
-///
-/// Returns the [`InnerConfig`] the element should install on the
-/// data path; today always [`InnerConfig::Real`] on success because
-/// deferred-mode registration is only attempted when `mxl-domain-path`
-/// is set (the fake chain is the alternative the caller picks when
-/// this helper isn't called).
-pub(crate) fn register_deferred(
-    cat: &gst::DebugCategory,
+/// Fixate upstream peer caps for deferred sender registration.
+fn prepare_deferred_peer_caps(
     element: &str,
-    settings: &CommonSettings,
-    session: &Mutex<Option<Session>>,
     peer_caps: gst::Caps,
-) -> Result<InnerConfig, anyhow::Error> {
-    if settings.transport != Transport::Mxl {
-        bail!(
-            "{element}: deferred registration unsupported for transport `{:?}`",
-            settings.transport
-        );
-    }
-    if settings.side != Side::Sender {
-        // Receiver deferred mode is explicitly out of scope (plan doc:
-        // “`nmossrc` cannot use deferred mode — there is no peer to
-        // query.”). Reject so we don't accidentally try.
-        bail!("{element}: deferred registration is sender-only");
-    }
-
+) -> Result<gst::Caps, anyhow::Error> {
     if peer_caps.is_empty() {
         bail!(
             "{element}: deferred registration: upstream peer offered no caps. \
              Declare `caps=\"…\"` on the element or insert a `capsfilter` \
-             upstream so the element knows what flow_def to register."
+             upstream so the element knows what transport file to register."
         );
     }
     if peer_caps.is_any() {
@@ -800,21 +771,56 @@ pub(crate) fn register_deferred(
             "{element}: deferred registration: upstream peer offered ANY caps \
              (likely no negotiated caps yet — e.g. `fakesrc` with no upstream \
              capsfilter). Declare `caps=\"…\"` on the element or insert a \
-             `capsfilter` upstream so the element knows what flow_def to register."
+             `capsfilter` upstream so the element knows what transport file to \
+             register."
         );
     }
-
-    // Fixate the (possibly under-constrained) peer caps into a single,
-    // concrete shape — the same operation any sink performs to decide
-    // its negotiated caps. The fixated caps drive the flow_def
-    // builder.
     let mut fixated = peer_caps;
     fixated.fixate();
+    Ok(fixated)
+}
+
+/// Register a Sender via the deferred-mode path: synthesise a
+/// configuring transport file from upstream peer caps and call
+/// `AddSender` against a session that was opened without one. Used by
+/// `nmossink` from inside `change_state(ReadyToPaused)` when neither
+/// `transport-file*` nor `caps` was set at NULL→READY.
+///
+/// MXL senders synthesise a `flow_def` JSON; RTP senders (`udp` /
+/// `udp2` / `nvdsudp`) synthesise SDP. `peer_caps` is what
+/// `gst_pad_peer_query_caps()` returned, before fixation.
+pub(crate) fn register_deferred(
+    cat: &gst::DebugCategory,
+    element: &str,
+    settings: &CommonSettings,
+    session: &Mutex<Option<Session>>,
+    peer_caps: gst::Caps,
+) -> Result<InnerConfig, anyhow::Error> {
+    if settings.side != Side::Sender {
+        bail!("{element}: deferred registration is sender-only");
+    }
+
+    let fixated = prepare_deferred_peer_caps(element, peer_caps)?;
     gst::info!(
         cat,
         "{element}: deferred mode: peer caps fixated to `{fixated}`",
     );
 
+    match settings.transport {
+        Transport::Mxl => register_deferred_mxl(cat, element, settings, session, &fixated),
+        Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => {
+            register_deferred_rtp(cat, element, settings, session, &fixated)
+        }
+    }
+}
+
+fn register_deferred_mxl(
+    cat: &gst::DebugCategory,
+    element: &str,
+    settings: &CommonSettings,
+    session: &Mutex<Option<Session>>,
+    fixated: &gst::Caps,
+) -> Result<InnerConfig, anyhow::Error> {
     let domain_resolution =
         domain::resolve_mxl_domain_id(&settings.mxl_domain_id, &settings.mxl_domain_path)
             .with_context(|| {
@@ -834,14 +840,14 @@ pub(crate) fn register_deferred(
         mxl_domain_id: &domain_resolution.id,
         label: &settings.label,
         description: &settings.description,
-        caps: &fixated,
+        caps: fixated,
     })
     .with_context(|| format!("{element}: synthesising flow_def from peer caps"))?;
     gst::info!(cat, "{element}: deferred mode: synthesised flow_def");
 
     let flow = flow_def::resolve_mxl_flow_meta(
         &settings.mxl_flow_id,
-        FlowFormat::from_caps(&fixated),
+        FlowFormat::from_caps(fixated),
         Some(&json),
     )
     .with_context(|| {
@@ -851,15 +857,25 @@ pub(crate) fn register_deferred(
         decide_inner_config_mxl(settings, &flow, Some(&json)),
         settings.auto_activate,
     );
+    finish_deferred_add_sender(cat, element, session, inner, &json, settings)
+}
 
+/// Call `AddSender` after deferred synthesis. Shared by MXL and RTP paths.
+pub(super) fn finish_deferred_add_sender(
+    cat: &gst::DebugCategory,
+    element: &str,
+    session: &Mutex<Option<Session>>,
+    inner: InnerConfig,
+    transport_file: &str,
+    settings: &CommonSettings,
+) -> Result<InnerConfig, anyhow::Error> {
     let transport = transport_to_proto(settings.transport);
     let side = settings.side;
     let name = settings.name.clone();
     // Take the Session out of the std::Mutex before doing async work
-    // (clippy's `await_holding_lock` lint, same pattern `close()` uses
-    // for the symmetrical CloseSession call). The session is put back
-    // afterwards whether AddSender succeeded or failed so READY→NULL
-    // still has something to close.
+    // (clippy's `await_holding_lock` lint, same pattern `close()` uses).
+    // Put it back before checking the RPC result so READY→NULL always
+    // has a session to close whether AddSender succeeded or failed.
     let mut taken = session.lock().unwrap().take().ok_or_else(|| {
         anyhow::anyhow!(
             "{element}: deferred registration but no open session — was NULL→READY skipped?"
@@ -868,7 +884,7 @@ pub(crate) fn register_deferred(
     let rpc_result = SHARED_RUNTIME.block_on(async {
         tokio::time::timeout(
             OPEN_TIMEOUT,
-            taken.add_resource(side, &name, transport, &json),
+            taken.add_resource(side, &name, transport, transport_file),
         )
         .await
         .with_context(|| format!("{element}: AddSender for deferred registration timed out"))?

--- a/rust/gst-nmos-rs/src/session/mxl.rs
+++ b/rust/gst-nmos-rs/src/session/mxl.rs
@@ -632,35 +632,6 @@ mod tests {
         }
 
         #[test]
-        fn unsupported_transport_is_error() {
-            // Deferred mode rejects non-`mxl` transports up-front,
-            // mirroring `validate_and_open`'s same check. This test
-            // covers the synchronous branch; the async sibling is
-            // covered by integration tests.
-            for t in [Transport::Udp, Transport::Udp2, Transport::NvDsUdp] {
-                let s = CommonSettings {
-                    transport: t,
-                    ..sender_settings()
-                };
-                let res = register_deferred(
-                    &cat(),
-                    "nmossink",
-                    &s,
-                    &no_session(),
-                    good_caps(),
-                );
-                let err = res.expect_err(
-                    "non-mxl transport must be rejected by deferred path",
-                );
-                let msg = format!("{err:#}");
-                assert!(
-                    msg.contains("deferred registration unsupported"),
-                    "expected deferred-transport rejection reason for {t:?}: {msg}",
-                );
-            }
-        }
-
-        #[test]
         fn missing_domain_id_is_error() {
             let s = CommonSettings {
                 mxl_domain_id: String::new(),

--- a/rust/gst-nmos-rs/src/session/mxl.rs
+++ b/rust/gst-nmos-rs/src/session/mxl.rs
@@ -60,6 +60,52 @@ pub(crate) fn synthesise_or_passthrough_mxl(
         (None, None) => Ok(None),
     }
 }
+
+/// Synthesise configuring flow_def JSON and resolve the inner chain for
+/// deferred MXL sender AddSender from fixated upstream peer caps.
+pub(super) fn synthesise_deferred_sender_mxl(
+    element: &str,
+    settings: &CommonSettings,
+    fixated: &gst::Caps,
+) -> Result<(String, InnerConfig), anyhow::Error> {
+    let domain_resolution =
+        domain::resolve_mxl_domain_id(&settings.mxl_domain_id, &settings.mxl_domain_path)
+            .with_context(|| {
+                format!("{element}: resolving MXL Domain identity for deferred AddSender")
+            })?;
+    if domain_resolution.id.is_empty() {
+        bail!(
+            "{element}: deferred AddSender: `mxl-domain-id` is required \
+             (set the property directly or supply an `mxl-domain-path` whose \
+             `domain_def.json` provides the id)"
+        );
+    }
+
+    let json = flow_def::from_caps(&FlowDefBuildInput {
+        flow_id: &settings.mxl_flow_id,
+        name: &settings.name,
+        mxl_domain_id: &domain_resolution.id,
+        label: &settings.label,
+        description: &settings.description,
+        caps: fixated,
+    })
+    .with_context(|| format!("{element}: synthesising flow_def from peer caps"))?;
+
+    let flow = flow_def::resolve_mxl_flow_meta(
+        &settings.mxl_flow_id,
+        FlowFormat::from_caps(fixated),
+        Some(&json),
+    )
+    .with_context(|| {
+        format!("{element}: resolving MXL flow id / format for deferred AddSender")
+    })?;
+    let inner = super::apply_auto_activate_gate(
+        decide_inner_config_mxl(settings, &flow, Some(&json)),
+        settings.auto_activate,
+    );
+    Ok((json, inner))
+}
+
 pub(crate) fn property_overrides_mxl<'a>(
     settings: &'a CommonSettings,
     resolved_mxl_domain_id: &'a str,
@@ -184,11 +230,11 @@ pub(super) fn resolve_inner_config_mxl(
 
     let mut inner = decide_inner_config_mxl(settings, &flow, transport_file.as_deref());
     // Deferred-mode case (sender only): no resource is going to be
-    // registered at NULL→READY because neither `transport-file*` nor
+    // added at NULL→READY because neither `transport-file*` nor
     // `caps` was supplied. Keep the fake chain so we don't bring
-    // `mxlsink` up against an unregistered Flow (which would fail to
+    // `mxlsink` up against an un-added Flow (which would fail to
     // preroll); the inner is swapped to `mxlsink` only after
-    // `register_deferred` registers the Sender at READY→PAUSED.
+    // `add_deferred_sender` calls AddSender at READY→PAUSED.
     if transport_file.is_none()
         && settings.side == Side::Sender
         && matches!(inner, InnerConfig::Real(_))
@@ -560,7 +606,7 @@ mod tests {
         assert!(matches!(plan.ack, ActivationAck::Failure { .. }));
     }
 
-    mod register_deferred {
+    mod add_deferred_sender {
         use super::*;
         use std::str::FromStr;
 
@@ -586,7 +632,7 @@ mod tests {
 
         #[test]
         fn empty_caps_is_error() {
-            let res = register_deferred(
+            let res = add_deferred_sender(
                 &cat(),
                 "nmossink",
                 &sender_settings(),
@@ -602,7 +648,7 @@ mod tests {
 
         #[test]
         fn any_caps_is_error() {
-            let res = register_deferred(
+            let res = add_deferred_sender(
                 &cat(),
                 "nmossink",
                 &sender_settings(),
@@ -623,7 +669,7 @@ mod tests {
                 side: Side::Receiver,
                 ..sender_settings()
             };
-            let res = register_deferred(&cat(), "nmossrc", &s, &no_session(), good_caps());
+            let res = add_deferred_sender(&cat(), "nmossrc", &s, &no_session(), good_caps());
             let err = res.expect_err("receiver deferred mode is out of scope");
             assert!(
                 format!("{err:#}").contains("sender-only"),
@@ -638,7 +684,7 @@ mod tests {
                 mxl_domain_path: String::new(),
                 ..sender_settings()
             };
-            let res = register_deferred(&cat(), "nmossink", &s, &no_session(), good_caps());
+            let res = add_deferred_sender(&cat(), "nmossink", &s, &no_session(), good_caps());
             let err = res.expect_err("missing mxl-domain-id must be rejected");
             assert!(
                 format!("{err:#}").contains("mxl-domain-id"),
@@ -652,7 +698,7 @@ mod tests {
                 mxl_flow_id: String::new(),
                 ..sender_settings()
             };
-            let res = register_deferred(&cat(), "nmossink", &s, &no_session(), good_caps());
+            let res = add_deferred_sender(&cat(), "nmossink", &s, &no_session(), good_caps());
             let err = res.expect_err("missing mxl-flow-id must be rejected");
             assert!(
                 format!("{err:#}").contains("flow_id") || format!("{err:#}").contains("flow-id"),
@@ -666,7 +712,7 @@ mod tests {
             // reject it, and the user is expected to add a capsfilter.
             let caps = gst::Caps::from_str("video/x-raw,format=I420,width=1920,height=1080")
                 .expect("static caps parse");
-            let res = register_deferred(&cat(), "nmossink", &sender_settings(), &no_session(), caps);
+            let res = add_deferred_sender(&cat(), "nmossink", &sender_settings(), &no_session(), caps);
             let err = res.expect_err("unsupported caps must be rejected");
             // exact message is owned by from_caps; we just want
             // the synthesis-context wrapper to be present.
@@ -680,7 +726,7 @@ mod tests {
         fn no_open_session_is_error() {
             // Caps are valid and validation passes; we should reach
             // the session-take step and surface a clear error.
-            let res = register_deferred(
+            let res = add_deferred_sender(
                 &cat(),
                 "nmossink",
                 &sender_settings(),

--- a/rust/gst-nmos-rs/src/session/mxl.rs
+++ b/rust/gst-nmos-rs/src/session/mxl.rs
@@ -32,15 +32,6 @@ pub(crate) fn synthesise_or_passthrough_mxl(
         }
         (Some(text), None) => Ok(Some(text)),
         (None, Some(caps)) => {
-            if settings.mxl_flow_id.is_empty() {
-                gst::debug!(
-                    cat,
-                    "{element}: `caps` set but `mxl-flow-id` empty; deferring flow_def \
-                     synthesis (the fake chain will be in use until an IS-05 \
-                     activation supplies the flow id)"
-                );
-                return Ok(None);
-            }
             let json = flow_def::from_caps(&FlowDefBuildInput {
                 flow_id: &settings.mxl_flow_id,
                 name: &settings.name,
@@ -50,11 +41,21 @@ pub(crate) fn synthesise_or_passthrough_mxl(
                 caps,
             })
             .with_context(|| format!("{element}: synthesising flow_def from caps"))?;
-            gst::info!(
-                cat,
-                "{element}: synthesised flow_def from `caps` (side={:?})",
-                settings.side,
-            );
+            if settings.mxl_flow_id.is_empty() {
+                gst::debug!(
+                    cat,
+                    "{element}: synthesised flow_def from `caps` without \
+                     top-level `id` (libnvnmos resolves the MXL flow id at activation; \
+                     side={:?})",
+                    settings.side,
+                );
+            } else {
+                gst::info!(
+                    cat,
+                    "{element}: synthesised flow_def from `caps` (side={:?})",
+                    settings.side,
+                );
+            }
             Ok(Some(json))
         }
         (None, None) => Ok(None),
@@ -99,9 +100,11 @@ pub(super) fn synthesise_deferred_sender_mxl(
     .with_context(|| {
         format!("{element}: resolving MXL flow id / format for deferred AddSender")
     })?;
-    let inner = super::apply_auto_activate_gate(
+    let inner = super::apply_auto_activate_policy(
+        &crate::CAT,
+        element,
+        settings,
         decide_inner_config_mxl(settings, &flow, Some(&json)),
-        settings.auto_activate,
     );
     Ok((json, inner))
 }
@@ -143,6 +146,13 @@ pub(crate) fn decide_inner_config_mxl(
         };
     }
     if flow.id.is_empty() {
+        if transport_file.is_some() {
+            return InnerConfig::Fake {
+                kind: FakeKind::NotActive,
+                detail: "`mxl-flow-id` unset; waiting for IS-05 activation to supply the MXL flow id"
+                    .into(),
+            };
+        }
         return InnerConfig::Fake {
             kind: FakeKind::Misconfigured,
             detail: "`mxl-flow-id` unset (neither property nor transport file supplied it)".into(),
@@ -228,22 +238,29 @@ pub(super) fn resolve_inner_config_mxl(
     log_flow_origin(cat, "mxl-flow-id", flow.id_origin);
     log_flow_origin(cat, "caps format", flow.format_origin);
 
-    let mut inner = decide_inner_config_mxl(settings, &flow, transport_file.as_deref());
+    let inner = super::apply_auto_activate_policy(
+        cat,
+        element,
+        settings,
+        decide_inner_config_mxl(settings, &flow, transport_file.as_deref()),
+    );
     // Deferred-mode case (sender only): no resource is going to be
     // added at NULL→READY because neither `transport-file*` nor
     // `caps` was supplied. Keep the fake chain so we don't bring
     // `mxlsink` up against an un-added Flow (which would fail to
     // preroll); the inner is swapped to `mxlsink` only after
     // `add_deferred_sender` calls AddSender at READY→PAUSED.
-    if transport_file.is_none()
+    let inner = if transport_file.is_none()
         && settings.side == Side::Sender
         && matches!(inner, InnerConfig::Real(_))
     {
-        inner = InnerConfig::Fake {
+        InnerConfig::Fake {
             kind: FakeKind::NotConfigured,
             detail: String::new(),
-        };
-    }
+        }
+    } else {
+        inner
+    };
 
     Ok((inner, transport_file))
 }
@@ -693,17 +710,23 @@ mod tests {
         }
 
         #[test]
-        fn missing_flow_id_is_error_via_builder() {
+        fn missing_flow_id_still_synthesises_for_deferred_add_sender() {
             let s = CommonSettings {
                 mxl_flow_id: String::new(),
                 ..sender_settings()
             };
-            let res = add_deferred_sender(&cat(), "nmossink", &s, &no_session(), good_caps());
-            let err = res.expect_err("missing mxl-flow-id must be rejected");
-            assert!(
-                format!("{err:#}").contains("flow_id") || format!("{err:#}").contains("flow-id"),
-                "expected mxl-flow-id reason: {err:#}"
-            );
+            let caps = good_caps();
+            let json = flow_def::from_caps(&FlowDefBuildInput {
+                flow_id: &s.mxl_flow_id,
+                name: &s.name,
+                mxl_domain_id: DOMAIN_ID,
+                label: &s.label,
+                description: &s.description,
+                caps: &caps,
+            })
+            .expect("deferred AddSender may synthesise without mxl-flow-id");
+            let v = serde_json::from_str::<serde_json::Value>(&json).expect("json");
+            assert!(v.get("id").is_none());
         }
 
         #[test]
@@ -776,13 +799,10 @@ mod tests {
             assert_eq!(v["tags"]["urn:x-nvnmos:tag:mxl-domain-id"][0], DOMAIN_ID);
         }
 
-        /// Receiver synthesis is gated on `mxl-flow-id`: without it
-        /// we have nothing to subscribe to and no stable id for the
-        /// configuring flow_def. Returning `None` puts the element
-        /// on the fake chain until an IS-05 activation supplies the
-        /// missing piece.
+        /// Caps without `mxl-flow-id` still synthesise a configuring
+        /// flow_def (top-level `id` omitted) for AddReceiver.
         #[test]
-        fn receiver_caps_without_flow_id_returns_none() {
+        fn receiver_caps_without_flow_id_synthesises_configuring_flow_def() {
             let s = CommonSettings {
                 caps: Some(video_caps()),
                 ..settings(Side::Receiver)
@@ -790,7 +810,29 @@ mod tests {
             assert!(s.mxl_flow_id.is_empty(), "test precondition");
             let out = super::synthesise_or_passthrough_mxl(&cat(), "nmossrc", &s, DOMAIN_ID, None)
                 .expect("absent flow id must not error");
-            assert!(out.is_none(), "Receiver without flow id must not synthesise");
+            let text = out.expect("Receiver without flow id must synthesise configuring flow_def");
+            let v = parse(&text);
+            assert!(v.get("id").is_none());
+            assert_eq!(v["format"], "urn:x-nmos:format:video");
+        }
+
+        /// Receiver with configuring flow_def but no flow id keeps a
+        /// fake inner chain until IS-05 activation supplies one.
+        #[test]
+        fn receiver_without_flow_id_keeps_fake_inner() {
+            let s = CommonSettings {
+                caps: Some(video_caps()),
+                ..settings(Side::Receiver)
+            };
+            let synth = super::synthesise_or_passthrough_mxl(&cat(), "nmossrc", &s, DOMAIN_ID, None)
+                .expect("synthesis")
+                .expect("some json");
+            let flow = flow_def::resolve_mxl_flow_meta("", FlowFormat::Video, Some(&synth)).unwrap();
+            let inner = super::decide_inner_config_mxl(&s, &flow, Some(&synth));
+            match inner {
+                InnerConfig::Fake { kind, .. } => assert_eq!(kind, FakeKind::NotActive),
+                InnerConfig::Real(_) => panic!("must not build mxlsrc without mxl-flow-id"),
+            }
         }
 
         /// Sender synthesis still works the same way. Sanity check

--- a/rust/gst-nmos-rs/src/session/types.rs
+++ b/rust/gst-nmos-rs/src/session/types.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Session types shared across transport families (MXL, UDP/RTP).
+//! Session types shared across transport families (MXL, RTP/UDP).
 
 /// Whether the snapshot came from `nmossink` or `nmossrc`. Surfaces in
 /// error/log messages so validation failures point the user at the

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -5,14 +5,11 @@
 
 pub(crate) mod types;
 
-use std::sync::Mutex;
-
 use anyhow::{Context, bail};
 use gstreamer as gst;
 
 use super::{CommonSettings, FakeKind, InnerConfig, TransportConfig};
 use super::types::Side;
-use crate::daemon::Session;
 use crate::sdp::{self, DualLegPassthroughPolicy, SdpOverrides};
 use crate::types::{CapsMode, Transport};
 
@@ -58,7 +55,7 @@ pub(super) fn receiver_connection_address(settings: &CommonSettings) -> &str {
 
 /// Build [`sdp::SdpBuildInput`] from element settings and essence caps.
 /// Shared by NULL→READY caps synthesis and READY→PAUSED deferred
-/// sender registration.
+/// sender AddSender.
 pub(super) fn sdp_build_input<'a>(
     settings: &'a CommonSettings,
     essence_caps: &'a gst::Caps,
@@ -119,7 +116,7 @@ pub(super) fn synthesise_or_passthrough_udp(
 }
 
 /// When a Sender opens without `transport-file*` or `caps`, keep the
-/// fake chain until READY→PAUSED deferred registration (mirrors MXL).
+/// fake chain until READY→PAUSED deferred AddSender (mirrors MXL).
 fn gate_deferred_sender_udp(inner: InnerConfig, settings: &CommonSettings) -> InnerConfig {
     if settings.side == Side::Sender
         && matches!(
@@ -140,8 +137,8 @@ fn gate_deferred_sender_udp(inner: InnerConfig, settings: &CommonSettings) -> In
 }
 
 /// Synthesise configuring SDP and resolve the inner chain for deferred
-/// RTP sender registration from fixated upstream peer caps.
-pub(super) fn synthesise_deferred_sender_rtp(
+/// RTP sender AddSender from fixated upstream peer caps.
+pub(super) fn synthesise_deferred_sender_udp(
     element: &str,
     settings: &CommonSettings,
     essence_caps: &gst::Caps,
@@ -174,19 +171,6 @@ pub(super) fn synthesise_deferred_sender_rtp(
     };
     let inner = super::apply_auto_activate_gate(inner, settings.auto_activate);
     Ok((text, inner))
-}
-
-/// Register an RTP Sender from fixated peer caps at READY→PAUSED.
-pub(super) fn register_deferred_rtp(
-    cat: &gst::DebugCategory,
-    element: &str,
-    settings: &CommonSettings,
-    session: &Mutex<Option<Session>>,
-    fixated: &gst::Caps,
-) -> Result<InnerConfig, anyhow::Error> {
-    let (text, inner) = synthesise_deferred_sender_rtp(element, settings, fixated)?;
-    gst::info!(cat, "{element}: deferred mode: synthesised SDP");
-    super::finish_deferred_add_sender(cat, element, session, inner, &text, settings)
 }
 
 pub(crate) fn property_overrides_udp(settings: &CommonSettings) -> SdpOverrides<'_> {
@@ -296,7 +280,7 @@ pub(crate) fn decide_inner_config_udp(
     let Some(text) = transport_file else {
         return Ok(InnerConfig::Fake {
             kind: FakeKind::Misconfigured,
-            detail: "caps or transport-file required for NMOS registration".into(),
+            detail: "caps or transport-file required for AddSender / AddReceiver".into(),
         });
     };
     finish_udp_inner_config(
@@ -324,7 +308,7 @@ pub(crate) fn decide_inner_config_nvdsudp(
     let Some(text) = transport_file else {
         return Ok(InnerConfig::Fake {
             kind: FakeKind::Misconfigured,
-            detail: "caps or transport-file required for NMOS registration".into(),
+            detail: "caps or transport-file required for AddSender / AddReceiver".into(),
         });
     };
     finish_udp_inner_config(
@@ -1096,7 +1080,7 @@ mod tests {
         /// the empty-string / zero "unset" sentinel convention
         /// flows through to the splice helper as "leave the
         /// file's value alone". The shared `settings()` fixture
-        /// pre-fills `name` for IS-04 registration coverage; we
+        /// pre-fills `name` for IS-04 add-resource coverage; we
         /// clear it here together with the other identity /
         /// network fields so the test asserts on the splice
         /// builder's behaviour, not the fixture's defaults.
@@ -1221,7 +1205,7 @@ mod tests {
         }
 
         /// Sender with no `transport_file` and no `caps` defers
-        /// registration to READY→PAUSED (fake `NotConfigured`).
+        /// AddSender to READY→PAUSED (fake `NotConfigured`).
         #[test]
         fn resolve_inner_config_udp_sender_no_caps_no_file_is_not_configured() {
             let s = CommonSettings {
@@ -1920,8 +1904,8 @@ mod tests {
         }
     }
 
-    mod register_deferred {
-        use super::super::super::register_deferred;
+    mod add_deferred_sender {
+        use super::super::super::add_deferred_sender;
         use super::*;
         use std::str::FromStr;
 
@@ -1953,9 +1937,9 @@ mod tests {
         }
 
         #[test]
-        fn synthesise_deferred_sender_rtp_video_udp_builds_real_inner() {
+        fn synthesise_deferred_sender_udp_video_udp_builds_real_inner() {
             let s = sender_udp_settings(Transport::Udp);
-            let (text, inner) = synthesise_deferred_sender_rtp(
+            let (text, inner) = synthesise_deferred_sender_udp(
                 "nmossink",
                 &s,
                 &video_peer_caps(),
@@ -1967,9 +1951,9 @@ mod tests {
         }
 
         #[test]
-        fn synthesise_deferred_sender_rtp_anc_nvdsudp_builds_real_inner() {
+        fn synthesise_deferred_sender_udp_anc_nvdsudp_builds_real_inner() {
             let s = sender_udp_settings(Transport::NvDsUdp);
-            let (text, inner) = synthesise_deferred_sender_rtp(
+            let (text, inner) = synthesise_deferred_sender_udp(
                 "nmossink",
                 &s,
                 &anc_peer_caps(),
@@ -1980,12 +1964,12 @@ mod tests {
         }
 
         #[test]
-        fn synthesise_deferred_sender_rtp_unset_destination_ip_uses_zero_address() {
+        fn synthesise_deferred_sender_udp_unset_destination_ip_uses_zero_address() {
             let s = CommonSettings {
                 destination_ip: String::new(),
                 ..sender_udp_settings(Transport::Udp)
             };
-            let (text, inner) = synthesise_deferred_sender_rtp("nmossink", &s, &video_peer_caps())
+            let (text, inner) = synthesise_deferred_sender_udp("nmossink", &s, &video_peer_caps())
                 .expect("unset destination-ip synthesises");
             assert!(
                 text.contains("c=IN IP4 0.0.0.0"),
@@ -1995,10 +1979,10 @@ mod tests {
         }
 
         #[test]
-        fn register_deferred_rtp_unsupported_video_format_is_error() {
+        fn add_deferred_sender_udp_unsupported_video_format_is_error() {
             let caps = gst::Caps::from_str("video/x-raw,format=I420,width=1920,height=1080")
                 .expect("caps");
-            let err = register_deferred(
+            let err = add_deferred_sender(
                 &cat(),
                 "nmossink",
                 &sender_udp_settings(Transport::Udp),
@@ -2013,8 +1997,8 @@ mod tests {
         }
 
         #[test]
-        fn register_deferred_rtp_no_open_session_is_error() {
-            let err = register_deferred(
+        fn add_deferred_sender_udp_no_open_session_is_error() {
+            let err = add_deferred_sender(
                 &cat(),
                 "nmossink",
                 &sender_udp_settings(Transport::Udp2),

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! UDP/RTP transport session setup and activation.
+//! RTP/UDP transport session setup and activation.
 
 pub(crate) mod types;
 
@@ -50,6 +50,27 @@ pub(super) fn receiver_connection_address(settings: &CommonSettings) -> &str {
         settings.multicast_ip.as_str()
     } else {
         settings.interface_ip.as_str()
+    }
+}
+
+/// Minimum IS-05 endpoint properties required to synthesise a configuring
+/// SDP for AddSender / AddReceiver. Wire destinations may be omitted.
+pub(super) fn validate_rtp_configuring_minimum(
+    element: &str,
+    settings: &CommonSettings,
+) -> Result<(), anyhow::Error> {
+    match settings.side {
+        Side::Sender if settings.source_ip.is_empty() => {
+            bail!(
+                "{element}: `source-ip` is required to synthesise configuring SDP for AddSender"
+            );
+        }
+        Side::Receiver if settings.interface_ip.is_empty() => {
+            bail!(
+                "{element}: `interface-ip` is required to synthesise configuring SDP for AddReceiver"
+            );
+        }
+        _ => Ok(()),
     }
 }
 
@@ -102,6 +123,7 @@ pub(super) fn synthesise_or_passthrough_udp(
         }
         (Some(text), None) => Ok(Some(text)),
         (None, Some(essence_caps)) => {
+            validate_rtp_configuring_minimum(element, settings)?;
             let text = sdp::from_caps(&sdp_build_input(settings, essence_caps))
                 .with_context(|| format!("{element}: synthesising SDP from caps"))?;
             gst::info!(
@@ -115,8 +137,11 @@ pub(super) fn synthesise_or_passthrough_udp(
     }
 }
 
-/// When a Sender opens without `transport-file*` or `caps`, keep the
-/// fake chain until READY→PAUSED deferred AddSender (mirrors MXL).
+/// `decide_inner_config_*` treats missing SDP as [`FakeKind::Misconfigured`].
+/// For senders with neither `transport-file*` nor `caps`, that is deferred
+/// mode — rewrite to [`FakeKind::NotConfigured`] so NULL→READY opens the
+/// session without AddSender and waits for peer caps at READY→PAUSED.
+/// Receivers without input stay misconfigured (no deferred path).
 fn gate_deferred_sender_udp(inner: InnerConfig, settings: &CommonSettings) -> InnerConfig {
     if settings.side == Side::Sender
         && matches!(
@@ -143,6 +168,7 @@ pub(super) fn synthesise_deferred_sender_udp(
     settings: &CommonSettings,
     essence_caps: &gst::Caps,
 ) -> Result<(String, InnerConfig), anyhow::Error> {
+    validate_rtp_configuring_minimum(element, settings)?;
     let text = sdp::from_caps(&sdp_build_input(settings, essence_caps))
         .map_err(anyhow::Error::from)
         .with_context(|| format!("{element}: synthesising SDP from peer caps"))?;
@@ -167,9 +193,14 @@ pub(super) fn synthesise_deferred_sender_udp(
             Some(&text),
             sdp::EssenceCrossCheckMode::Full,
         )?,
-        Transport::Mxl => bail!("{element}: internal: MXL is not an RTP transport"),
+        Transport::Mxl => bail!("{element}: internal: MXL is not an RTP/UDP transport"),
     };
-    let inner = super::apply_auto_activate_gate(inner, settings.auto_activate);
+    let inner = super::apply_auto_activate_policy(
+        &crate::CAT,
+        element,
+        settings,
+        inner,
+    );
     Ok((text, inner))
 }
 
@@ -612,7 +643,7 @@ mod tests {
                     Some(&sdp),
                     sdp::EssenceCrossCheckMode::Full,
                 )
-                .expect_err("dual-leg SDP must be rejected for OSS UDP");
+                .expect_err("dual-leg SDP must be rejected for transport=udp/udp2");
                 assert!(
                     format!("{err:#}").contains("dual-leg SDP requires transport=nvdsudp"),
                     "unexpected error: {err:#}",
@@ -1975,7 +2006,12 @@ mod tests {
                 text.contains("c=IN IP4 0.0.0.0"),
                 "expected unspecified c= line, got:\n{text}",
             );
-            assert!(matches!(inner, InnerConfig::Real(TransportConfig::Udp { .. })));
+            match inner {
+                InnerConfig::Fake { kind, .. } => assert_eq!(kind, FakeKind::NotActive),
+                InnerConfig::Real(_) => {
+                    panic!("configuring-only sender keeps fake inner until activation")
+                }
+            }
         }
 
         #[test]

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -5,11 +5,14 @@
 
 pub(crate) mod types;
 
-use anyhow::Context;
+use std::sync::Mutex;
+
+use anyhow::{Context, bail};
 use gstreamer as gst;
 
 use super::{CommonSettings, FakeKind, InnerConfig, TransportConfig};
 use super::types::Side;
+use crate::daemon::Session;
 use crate::sdp::{self, DualLegPassthroughPolicy, SdpOverrides};
 use crate::types::{CapsMode, Transport};
 
@@ -33,6 +36,59 @@ pub(crate) enum UdpVariant {
     V2,
 }
 
+/// Receiver SDP connection address for the `c=` line from IS-05
+/// properties. Matches nmos-cpp `get_connection_address`:
+/// `multicast_ip` when set, else `interface_ip` (unicast reception /
+/// caps synthesis).
+///
+/// On the passthrough path this same dispatch feeds
+/// [`SdpOverrides::destination_ip`], so `interface-ip` alone rewrites
+/// `c=` even when the transport file already carries a multicast
+/// address — it is not a "join NIC only, leave `c=` alone" override.
+/// To pin IGMP join NIC on multicast without changing the group, put
+/// `a=x-nvnmos-iface-ip` in the file or set `multicast-ip` to the
+/// group's address alongside `interface-ip`.
+pub(super) fn receiver_connection_address(settings: &CommonSettings) -> &str {
+    if !settings.multicast_ip.is_empty() {
+        settings.multicast_ip.as_str()
+    } else {
+        settings.interface_ip.as_str()
+    }
+}
+
+/// Build [`sdp::SdpBuildInput`] from element settings and essence caps.
+/// Shared by NULL→READY caps synthesis and READY→PAUSED deferred
+/// sender registration.
+pub(super) fn sdp_build_input<'a>(
+    settings: &'a CommonSettings,
+    essence_caps: &'a gst::Caps,
+) -> sdp::SdpBuildInput<'a> {
+    let destination_ip = match settings.side {
+        Side::Sender => settings.destination_ip.as_str(),
+        Side::Receiver => receiver_connection_address(settings),
+    };
+    let advertise_caps = match settings.caps_mode {
+        CapsMode::Auto | CapsMode::Narrow => false,
+        CapsMode::Wide => true,
+    };
+    sdp::SdpBuildInput {
+        essence_caps,
+        transport_caps: settings.transport_caps.as_ref(),
+        side: settings.side,
+        label: &settings.label,
+        description: &settings.description,
+        name: &settings.name,
+        source_ip: &settings.source_ip,
+        source_port: settings.source_port,
+        destination_ip,
+        destination_port: settings.destination_port,
+        interface_ip: &settings.interface_ip,
+        advertise_caps,
+        node_seed: &settings.node_seed,
+        narrow_traffic_profile: settings.transport == Transport::NvDsUdp,
+    }
+}
+
 pub(super) fn synthesise_or_passthrough_udp(
     cat: &gst::DebugCategory,
     element: &str,
@@ -49,43 +105,7 @@ pub(super) fn synthesise_or_passthrough_udp(
         }
         (Some(text), None) => Ok(Some(text)),
         (None, Some(essence_caps)) => {
-            // Per-side dispatch on the IS-05 destination slot:
-            // Senders carry it as `destination_ip`, Receivers
-            // as `multicast_ip`. The single wire slot on the
-            // SDP `m=` / `c=` line is named `destination_ip`
-            // on `sdp::SdpBuildInput`.
-            let destination_ip = match settings.side {
-                Side::Sender => settings.destination_ip.as_str(),
-                Side::Receiver => settings.multicast_ip.as_str(),
-            };
-            let advertise_caps = match settings.caps_mode {
-                // Auto resolves to narrow for synthesised
-                // SDPs — the splice path can promote to wide
-                // later if `receiver-caps-mode=Wide` is set.
-                // (For synthesis we always know
-                // `caps_mode` directly, so we can apply it
-                // here without going through the splice's
-                // text-rewrite.)
-                CapsMode::Auto | CapsMode::Narrow => false,
-                CapsMode::Wide => true,
-            };
-            let input = sdp::SdpBuildInput {
-                essence_caps,
-                transport_caps: settings.transport_caps.as_ref(),
-                side: settings.side,
-                label: &settings.label,
-                description: &settings.description,
-                name: &settings.name,
-                source_ip: &settings.source_ip,
-                source_port: settings.source_port,
-                destination_ip,
-                destination_port: settings.destination_port,
-                interface_ip: &settings.interface_ip,
-                advertise_caps,
-                node_seed: &settings.node_seed,
-                narrow_traffic_profile: settings.transport == Transport::NvDsUdp,
-            };
-            let text = sdp::from_caps(&input)
+            let text = sdp::from_caps(&sdp_build_input(settings, essence_caps))
                 .with_context(|| format!("{element}: synthesising SDP from caps"))?;
             gst::info!(
                 cat,
@@ -97,6 +117,78 @@ pub(super) fn synthesise_or_passthrough_udp(
         (None, None) => Ok(None),
     }
 }
+
+/// When a Sender opens without `transport-file*` or `caps`, keep the
+/// fake chain until READY→PAUSED deferred registration (mirrors MXL).
+fn gate_deferred_sender_udp(inner: InnerConfig, settings: &CommonSettings) -> InnerConfig {
+    if settings.side == Side::Sender
+        && matches!(
+            inner,
+            InnerConfig::Fake {
+                kind: FakeKind::Misconfigured,
+                ..
+            }
+        )
+    {
+        InnerConfig::Fake {
+            kind: FakeKind::NotConfigured,
+            detail: String::new(),
+        }
+    } else {
+        inner
+    }
+}
+
+/// Synthesise configuring SDP and resolve the inner chain for deferred
+/// RTP sender registration from fixated upstream peer caps.
+pub(super) fn synthesise_deferred_sender_rtp(
+    element: &str,
+    settings: &CommonSettings,
+    essence_caps: &gst::Caps,
+) -> Result<(String, InnerConfig), anyhow::Error> {
+    let text = sdp::from_caps(&sdp_build_input(settings, essence_caps))
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("{element}: synthesising SDP from peer caps"))?;
+    let inner = match settings.transport {
+        Transport::Udp => decide_inner_config_udp(
+            element,
+            settings,
+            UdpVariant::V1,
+            Some(&text),
+            sdp::EssenceCrossCheckMode::Full,
+        )?,
+        Transport::Udp2 => decide_inner_config_udp(
+            element,
+            settings,
+            UdpVariant::V2,
+            Some(&text),
+            sdp::EssenceCrossCheckMode::Full,
+        )?,
+        Transport::NvDsUdp => decide_inner_config_nvdsudp(
+            element,
+            settings,
+            Some(&text),
+            sdp::EssenceCrossCheckMode::Full,
+        )?,
+        Transport::Mxl => bail!("{element}: internal: MXL is not an RTP transport"),
+    };
+    let inner = super::apply_auto_activate_gate(inner, settings.auto_activate);
+    Ok((text, inner))
+}
+
+/// Register an RTP Sender from fixated peer caps at READY→PAUSED.
+pub(super) fn register_deferred_rtp(
+    cat: &gst::DebugCategory,
+    element: &str,
+    settings: &CommonSettings,
+    session: &Mutex<Option<Session>>,
+    fixated: &gst::Caps,
+) -> Result<InnerConfig, anyhow::Error> {
+    let (text, inner) = synthesise_deferred_sender_rtp(element, settings, fixated)?;
+    gst::info!(cat, "{element}: deferred mode: synthesised SDP");
+    super::finish_deferred_add_sender(cat, element, session, inner, &text, settings)
+}
+
 pub(crate) fn property_overrides_udp(settings: &CommonSettings) -> SdpOverrides<'_> {
     fn opt(s: &str) -> Option<&str> {
         if s.is_empty() { None } else { Some(s) }
@@ -115,8 +207,11 @@ pub(crate) fn property_overrides_udp(settings: &CommonSettings) -> SdpOverrides<
         ),
         Side::Receiver => (
             opt(&settings.source_ip),
+            // `x-nvnmos-iface-ip` (join NIC). When `multicast-ip` is
+            // unset, [`receiver_connection_address`] also maps this into
+            // `destination_ip` for the `c=` splice — see its doc.
             opt(&settings.interface_ip),
-            opt(&settings.multicast_ip),
+            opt(receiver_connection_address(settings)),
             None,
         ),
     };
@@ -270,12 +365,15 @@ pub(super) fn resolve_inner_config_nvdsudp(
         ),
         other => other,
     };
-    let inner = decide_inner_config_nvdsudp(
-        element,
+    let inner = gate_deferred_sender_udp(
+        decide_inner_config_nvdsudp(
+            element,
+            settings,
+            resolved_transport_file.as_deref(),
+            sdp::EssenceCrossCheckMode::Full,
+        )?,
         settings,
-        resolved_transport_file.as_deref(),
-        sdp::EssenceCrossCheckMode::Full,
-    )?;
+    );
     Ok((inner, resolved_transport_file))
 }
 
@@ -333,13 +431,16 @@ pub(super) fn resolve_inner_config_udp(
         ),
         other => other,
     };
-    let inner = decide_inner_config_udp(
-        element,
+    let inner = gate_deferred_sender_udp(
+        decide_inner_config_udp(
+            element,
+            settings,
+            variant,
+            resolved_transport_file.as_deref(),
+            sdp::EssenceCrossCheckMode::Full,
+        )?,
         settings,
-        variant,
-        resolved_transport_file.as_deref(),
-        sdp::EssenceCrossCheckMode::Full,
-    )?;
+    );
     Ok((inner, resolved_transport_file))
 }
 
@@ -717,13 +818,9 @@ mod tests {
             assert_eq!(o.destination_port, Some(5004));
         }
 
-        /// Pure-function: a Receiver's `multicast_ip` populates
-        /// `SdpOverrides.destination_ip` (the SDP `c=` line wire
-        /// slot, which IS-05 splits between sender's
-        /// `destination_ip` and receiver's `multicast_ip` by
-        /// resource direction). `source_port` is forced to
-        /// `None` because the IS-05 receiver schema doesn't
-        /// define that slot.
+        /// Receiver `multicast_ip` wins over `interface_ip` for the
+        /// `c=` override slot; `interface_ip` still drives
+        /// `a=x-nvnmos-iface-ip` separately.
         #[test]
         fn property_overrides_udp_receiver_maps_multicast_ip_to_destination_ip() {
             let s = CommonSettings {
@@ -747,6 +844,252 @@ mod tests {
                 o.source_port, None,
                 "IS-05 receiver schema has no source-port slot",
             );
+        }
+
+        /// Unicast receiver: empty `multicast_ip` maps `interface_ip`
+        /// into `SdpOverrides.destination_ip` (the `c=` slot).
+        #[test]
+        fn property_overrides_udp_receiver_unicast_maps_interface_ip_to_destination_ip() {
+            let s = CommonSettings {
+                side: Side::Receiver,
+                interface_ip: "192.0.2.30".to_owned(),
+                ..udp_settings(Side::Receiver, Transport::Udp)
+            };
+            let o = property_overrides_udp(&s);
+            assert_eq!(o.destination_ip, Some("192.0.2.30"));
+            assert_eq!(o.interface_ip, Some("192.0.2.30"));
+            assert_eq!(o.source_ip, None);
+        }
+
+        // -- receiver passthrough override matrix ----------------
+
+        /// Passthrough property-override matrix (3 SDP baselines × 8
+        /// property combos). Notable case: multicast configuring SDP with
+        /// `interface-ip` only (no `multicast-ip`) rewrites `c=` to the
+        /// unicast NIC — see
+        /// `receiver_passthrough_multicast_file_interface_ip_only_rewrites_c`.
+        mod receiver_passthrough_matrix {
+            use super::*;
+
+            const FILE_MCAST: &str = "239.1.1.1";
+            const FILE_UNICAST: &str = "192.0.2.50";
+            const FILE_SSM_SRC: &str = "192.0.2.100";
+            const PROP_MCAST: &str = "232.99.99.1";
+            const PROP_IFACE: &str = "192.0.2.30";
+            const PROP_SRC: &str = "192.0.2.20";
+
+            const MCAST_ASM_SDP: &str = concat!(
+                "v=0\r\n",
+                "o=- 1 0 IN IP4 192.0.2.10\r\n",
+                "s=test\r\n",
+                "t=0 0\r\n",
+                "m=video 5004 RTP/AVP 96\r\n",
+                "c=IN IP4 239.1.1.1/64\r\n",
+                "a=rtpmap:96 raw/90000\r\n",
+                "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080;",
+                " exactframerate=50; depth=10\r\n",
+            );
+
+            const MCAST_SSM_SDP: &str = concat!(
+                "v=0\r\n",
+                "o=- 1 0 IN IP4 192.0.2.10\r\n",
+                "s=test\r\n",
+                "t=0 0\r\n",
+                "m=video 5004 RTP/AVP 96\r\n",
+                "c=IN IP4 239.1.1.1/64\r\n",
+                "a=rtpmap:96 raw/90000\r\n",
+                "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080;",
+                " exactframerate=50; depth=10\r\n",
+                "a=source-filter: incl IN IP4 239.1.1.1 192.0.2.100\r\n",
+            );
+
+            const UNICAST_SDP: &str = concat!(
+                "v=0\r\n",
+                "o=- 1 0 IN IP4 192.0.2.10\r\n",
+                "s=test\r\n",
+                "t=0 0\r\n",
+                "m=video 5004 RTP/AVP 96\r\n",
+                "c=IN IP4 192.0.2.50\r\n",
+                "a=rtpmap:96 raw/90000\r\n",
+                "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080;",
+                " exactframerate=50; depth=10\r\n",
+            );
+
+            #[derive(Debug, Clone, Copy)]
+            enum SdpKind {
+                McastAsm,
+                McastSsm,
+                Unicast,
+            }
+
+            impl SdpKind {
+                fn sdp(self) -> &'static str {
+                    match self {
+                        Self::McastAsm => MCAST_ASM_SDP,
+                        Self::McastSsm => MCAST_SSM_SDP,
+                        Self::Unicast => UNICAST_SDP,
+                    }
+                }
+
+                fn baseline_c(self) -> &'static str {
+                    match self {
+                        Self::McastAsm | Self::McastSsm => FILE_MCAST,
+                        Self::Unicast => FILE_UNICAST,
+                    }
+                }
+
+                fn baseline_has_ssm(self) -> bool {
+                    matches!(self, Self::McastSsm)
+                }
+            }
+
+            fn receiver_settings(
+                multicast: bool,
+                interface: bool,
+                source: bool,
+            ) -> CommonSettings {
+                let mut s = udp_settings(Side::Receiver, Transport::Udp);
+                if multicast {
+                    s.multicast_ip = PROP_MCAST.to_owned();
+                }
+                if interface {
+                    s.interface_ip = PROP_IFACE.to_owned();
+                }
+                if source {
+                    s.source_ip = PROP_SRC.to_owned();
+                }
+                s
+            }
+
+            fn splice(sdp: &str, settings: &CommonSettings) -> String {
+                sdp::passthrough_with_overrides(
+                    sdp,
+                    &property_overrides_udp(settings),
+                    DualLegPassthroughPolicy::RejectDualLeg,
+                )
+                .unwrap_or_else(|e| panic!("passthrough splice: {e}"))
+            }
+
+            fn expected_c(
+                multicast: bool,
+                interface: bool,
+                baseline: &'static str,
+            ) -> &'static str {
+                if multicast {
+                    PROP_MCAST
+                } else if interface {
+                    PROP_IFACE
+                } else {
+                    baseline
+                }
+            }
+
+            fn assert_c_contains(spliced: &str, addr: &str) {
+                let is_mcast = addr
+                    .parse::<std::net::Ipv4Addr>()
+                    .is_ok_and(|ip| ip.is_multicast());
+                if is_mcast {
+                    assert!(
+                        spliced.contains(&format!("c=IN IP4 {addr}/")),
+                        "expected multicast c= for {addr} in:\n{spliced}",
+                    );
+                } else {
+                    assert!(
+                        spliced.contains(&format!("c=IN IP4 {addr}\r\n"))
+                            || spliced.contains(&format!("c=IN IP4 {addr}\n")),
+                        "expected unicast c= for {addr} in:\n{spliced}",
+                    );
+                }
+            }
+
+            fn assert_source_filter(spliced: &str, expect: Option<(&str, &str)>) {
+                match expect {
+                    None => assert!(
+                        !spliced.contains("a=source-filter:"),
+                        "expected no source-filter in:\n{spliced}",
+                    ),
+                    Some((dest, src)) => {
+                        let needle = format!("incl IN IP4 {dest} {src}");
+                        assert!(
+                            spliced.contains(&needle),
+                            "expected source-filter containing `{needle}` in:\n{spliced}",
+                        );
+                    }
+                }
+            }
+
+            fn assert_iface_attr(spliced: &str, expect: Option<&str>) {
+                match expect {
+                    None => assert!(
+                        !spliced.contains("a=x-nvnmos-iface-ip:"),
+                        "expected no x-nvnmos-iface-ip in:\n{spliced}",
+                    ),
+                    Some(ip) => assert!(
+                        spliced.contains(&format!("a=x-nvnmos-iface-ip:{ip}")),
+                        "expected x-nvnmos-iface-ip:{ip} in:\n{spliced}",
+                    ),
+                }
+            }
+
+            /// Multicast file + `interface-ip` only: `c=` becomes the
+            /// property value (unicast), not the file's multicast
+            /// group. This follows nmos-cpp `get_connection_address`
+            /// but can surprise users who expected join-NIC-only.
+            /// To keep the group, set `multicast-ip` or embed
+            /// `a=x-nvnmos-iface-ip` in the file without setting the
+            /// property.
+            #[test]
+            fn receiver_passthrough_multicast_file_interface_ip_only_rewrites_c() {
+                let settings = receiver_settings(false, true, false);
+                let spliced = splice(MCAST_ASM_SDP, &settings);
+                assert_c_contains(&spliced, PROP_IFACE);
+                assert!(
+                    !spliced.contains(FILE_MCAST),
+                    "multicast c= must be replaced when only interface-ip \
+                     is set; got:\n{spliced}",
+                );
+                assert_iface_attr(&spliced, Some(PROP_IFACE));
+            }
+
+            #[test]
+            fn receiver_passthrough_property_override_matrix() {
+                for sdp_kind in [SdpKind::McastAsm, SdpKind::McastSsm, SdpKind::Unicast] {
+                    for multicast in [false, true] {
+                        for interface in [false, true] {
+                            for source in [false, true] {
+                                let settings = receiver_settings(multicast, interface, source);
+                                let spliced = splice(sdp_kind.sdp(), &settings);
+                                let c = expected_c(
+                                    multicast,
+                                    interface,
+                                    sdp_kind.baseline_c(),
+                                );
+
+                                assert_c_contains(
+                                    &spliced,
+                                    c,
+                                );
+
+                                let sf = if source {
+                                    Some((c, PROP_SRC))
+                                } else if sdp_kind.baseline_has_ssm() {
+                                    // Baseline SSM filter survives; `c=`
+                                    // overrides rewrite its dest address.
+                                    Some((c, FILE_SSM_SRC))
+                                } else {
+                                    None
+                                };
+                                assert_source_filter(&spliced, sf);
+
+                                assert_iface_attr(
+                                    &spliced,
+                                    interface.then_some(PROP_IFACE),
+                                );
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         /// All slots `None` when no property is set. Pins that
@@ -852,14 +1195,11 @@ mod tests {
             }
         }
 
-        /// No `transport_file` and no `caps` → neither synthesis
-        /// nor splice fires; inner stays misconfigured (no NMOS
-        /// resource can be registered).
+        /// Receiver with no `transport_file` and no `caps` stays
+        /// misconfigured — receivers cannot use deferred mode.
         #[test]
-        fn resolve_inner_config_udp_no_transport_file_and_no_caps_is_misconfigured() {
+        fn resolve_inner_config_udp_receiver_no_transport_file_and_no_caps_is_misconfigured() {
             let s = CommonSettings {
-                // IS-05 endpoint property set but no caps and no
-                // transport file — nothing to synthesise from.
                 multicast_ip: "232.0.0.1".to_owned(),
                 ..udp_settings(Side::Receiver, Transport::Udp)
             };
@@ -880,10 +1220,90 @@ mod tests {
             }
         }
 
+        /// Sender with no `transport_file` and no `caps` defers
+        /// registration to READY→PAUSED (fake `NotConfigured`).
+        #[test]
+        fn resolve_inner_config_udp_sender_no_caps_no_file_is_not_configured() {
+            let s = CommonSettings {
+                destination_ip: "239.1.1.1".to_owned(),
+                ..udp_settings(Side::Sender, Transport::Udp)
+            };
+            let (inner, text) = resolve_inner_config_udp(
+                &cat(),
+                "nmossink",
+                &s,
+                UdpVariant::V1,
+                None,
+            )
+            .expect("no error");
+            assert!(text.is_none());
+            match inner {
+                InnerConfig::Fake { kind, .. } => {
+                    assert_eq!(kind, FakeKind::NotConfigured);
+                }
+                other => panic!("expected not-configured fake, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn resolve_inner_config_nvdsudp_sender_no_caps_no_file_is_not_configured() {
+            let s = CommonSettings {
+                destination_ip: "239.1.1.1".to_owned(),
+                ..udp_settings(Side::Sender, Transport::NvDsUdp)
+            };
+            let (inner, text) = resolve_inner_config_nvdsudp(&cat(), "nmossink", &s, None)
+                .expect("no error");
+            assert!(text.is_none());
+            assert!(matches!(
+                inner,
+                InnerConfig::Fake {
+                    kind: FakeKind::NotConfigured,
+                    ..
+                }
+            ));
+        }
+
         /// `caps` supplied but no transport_file →
         /// `synthesise_or_passthrough_udp` builds an SDP from
         /// caps + transport_caps + IS-05 endpoint properties.
         /// The resolved config is now `Real`, not `Fake`.
+        #[test]
+        fn resolve_inner_config_udp_synthesises_unicast_receiver_from_caps_only() {
+            let mut s = udp_settings(Side::Receiver, Transport::Udp);
+            s.caps = Some(
+                gst::Caps::from_str(
+                    "audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved",
+                )
+                .unwrap(),
+            );
+            s.interface_ip = "192.0.2.30".to_owned();
+            s.destination_port = 5004;
+            let (inner, text) = resolve_inner_config_udp(
+                &cat(),
+                "nmossrc",
+                &s,
+                UdpVariant::V1,
+                None,
+            )
+            .expect("unicast receiver caps synthesis");
+            let text = text.expect("synthesised SDP");
+            assert!(
+                text.contains("c=IN IP4 192.0.2.30"),
+                "unicast receiver c= comes from interface-ip, not multicast-ip:\n{text}",
+            );
+            assert!(
+                !text.contains("source-filter:"),
+                "unicast receiver synthesis omits source-filter when source-ip unset:\n{text}",
+            );
+            match inner {
+                InnerConfig::Real(TransportConfig::Udp { media, .. }) => {
+                    assert_eq!(media.primary.destination_ip, "192.0.2.30");
+                    assert_eq!(media.primary.interface_ip.as_deref(), Some("192.0.2.30"));
+                }
+                other => panic!("expected Real(Udp) from unicast caps synthesis, got {other:?}"),
+            }
+        }
+
         #[test]
         fn resolve_inner_config_udp_synthesises_sdp_from_caps_only() {
             let essence = gst::Caps::from_str(
@@ -1497,6 +1917,115 @@ mod tests {
                     other => panic!("expected Real for {transport:?} ANC, got {other:?}"),
                 }
             }
+        }
+    }
+
+    mod register_deferred {
+        use super::super::super::register_deferred;
+        use super::*;
+        use std::str::FromStr;
+
+        fn sender_udp_settings(transport: Transport) -> CommonSettings {
+            cat();
+            CommonSettings {
+                transport,
+                destination_ip: "239.99.99.1".to_owned(),
+                destination_port: 5004,
+                source_ip: "192.0.2.10".to_owned(),
+                auto_activate: true,
+                ..settings(Side::Sender)
+            }
+        }
+
+        fn video_peer_caps() -> gst::Caps {
+            cat();
+            gst::Caps::from_str(
+                "video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1,\
+                 interlace-mode=progressive",
+            )
+            .expect("video caps")
+        }
+
+        fn anc_peer_caps() -> gst::Caps {
+            cat();
+            gst::Caps::from_str("meta/x-st-2038,alignment=frame,framerate=30/1")
+                .expect("anc caps")
+        }
+
+        #[test]
+        fn synthesise_deferred_sender_rtp_video_udp_builds_real_inner() {
+            let s = sender_udp_settings(Transport::Udp);
+            let (text, inner) = synthesise_deferred_sender_rtp(
+                "nmossink",
+                &s,
+                &video_peer_caps(),
+            )
+            .expect("synth");
+            assert!(text.contains("m=video 5004 RTP/AVP 96"), "SDP:\n{text}");
+            assert!(text.contains("c=IN IP4 239.99.99.1/"));
+            assert!(matches!(inner, InnerConfig::Real(TransportConfig::Udp { .. })));
+        }
+
+        #[test]
+        fn synthesise_deferred_sender_rtp_anc_nvdsudp_builds_real_inner() {
+            let s = sender_udp_settings(Transport::NvDsUdp);
+            let (text, inner) = synthesise_deferred_sender_rtp(
+                "nmossink",
+                &s,
+                &anc_peer_caps(),
+            )
+            .expect("synth");
+            assert!(text.contains("smpte291/90000"), "ANC SDP:\n{text}");
+            assert!(matches!(inner, InnerConfig::Real(TransportConfig::NvDsUdp { .. })));
+        }
+
+        #[test]
+        fn synthesise_deferred_sender_rtp_unset_destination_ip_uses_zero_address() {
+            let s = CommonSettings {
+                destination_ip: String::new(),
+                ..sender_udp_settings(Transport::Udp)
+            };
+            let (text, inner) = synthesise_deferred_sender_rtp("nmossink", &s, &video_peer_caps())
+                .expect("unset destination-ip synthesises");
+            assert!(
+                text.contains("c=IN IP4 0.0.0.0"),
+                "expected unspecified c= line, got:\n{text}",
+            );
+            assert!(matches!(inner, InnerConfig::Real(TransportConfig::Udp { .. })));
+        }
+
+        #[test]
+        fn register_deferred_rtp_unsupported_video_format_is_error() {
+            let caps = gst::Caps::from_str("video/x-raw,format=I420,width=1920,height=1080")
+                .expect("caps");
+            let err = register_deferred(
+                &cat(),
+                "nmossink",
+                &sender_udp_settings(Transport::Udp),
+                &Mutex::new(None),
+                caps,
+            )
+            .expect_err("I420 unsupported for ST 2110 synthesis");
+            assert!(
+                format!("{err:#}").contains("synthesising SDP from peer caps"),
+                "expected synthesis context: {err:#}",
+            );
+        }
+
+        #[test]
+        fn register_deferred_rtp_no_open_session_is_error() {
+            let err = register_deferred(
+                &cat(),
+                "nmossink",
+                &sender_udp_settings(Transport::Udp2),
+                &Mutex::new(None),
+                video_peer_caps(),
+            )
+            .expect_err("missing session");
+            assert!(
+                format!("{err:#}").contains("no open session"),
+                "expected no-open-session reason: {err:#}",
+            );
         }
     }
 }

--- a/rust/gst-nmos-rs/src/session/udp/types.rs
+++ b/rust/gst-nmos-rs/src/session/udp/types.rs
@@ -38,7 +38,7 @@ use crate::types::FlowFormat;
 /// scalars (`destination-ip`, `interface-ip`, …); there is no `-2`
 /// suffixed leg-2 property surface. ST 2022-7 uses a dual-`m=`
 /// **transport file** on `transport=nvdsudp` (configuring passthrough
-/// preserves both legs for NMOS registration) and inner-element
+/// preserves both legs for AddSender / AddReceiver) and inner-element
 /// redundancy properties on receive (comma-separated `st2022-7-streams`,
 /// `local-iface-ip`, and `source-address` on `nvdsudpsrc`). Dual-leg
 /// `transport-file*` on `udp` / `udp2` is rejected at element creation.

--- a/rust/gst-nmos-rs/src/types.rs
+++ b/rust/gst-nmos-rs/src/types.rs
@@ -15,7 +15,7 @@ use gstreamer::glib;
 ///
 /// [`Transport::Mxl`] uses the MXL shared-memory pair (`mxlsrc` /
 /// `mxlsink`). [`Transport::Udp`] and [`Transport::Udp2`] both
-/// drive an OSS RTP-over-UDP chain (RFC 4175 video, ST 2110-30
+/// drive an RTP-over-UDP chain (RFC 4175 video, ST 2110-30
 /// audio, RFC 8331 / ST 2110-40 ancillary), differing only in
 /// which factory family is preferred when both are installed:
 /// `Udp` picks gst-plugins-good (`udpsrc` / `udpsink` + the
@@ -34,16 +34,16 @@ pub enum Transport {
     #[default]
     #[enum_value(name = "MXL shared-memory transport", nick = "mxl")]
     Mxl = 0,
-    /// ST 2110 via OSS gst-plugins-good `udpsrc` / `udpsink` plus
+    /// ST 2110 via gst-plugins-good `udpsrc` / `udpsink` plus
     /// the matching gst-plugins-good RTP (de)payloaders.
-    #[enum_value(name = "OSS udp + RTP via gst-plugins-good", nick = "udp")]
+    #[enum_value(name = "RTP/UDP via gst-plugins-good", nick = "udp")]
     Udp = 1,
     /// ST 2110 via gst-plugins-rs' `udpsrc2` plus the
-    /// gst-plugins-rs `*pay2` / `*depay2` RTP elements where
+    /// gst-plugins-rs `rtp*pay2` / `rtp*depay2` RTP elements where
     /// available, falling back to gst-plugins-good per-element
     /// for any V1-only piece (notably `udpsink` — no `udpsink2`
     /// exists).
-    #[enum_value(name = "OSS udp + RTP via gst-plugins-rs", nick = "udp2")]
+    #[enum_value(name = "RTP/UDP via gst-plugins-rs", nick = "udp2")]
     Udp2 = 2,
     /// ST 2110 via DeepStream's `nvdsudpsrc` / `nvdsudpsink` (Rivermax).
     #[enum_value(name = "NvDsUdp / Rivermax (DeepStream nvdsudp*)", nick = "nvdsudp")]

--- a/rust/nvnmos-rpc/proto/nvnmosd.proto
+++ b/rust/nvnmos-rpc/proto/nvnmosd.proto
@@ -48,7 +48,7 @@ service NvnmosDaemon {
   // (across many client processes) may share a Node by reusing the
   // same `seed`. The session handle distinguishes them so that the
   // daemon can refcount Node lifetime correctly, route activations
-  // only to the session that registered the affected resource, and
+  // only to the session that added the affected resource, and
   // drop the right resources when a stream dies.
 
   // Open a session on the Node identified by `node_config.seed`.

--- a/rust/nvnmos/src/lib.rs
+++ b/rust/nvnmos/src/lib.rs
@@ -994,8 +994,8 @@ impl NodeServer {
 
     /// Look up a sender's NMOS UUID by its name.
     ///
-    /// Returns `Ok(None)` if no sender with the given `sender_name` is
-    /// currently registered with this server.
+    /// Returns `Ok(None)` if no sender with the given `sender_name`
+    /// currently exists on this server.
     pub fn sender_id(&self, sender_name: &str) -> Result<Option<String>> {
         let cname = CString::new(sender_name)?;
         let mut buf = [0u8; ID_BUF_LEN];
@@ -1015,8 +1015,8 @@ impl NodeServer {
 
     /// Look up a receiver's NMOS UUID by its name.
     ///
-    /// Returns `Ok(None)` if no receiver with the given `receiver_name` is
-    /// currently registered with this server.
+    /// Returns `Ok(None)` if no receiver with the given `receiver_name`
+    /// currently exists on this server.
     pub fn receiver_id(&self, receiver_name: &str) -> Result<Option<String>> {
         let cname = CString::new(receiver_name)?;
         let mut buf = [0u8; ID_BUF_LEN];

--- a/rust/nvnmosd-bench/src/main.rs
+++ b/rust/nvnmosd-bench/src/main.rs
@@ -64,11 +64,11 @@ struct Args {
     #[arg(long, default_value_t = 1)]
     nodes: usize,
 
-    /// Senders to register via `AddSender` (`--senders` alias).
+    /// Senders to create via `AddSender` (`--senders` alias).
     #[arg(long = "add-senders", alias = "senders", default_value_t = 5)]
     add_senders: usize,
 
-    /// Receivers to register via `AddReceiver` (`--receivers` alias).
+    /// Receivers to create via `AddReceiver` (`--receivers` alias).
     #[arg(long = "add-receivers", alias = "receivers", default_value_t = 5)]
     add_receivers: usize,
 
@@ -95,12 +95,12 @@ struct Args {
     interface_ip: Option<String>,
 
     /// Out-of-band `SyncResourceState` workflows (`0` = none). Evenly spaced targets when
-    /// not more than registered senders; otherwise round-robin through them.
+    /// not more than created senders; otherwise round-robin through them.
     #[arg(long, default_value_t = 0)]
     syncs: usize,
 
     /// In-band GET/PATCH activation workflows (`0` = none). Evenly spaced targets when not
-    /// more than registered senders; otherwise round-robin through them.
+    /// more than created senders; otherwise round-robin through them.
     #[arg(long, default_value_t = 0)]
     patches: usize,
 
@@ -580,10 +580,10 @@ async fn main() -> anyhow::Result<()> {
         "patches must be <= {MAX_PATCHES}"
     );
     if args.syncs > 0 && args.add_senders == 0 {
-        anyhow::bail!("syncs > 0 requires at least one registered sender");
+        anyhow::bail!("syncs > 0 requires at least one created sender");
     }
     if args.patches > 0 && args.add_senders == 0 {
-        anyhow::bail!("patches > 0 requires at least one registered sender");
+        anyhow::bail!("patches > 0 requires at least one created sender");
     }
     anyhow::ensure!(
         args.clients <= MAX_CLIENTS,
@@ -597,7 +597,7 @@ async fn main() -> anyhow::Result<()> {
         "sessions must be <= {MAX_SESSIONS}"
     );
     if args.add_senders > 0 || args.add_receivers > 0 {
-        anyhow::ensure!(args.sessions >= 1, "sessions must be >= 1 when registering resources");
+        anyhow::ensure!(args.sessions >= 1, "sessions must be >= 1 when creating resources");
     }
     anyhow::ensure!(
         u32::from(args.base_http_port) + args.nodes as u32 <= u16::MAX as u32,
@@ -1140,10 +1140,10 @@ fn session_for_resource(resource_index: usize, session_count: usize) -> usize {
 }
 
 /// Per-workflow index for sync, PATCH, or RemoveResource. `workflow_count == 0` → none.
-/// When `workflow_count <= registered_count`, targets are evenly spaced; when larger,
-/// round-robin through `[0, registered_count)`.
-fn sender_activation_indices(registered_count: usize, workflow_count: usize) -> Vec<usize> {
-    match (registered_count, workflow_count) {
+/// When `workflow_count <= created_count`, targets are evenly spaced; when larger,
+/// round-robin through `[0, created_count)`.
+fn sender_activation_indices(created_count: usize, workflow_count: usize) -> Vec<usize> {
+    match (created_count, workflow_count) {
         (0, _) | (_, 0) => Vec::new(),
         (n, c) if c <= n => (0..c).map(|i| i * n / c).collect(),
         (n, c) => (0..c).map(|i| i % n).collect(),
@@ -1347,7 +1347,7 @@ mod tests {
     }
 
     #[test]
-    fn activation_indices_round_robin_when_exceeding_registered() {
+    fn activation_indices_round_robin_when_exceeding_created() {
         let indices = sender_activation_indices(1000, 5000);
         assert_eq!(indices.len(), 5000);
         assert_eq!(indices[0], 0);

--- a/rust/nvnmosd-example/src/main.rs
+++ b/rust/nvnmosd-example/src/main.rs
@@ -36,9 +36,9 @@
 //!     and start a background task that auto-acks each event with
 //!     `success = true`. Stays alive for the rest of the resource phase
 //!     so IS-05 PATCHes against libnvnmos can drive the round-trip.
-//! 11. `AddSender` — register a sender, assert `resource_id` matches
+//! 11. `AddSender` — create a sender, assert `resource_id` matches
 //!     `nvnmos::make_sender_id(seed, name)`.
-//! 12. `AddReceiver` — register a receiver with the same `name` as the
+//! 12. `AddReceiver` — create a receiver with the same `name` as the
 //!     sender in (11) to exercise the side-disambiguated namespace, and
 //!     assert `resource_id` matches `nvnmos::make_receiver_id(seed,
 //!     name)` (a distinct UUID from the sender's).

--- a/rust/nvnmosd/src/main.rs
+++ b/rust/nvnmosd/src/main.rs
@@ -418,7 +418,7 @@ fn route_activation(
                 "activation for unknown resource (likely a stray from a \
                  prior name mismatch); NACKing",
             );
-            return Err("resource not registered with daemon".to_string());
+            return Err("resource not known to daemon".to_string());
         }
         ActivationDispatch::NoSubscriber => {
             tracing::warn!(

--- a/rust/nvnmosd/src/state.rs
+++ b/rust/nvnmosd/src/state.rs
@@ -13,7 +13,7 @@
 //! * **Sessions** are keyed by daemon-allocated `session_handle` strings.
 //!   Each session remembers which `node_seed` it attached to (so
 //!   [`State::close_session`] can find the right [`NodeEntry`] to detach
-//!   from) and which `resource_handle`s it has registered (so the same
+//!   from) and which `resource_handle`s it has created (so the same
 //!   call can drop them via libnvnmos before the Node itself goes away).
 //! * **Resources** (senders and receivers) are keyed by daemon-allocated
 //!   `resource_handle` strings. Each entry remembers the owning session,
@@ -375,7 +375,7 @@ pub enum ActivationDispatch {
         activation_handle: String,
         ack_rx: std_mpsc::Receiver<AckOutcome>,
     },
-    /// No resource is registered for `(node_seed, name)`. Either
+    /// No resource is created for `(node_seed, name)`. Either
     /// the activation is for a stray (a resource that survived the
     /// `AddSender`/`AddReceiver` mismatch path) or for one that was
     /// removed between the IS-05 PATCH arriving and the callback firing.
@@ -590,7 +590,7 @@ impl State {
         })
     }
 
-    /// Count live senders/receivers registered on `node_seed`.
+    /// Count live senders/receivers created on `node_seed`.
     pub fn resource_count_for_node(&self, node_seed: &str) -> usize {
         self.resources
             .values()
@@ -671,7 +671,7 @@ impl State {
         })
     }
 
-    /// Register a sender. Thin wrapper around [`State::add_resource`].
+    /// Create a sender. Thin wrapper around [`State::add_resource`].
     pub fn add_sender(
         &mut self,
         session_handle: &str,
@@ -688,7 +688,7 @@ impl State {
         )
     }
 
-    /// Register a receiver. Thin wrapper around [`State::add_resource`].
+    /// Create a receiver. Thin wrapper around [`State::add_resource`].
     pub fn add_receiver(
         &mut self,
         session_handle: &str,
@@ -714,7 +714,7 @@ impl State {
     /// 1. Daemon-registry pre-check — refuses a duplicate `name`
     ///    on the same Node before any FFI happens.
     /// 2. `add_{sender,receiver}` into libnvnmos. libnvnmos parses the
-    ///    transport file and registers the resource under its embedded
+    ///    transport file and creates the resource under its embedded
     ///    resource name.
     /// 3. `{sender,receiver}_id(claimed_name)` — uses libnvnmos
     ///    itself as the oracle: success proves the transport file's id
@@ -746,7 +746,7 @@ impl State {
         if let Some(existing) = self.by_name.get(&key) {
             return Err(Status::already_exists(format!(
                 "a {} with name {claimed_name:?} is already \
-                 registered on node_seed {node_seed:?} as resource_handle \
+                 created on node_seed {node_seed:?} as resource_handle \
                  {existing:?}",
                 side.label(),
             )));


### PR DESCRIPTION
## Summary

Extends `nmossink` **deferred sender registration** — previously MXL-only — to **RTP transports** (`udp`, `udp2`, `nvdsudp`). When neither `transport-file*` nor `caps` is set at NULL→READY, the element opens a session without a Sender, queries upstream peer caps at READY→PAUSED, synthesises configuring SDP, and calls `AddSender` through the shared deferred path. SDP synthesis aligns `c=` handling with nmos-cpp, defaults unset wire addresses to `0.0.0.0` on synthesis only, and documents the `interface-ip` passthrough caveat for multicast SDPs.

Renames deferred internals for clarity (`register_deferred` → `add_deferred_sender`, etc.) and centralises shared property blurbs in `session/mod.rs`. ("Register" has a specific meaning in NMOS!)

Docs and demo tooling follow the transport work:

- New `scripts/env.sh` with shared `DEMO_*` defaults (caps, multicast, queues, `DEMO_TRANSPORT`)
- Example pipelines for MXL and UDP: sender, receiver, flipper, deferred sender, multi-flow
- `pipeline-examples.md` extracted from README; nvdsudp install pointers and WSLg Pulse note for demo audio
- Interactive demo refactored around `env.sh`, including `DEMO_TRANSPORT=nvdsudp` with a gst-inspect precheck
- Transport-generic comments across crate and design docs (replacing stale MXL-only wording)
