### PR TITLE
gst-nmos-rs: align mutable_ready() pspecs with lifecycle steps

### DIFF
--- a/doc/designs/gst-nmos-rs-mutable-ready-audit.md
+++ b/doc/designs/gst-nmos-rs-mutable-ready-audit.md
@@ -1,0 +1,133 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# `gst-nmos-rs` — `mutable_ready()` property audit
+
+`mutable_ready()` lets `g_object_set()` run in **NULL or READY**; it does **not** mean the element re-reads the property on every READY-time set. Values are taken from `Settings` only when a **lifecycle step** runs (below).
+
+Override vs cross-check rules for transport-file interaction: [README](../rust/gst-nmos-rs/README.md#property-interaction-with-transport-file). This doc covers **when** each property must be set and which outer pspec flags apply.
+
+## Lifecycle steps
+
+Daemon RPC steps and **inner build** (element-local — not an RPC). Inner build is **not** the same as activation-event: it is when the bin swaps the fake chain for a real transport sink/source. That happens at **add-resource** when `auto-activate=true`, or at **activation-event** otherwise.
+
+| Step | gRPC | GStreamer | What happens |
+|------|------|-----------|--------------|
+| **open-session** | `OpenSession` | NULL→READY | UDS session; node identity if this session creates the Node; `SubscribeActivations` starts. |
+| **add-resource** | `AddSender` / `AddReceiver` | NULL→READY (eager) or READY→PAUSED (deferred) | IS-04 resource with configuring transport file. Skipped at open when nothing to register yet. |
+| **activation-event** | `ActivationEvent` → `AckActivation` | Async (often PLAYING) | IS-05 PATCH → transport file on subscription → inner build (unless already real via `auto-activate`) + ack. |
+| **inner build** | — | with add-resource if `auto-activate`; else during activation-event | Real transport sink/source replaces fake chain; `mxl-domain-path`, `*-properties` bags applied to fresh inner elements. |
+
+```text
+NULL
+ │
+ │  open-session (always)
+ │  add-resource (eager) if transport-file* or caps set
+ │  inner build if auto-activate (with eager add-resource)
+ ▼
+READY
+ │
+ │  add-resource (deferred; nmossink MXL only) if transport-file*
+ │  and caps were unset at NULL→READY
+ │  inner build if auto-activate (with deferred add-resource)
+ ▼
+PAUSED
+ │
+ ▼
+PLAYING
+    activation-event (async, usually during PLAYING)
+    inner build (from activation-event)
+```
+
+**Deferred add-resource** (`nmossink`, `transport=mxl` only): at READY→PAUSED the element queries upstream peer caps and calls `AddSender`. RTP senders must register eagerly. **`nmossrc` has no deferred path.**
+
+**`auto-activate`:** at add-resource, gates whether inner build runs there (real vs fake chain) — not a shortcut to PLAYING. Ignored at activation-event. When `true`, also calls `SyncResourceState` so daemon `/active` matches without an external PATCH.
+
+## `mutable_ready` rule
+
+
+| First step   | `nmossink`                                                                      | `nmossrc`                                                                 |
+| ------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| open-session | no `mutable_ready()` — set in **NULL**                                          | same                                                                      |
+| add-resource | `mutable_ready()` — **NULL** (eager) or **NULL/READY** before PAUSED (deferred) | no `mutable_ready()` — eager at NULL→READY only                           |
+| inner build  | `mutable_ready()` — **NULL/READY** before PLAYING                               | same (`mxl-domain-path`, `transport-properties`, `depay-properties` only) |
+
+
+**`*-properties` (current choice, may revisit):** `mutable_ready()` only, not `mutable_playing()`. Bags apply on the **next** inner build so PLAYING-time sets are rejected. Revisit if applications need to tune them during the PLAYING wait or between real→real activation-event swaps.
+
+**gst-launch:** sets props in NULL before READY — NULL-only pspec is enough for typical lines.
+
+## `nmossink` properties
+
+*Add-resource rows:* `mutable_ready`, NULL or READY. If eager registration already ran at NULL→READY, later READY-time changes have no effect. Setting `transport-file`, `transport-file-path`, or `caps` at READY (before PAUSED) triggers eager add-resource and skips deferred. Deferred add-resource is currently only implemented for `transport=mxl`. `source-ip` … `destination-port` are honoured when `transport` is `udp`, `udp2`, or `nvdsudp`; ignored on `mxl`. *Inner build rows:* `mxl-domain-path` is optional at add-resource (can populate or cross-check `mxl-domain-id` via `domain_def.json`); first required at inner build for `mxlsink domain=`.
+
+| Property | First step |
+|----------|------------|
+| `daemon-uri` | open-session |
+| `node-seed` | open-session |
+| `http-port` | open-session |
+| `host-name` | open-session |
+| `domain` | open-session |
+| `registration-url` | open-session |
+| `system-url` | open-session |
+| `auto-activate` | add-resource |
+| `transport` | add-resource |
+| `sender-name` | add-resource |
+| `mxl-domain-id` | add-resource |
+| `mxl-flow-id` | add-resource |
+| `label` | add-resource |
+| `description` | add-resource |
+| `transport-file` | add-resource |
+| `transport-file-path` | add-resource |
+| `caps` | add-resource |
+| `transport-caps` | add-resource |
+| `source-ip` | add-resource |
+| `source-port` | add-resource |
+| `destination-ip` | add-resource |
+| `destination-port` | add-resource |
+| `mxl-domain-path` | inner build |
+| `transport-properties` | inner build |
+| `pay-properties` | inner build |
+
+
+## `nmossrc` properties
+
+*Open-session and add-resource rows:* no `mutable_ready()` — set in **NULL** (eager add-resource only). `mxl-domain-id` is the registration requirement (UUID, not filesystem path). `mxl-flow-id` property is ignored at activation-event (PATCH transport file wins). *Inner build rows:* `mutable_ready`, NULL or READY. `mxl-domain-path` is optional at add-resource; first required at inner build for `mxlsrc domain=`. `depay-properties` applies when `transport` is `udp` or `udp2`.
+
+| Property | First step |
+|----------|------------|
+| `daemon-uri` | open-session |
+| `node-seed` | open-session |
+| `http-port` | open-session |
+| `host-name` | open-session |
+| `domain` | open-session |
+| `registration-url` | open-session |
+| `system-url` | open-session |
+| `auto-activate` | add-resource |
+| `transport` | add-resource |
+| `receiver-name` | add-resource |
+| `mxl-domain-id` | add-resource |
+| `mxl-flow-id` | add-resource |
+| `label` | add-resource |
+| `description` | add-resource |
+| `transport-file` | add-resource |
+| `transport-file-path` | add-resource |
+| `caps` | add-resource |
+| `transport-caps` | add-resource |
+| `receiver-caps-mode` | add-resource |
+| `source-ip` | add-resource |
+| `interface-ip` | add-resource |
+| `multicast-ip` | add-resource |
+| `destination-port` | add-resource |
+| `mxl-domain-path` | inner build |
+| `transport-properties` | inner build |
+| `depay-properties` | inner build |
+
+
+## Related tests
+
+- Deferred sender: integration plan Tier 2 (`registration_matrix.rs`, planned).
+- `channel-order` via `transport-caps`: `sdp.rs` tests on `feature/mutable-ready-and-channel-order`.
+

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -140,12 +140,10 @@ impl ObjectImpl for NmosSink {
                     .nick("Daemon URI")
                     .blurb(crate::session::DAEMON_URI_BLURB)
                     .default_value(Some(DEFAULT_DAEMON_URI))
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("node-seed")
                     .nick("Node seed")
                     .blurb(crate::session::NODE_SEED_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecUInt::builder("http-port")
                     .nick("HTTP port")
@@ -153,27 +151,22 @@ impl ObjectImpl for NmosSink {
                     .minimum(0)
                     .maximum(65535)
                     .default_value(0)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("host-name")
                     .nick("Host name")
                     .blurb(crate::session::HOST_NAME_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("domain")
                     .nick("NMOS DNS domain")
                     .blurb(crate::session::DOMAIN_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("registration-url")
                     .nick("Registration URL")
                     .blurb(crate::session::REGISTRATION_URL_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("system-url")
                     .nick("System URL")
                     .blurb(crate::session::SYSTEM_URL_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecEnum::builder_with_default("transport", Transport::Mxl)
                     .nick("Transport")
@@ -195,12 +188,12 @@ impl ObjectImpl for NmosSink {
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("mxl-domain-id")
-                    .nick("MXL Domain id")
+                    .nick("MXL domain id")
                     .blurb(crate::session::MXL_DOMAIN_ID_BLURB)
                     .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("mxl-domain-path")
-                    .nick("MXL Domain path")
+                    .nick("MXL domain path")
                     .blurb(
                         "Local filesystem path identifying the MXL Domain on \
                          this host. If the directory contains a \

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -151,12 +151,10 @@ impl ObjectImpl for NmosSrc {
                     .nick("Daemon URI")
                     .blurb(crate::session::DAEMON_URI_BLURB)
                     .default_value(Some(DEFAULT_DAEMON_URI))
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("node-seed")
                     .nick("Node seed")
                     .blurb(crate::session::NODE_SEED_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecUInt::builder("http-port")
                     .nick("HTTP port")
@@ -164,32 +162,26 @@ impl ObjectImpl for NmosSrc {
                     .minimum(0)
                     .maximum(65535)
                     .default_value(0)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("host-name")
                     .nick("Host name")
                     .blurb(crate::session::HOST_NAME_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("domain")
                     .nick("NMOS DNS domain")
                     .blurb(crate::session::DOMAIN_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("registration-url")
                     .nick("Registration URL")
                     .blurb(crate::session::REGISTRATION_URL_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("system-url")
                     .nick("System URL")
                     .blurb(crate::session::SYSTEM_URL_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecEnum::builder_with_default("transport", Transport::Mxl)
                     .nick("Transport")
                     .blurb(crate::session::TRANSPORT_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("receiver-name")
                     .nick("NMOS receiver name")
@@ -203,23 +195,22 @@ impl ObjectImpl for NmosSrc {
                          Overrides the transport file's tag when both \
                          are supplied.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("mxl-domain-id")
-                    .nick("MXL Domain id")
+                    .nick("MXL domain id")
                     .blurb(crate::session::MXL_DOMAIN_ID_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("mxl-domain-path")
-                    .nick("MXL Domain path")
+                    .nick("MXL domain path")
                     .blurb(
                         "Local filesystem path identifying the MXL Domain on \
                          this host. If the directory contains a \
                          `domain_def.json` (AMWA BCP-007-03 WIP) its `id` is \
                          used to populate `mxl-domain-id` (or cross-checked \
                          against it when both are set). Fed into the inner \
-                         `mxlsrc` `domain=` property at NULL→READY when an \
-                         `mxl-flow-id` is also pinned.",
+                         `mxlsrc` `domain=` property when the real inner \
+                         chain is installed (after IS-05 activation, or at \
+                         startup when `auto-activate=true`).",
                     )
                     .mutable_ready()
                     .build(),
@@ -235,13 +226,11 @@ impl ObjectImpl for NmosSrc {
                          external controller. Overrides the transport \
                          file's top-level `id` when both are supplied.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecBoolean::builder("auto-activate")
                     .nick("Auto-activate")
                     .blurb(crate::session::AUTO_ACTIVATE_BLURB)
                     .default_value(false)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("label")
                     .nick("Label")
@@ -250,7 +239,6 @@ impl ObjectImpl for NmosSrc {
                          the transport file's top-level `label` when both \
                          are supplied.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("description")
                     .nick("Description")
@@ -259,7 +247,6 @@ impl ObjectImpl for NmosSrc {
                          Overrides the transport file's top-level \
                          `description` when both are supplied.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("transport-file")
                     .nick("Transport file")
@@ -271,12 +258,10 @@ impl ObjectImpl for NmosSrc {
                          use `transport-file-path` instead. Mutually exclusive with \
                          `transport-file-path`. Required unless `caps` is provided.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("transport-file-path")
                     .nick("Transport file path")
                     .blurb(crate::session::TRANSPORT_FILE_PATH_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Caps>("caps")
                     .nick("Essence caps")
@@ -289,12 +274,10 @@ impl ObjectImpl for NmosSrc {
                          mismatch is a hard error (the caps and the flow's essence shape \
                          must describe the same thing).",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Caps>("transport-caps")
                     .nick("Transport caps")
                     .blurb(crate::session::TRANSPORT_CAPS_BLURB)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecBoxed::builder::<gst::Structure>("transport-properties")
                     .nick("Transport source properties")
@@ -322,7 +305,6 @@ impl ObjectImpl for NmosSrc {
                          for wide is \"present + non-empty\").",
                     )
                     .default_value(CapsMode::Auto)
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("source-ip")
                     .nick("Source IP")
@@ -339,7 +321,6 @@ impl ObjectImpl for NmosSrc {
                          Honoured only on the RTP transports; ignored \
                          on `mxl`.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("interface-ip")
                     .nick("Interface IP")
@@ -353,7 +334,6 @@ impl ObjectImpl for NmosSrc {
                          (let the kernel pick). Honoured only on the \
                          RTP transports; ignored on `mxl`.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecString::builder("multicast-ip")
                     .nick("Multicast IP")
@@ -365,7 +345,6 @@ impl ObjectImpl for NmosSrc {
                          unset (unicast reception). Honoured only on \
                          the RTP transports; ignored on `mxl`.",
                     )
-                    .mutable_ready()
                     .build(),
                 glib::ParamSpecUInt::builder("destination-port")
                     .nick("Destination port")
@@ -382,7 +361,6 @@ impl ObjectImpl for NmosSrc {
                     .minimum(0)
                     .maximum(65535)
                     .default_value(0)
-                    .mutable_ready()
                     .build(),
             ]
         });

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -119,15 +119,16 @@ pub(crate) const TRANSPORT_BLURB: &str =
      Requires ConnectX-5+ and the Rivermax SDK.";
 
 pub(crate) const MXL_DOMAIN_ID_BLURB: &str =
-    "MXL Domain identifier (UUID) advertised in NMOS as \
+    "MXL Domain identifier (UUID) included as \
      `urn:x-nvnmos:tag:mxl-domain-id` in the transport file. \
      Required when transport=mxl, but may be omitted if \
      `mxl-domain-path` points at a directory containing a \
      `domain_def.json` (AMWA BCP-007-03 WIP): the file's `id` is \
      then used. Overrides the transport file's tag when both are \
      supplied. Cross-checked against `domain_def.json` when both \
-     are supplied (mismatch is an error — this is host-level \
-     identity, not just labelling).";
+     are supplied (mismatch is an error). On `nmossrc`, set before \
+     NULL\u{2192}READY; on `nmossink` it may also be set in READY \
+     for deferred sender registration.";
 
 pub(crate) const TRANSPORT_FILE_PATH_BLURB: &str =
     "Filesystem path read at NULL\u{2192}READY into `transport-file`. \
@@ -159,14 +160,13 @@ pub(crate) const DEPAY_PROPERTIES_BLURB: &str =
      logged if non-empty). Takes effect on the next chain build.";
 
 pub(crate) const AUTO_ACTIVATE_BLURB: &str =
-    "Bring the inner `mxlsink` / `mxlsrc` up immediately at \
-     NULL\u{2192}READY (or, for deferred-mode senders, READY\u{2192}PAUSED) \
-     once the configuring flow_def has been resolved, and call \
-     `SyncResourceState` on the daemon to advertise the resource as \
-     active on IS-04/IS-05 without waiting for an IS-05 PATCH. \
-     Default `false` gives canonical NMOS behaviour: the resource is \
-     registered (so it appears on IS-04) but the data path stays on \
-     the fake chain until an external IS-05 controller activates it.";
+    "When `true`, swap in the real transport sink or source (instead of the \
+     fake chain) once the configuring transport file has been resolved at \
+     NULL\u{2192}READY (or READY\u{2192}PAUSED for deferred senders), and call \
+     `SyncResourceState` so IS-04/IS-05 show active without an IS-05 PATCH. \
+     Does not force PLAYING — child state still follows the bin. Default \
+     `false`: register on IS-04 but keep the fake chain until an external \
+     IS-05 controller activates the resource.";
 
 /// Snapshot of the properties needed to open a session, taken under
 /// the per-element settings lock so the lock isn't held over the
@@ -195,7 +195,7 @@ pub(crate) struct CommonSettings {
     /// `by_name` index by `(node_seed, side, name)` and the activation
     /// callback surfaces the side alongside the name.
     pub(crate) name: String,
-    /// MXL Domain identifier (UUID) advertised in NMOS via
+    /// MXL Domain identifier (UUID) included as
     /// `urn:x-nvnmos:tag:mxl-domain-id` in the flow_def. If
     /// `mxl_domain_path` is also set and contains a `domain_def.json`
     /// (AMWA BCP-007-03 WIP), the file's `id` is cross-checked


### PR DESCRIPTION
Remove `mutable_ready()` from open-session and nmossrc add-resource properties so pspec flags match when each value is actually read. Keep `mutable_ready()` on nmossink add-resource props (including deferred MXL registration) and inner-build bags; document the audit and clarify that `auto-activate` gates real vs fake inner chains, not PLAYING.