### PR TITLE
nvnmosd: implicit CloseSession when clients abandon sessions

### DIFF
--- a/doc/designs/nvnmosd/README.md
+++ b/doc/designs/nvnmosd/README.md
@@ -214,6 +214,28 @@ When trim is enabled, the daemon calls `malloc_trim` after `RemoveResource`, `Cl
 
 `malloc_trim` can briefly contend on glibc allocator locks (other threads may hitch) but does not hold the daemon mutex.
 
+#### Session liveness (implicit `CloseSession`)
+
+Abandoned sessions (client crash, lost gRPC connection, forgot to call
+`CloseSession`) would otherwise hold sender/receiver names and node refcounts
+indefinitely. When session GC is enabled, the daemon runs the same teardown as
+an explicit `CloseSession` if activation subscription deadlines are missed.
+Implementation lives in
+[`rust/nvnmosd/src/session_gc.rs`](../../../rust/nvnmosd/src/session_gc.rs).
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `NVNMOSD_SESSION_GC` | on (unset = enabled) | Set to `0`, `false`, `off`, or `no` to disable implicit `CloseSession`. |
+| `NVNMOSD_SESSION_SUBSCRIBE_TIMEOUT_SEC` | 60 | After `OpenSession`, the client must call `SubscribeActivations` within this many **seconds** (before `AddSender` / `AddReceiver`). |
+| `NVNMOSD_SESSION_RESUBSCRIBE_TIMEOUT_SEC` | 5 | After the activation subscription stream ends, the client must call `SubscribeActivations` again within this many **seconds**. |
+
+When GC is enabled, `AddSender` and `AddReceiver` return `FAILED_PRECONDITION`
+if the session has no live `SubscribeActivations` stream. After an implicit
+close, RPCs with the old session handle return `NOT_FOUND`.
+
+The resubscribe timeout is intentionally short so crashed clients release
+resource names quickly; it is independent of NMOS Registry GC intervals.
+
 ## Element design
 
 ### Pad config
@@ -484,7 +506,7 @@ A `timestamp-mode` property (passthrough vs. regenerated wire timestamps) was sk
 
 - **Connection API responsiveness**: slow elements stall PATCH responses. Mitigation: tight default `AckActivation` timeout; document the failure mode.
 - **Daemon discovery**: `daemon-uri` property with a sensible default. Document; don't auto-spawn.
-- **Daemon reconnect / session liveness**: clients must call `CloseSession` on teardown; there is no GC today. Aspirational: durable `session_handle` across client reconnect and daemon restart with TTL.
+- **Daemon reconnect / session liveness**: clients should call `CloseSession` on clean teardown; session GC (see above) closes orphaned sessions when subscription deadlines are missed (`NVNMOSD_SESSION_GC`, on by default). Aspirational: durable `session_handle` across client reconnect and daemon restart with TTL.
 - **Inner-sink state under gating**: the originally-planned `output-selector` pattern removes the inner sink from the data path on deactivation. We still need to confirm per-transport that `nvdsudpsink`/`mxlsink` cleanly handle being de-pathed at runtime; if either disagrees, fall back to keeping it on the path with `fakesink sync=true async=false` *downstream* of the inner sink instead of *replacing* it (slightly more expensive, more conservative). (Phase 1 update: the as-built mechanism tears down and rebuilds the inner sink across activations rather than de-pathing it; this has been validated against `mxlsink`. Phase 2 must still validate the same against `nvdsudpsink`. See [*Phase 1 as-built: anchor + block-probe*](#phase-1-as-built-anchor--block-probe).)
 - **Cross-platform paths**: UDS on Linux/macOS, named pipe on Windows, TCP fallback. gRPC supports all three.
 - **NvNmos C-API thread safety**: confirmed thread-safe — every state mutation in `nvnmos_impl.cpp` takes `model.write_lock()` before touching the nmos-cpp model. The daemon can call NvNmos from any worker thread; no daemon-side serialisation needed.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1259,9 +1259,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "hyper-util",
  "libc",
  "nvnmos",
  "nvnmos-rpc",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/rust/nvnmos-rpc/proto/nvnmosd.proto
+++ b/rust/nvnmos-rpc/proto/nvnmosd.proto
@@ -63,6 +63,16 @@ service NvnmosDaemon {
   // Tears down the backing Node if the session was the last attached
   // *and* the Node is session-refcounted (i.e. was not created by
   // `AddNode`).
+  //
+  // The daemon may also close a session implicitly when session GC is
+  // enabled (`NVNMOSD_SESSION_GC`, on by default): if
+  // `SubscribeActivations` is not called within
+  // `NVNMOSD_SESSION_SUBSCRIBE_TIMEOUT_SEC` (default 60) of
+  // `OpenSession`, or not called again within
+  // `NVNMOSD_SESSION_RESUBSCRIBE_TIMEOUT_SEC` (default 5) after the
+  // previous activation stream ends. Implicit close uses the same
+  // teardown as this RPC; subsequent RPCs with the old session handle
+  // return `NOT_FOUND`.
   rpc CloseSession(CloseSessionRequest) returns (Empty);
 
   // -------- Resource lifecycle --------
@@ -86,6 +96,9 @@ service NvnmosDaemon {
   // NMOS `/senders/<id>` or `/receivers/<id>` UUID is returned in
   // `resource_id` for the client's convenience (e.g. cross-referencing
   // with controller logs).
+  //
+  // Requires an active `SubscribeActivations` stream on the session;
+  // otherwise `FAILED_PRECONDITION`.
 
   rpc AddSender(AddSenderRequest) returns (AddResourceResponse);
   rpc AddReceiver(AddReceiverRequest) returns (AddResourceResponse);
@@ -99,6 +112,11 @@ service NvnmosDaemon {
   // resources; the client applies (or refuses) it locally and replies
   // with `AckActivation`. The IS-05 controller's request remains
   // pending until the ack arrives.
+  //
+  // Must be called promptly after `OpenSession` (before `AddSender` /
+  // `AddReceiver`) and again within the resubscribe timeout after any
+  // prior activation stream ends. See `CloseSession` for the implicit
+  // teardown policy when these deadlines are missed.
   rpc SubscribeActivations(SubscribeActivationsRequest) returns (stream ActivationEvent);
 
   // Required after each `ActivationEvent`. The success/failure outcome

--- a/rust/nvnmosd/Cargo.toml
+++ b/rust/nvnmosd/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 nvnmos = { path = "../nvnmos" }
 nvnmos-rpc = { path = "../nvnmos-rpc" }
 
-tokio.workspace = true
+tokio = { workspace = true, features = ["time"] }
 tokio-stream.workspace = true
 tonic.workspace = true
 tower.workspace = true
@@ -35,3 +35,12 @@ tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+hyper-util = { workspace = true }
+nvnmos-rpc = { path = "../nvnmos-rpc" }
+tempfile = { workspace = true }
+tonic.workspace = true
+tokio = { workspace = true, features = ["time"] }
+tower.workspace = true
+

--- a/rust/nvnmosd/src/env_config.rs
+++ b/rust/nvnmosd/src/env_config.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parsing helpers for `NVNMOSD_*` environment variables.
+//!
+//! Boolean knobs use a small token vocabulary shared across the daemon:
+//!
+//! * [`EnvDefault::OptOut`] — unset → **on**; `0` / `false` / `off` / `no` → **off**;
+//!   anything else → **on** (`NVNMOSD_MALLOC_TRIM`, `NVNMOSD_SESSION_GC`).
+//! * [`EnvDefault::OptIn`] — unset → **off**; `1` / `true` / `yes` / `on` → **on**;
+//!   anything else → **off** (`NVNMOSD_MALLOC_INFO`).
+
+use std::time::Duration;
+
+const ENABLE_TOKENS: &[&str] = &["1", "true", "TRUE", "yes", "YES", "on", "ON"];
+const DISABLE_TOKENS: &[&str] = &["0", "false", "FALSE", "off", "OFF", "no", "NO"];
+
+/// Default when an environment variable is unset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnvDefault {
+    /// Unset → enabled; known disable tokens → disabled; anything else → enabled.
+    OptOut,
+    /// Unset → disabled; known enable tokens → enabled; anything else → disabled.
+    OptIn,
+}
+
+/// Read `name` from the process environment and parse it with [`parse_env_bool`].
+pub(crate) fn read_env_bool(name: &str, default: EnvDefault) -> bool {
+    parse_env_bool(
+        std::env::var(name)
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        default,
+    )
+}
+
+/// Parse a boolean environment value. `None` means the variable was unset.
+pub(crate) fn parse_env_bool(value: Option<&str>, default: EnvDefault) -> bool {
+    match value {
+        None => matches!(default, EnvDefault::OptOut),
+        Some(value) => match default {
+            EnvDefault::OptOut => !DISABLE_TOKENS.contains(&value),
+            EnvDefault::OptIn => ENABLE_TOKENS.contains(&value),
+        },
+    }
+}
+
+/// Read a positive timeout in **seconds** from `name`, falling back to `default_secs`
+/// when unset or invalid (logs a warning for invalid non-empty values).
+pub(crate) fn read_timeout_secs(name: &str, default_secs: u64) -> Duration {
+    match std::env::var(name) {
+        Err(_) => Duration::from_secs(default_secs),
+        Ok(value) => match parse_timeout_secs(value.trim()) {
+            Some(duration) => duration,
+            None => {
+                tracing::warn!(
+                    env = name,
+                    value = value.trim(),
+                    default = default_secs,
+                    "invalid timeout; using default"
+                );
+                Duration::from_secs(default_secs)
+            }
+        },
+    }
+}
+
+/// Parse a timeout in **seconds**. Returns `None` for zero and non-numeric values.
+pub(crate) fn parse_timeout_secs(value: &str) -> Option<Duration> {
+    match value.parse::<u64>() {
+        Ok(0) => None,
+        Ok(secs) => Some(Duration::from_secs(secs)),
+        Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opt_out_unset_is_true() {
+        assert!(parse_env_bool(None, EnvDefault::OptOut));
+    }
+
+    #[test]
+    fn opt_out_disable_tokens() {
+        for token in ["0", "false", "FALSE", "off", "OFF", "no", "NO"] {
+            assert!(
+                !parse_env_bool(Some(token), EnvDefault::OptOut),
+                "token {token:?} should disable"
+            );
+        }
+    }
+
+    #[test]
+    fn opt_out_other_values_enable() {
+        for token in ["1", "true", "yes", "on", "maybe", ""] {
+            assert!(
+                parse_env_bool(Some(token), EnvDefault::OptOut),
+                "token {token:?} should enable"
+            );
+        }
+    }
+
+    #[test]
+    fn opt_in_unset_is_false() {
+        assert!(!parse_env_bool(None, EnvDefault::OptIn));
+    }
+
+    #[test]
+    fn opt_in_enable_tokens() {
+        for token in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
+            assert!(
+                parse_env_bool(Some(token), EnvDefault::OptIn),
+                "token {token:?} should enable"
+            );
+        }
+    }
+
+    #[test]
+    fn opt_in_other_values_disable() {
+        for token in ["0", "false", "maybe", ""] {
+            assert!(
+                !parse_env_bool(Some(token), EnvDefault::OptIn),
+                "token {token:?} should disable"
+            );
+        }
+    }
+
+    #[test]
+    fn timeout_parses_seconds() {
+        assert_eq!(parse_timeout_secs("30"), Some(Duration::from_secs(30)));
+    }
+
+    #[test]
+    fn timeout_rejects_zero_and_garbage() {
+        assert_eq!(parse_timeout_secs("0"), None);
+        assert_eq!(parse_timeout_secs("nope"), None);
+    }
+}

--- a/rust/nvnmosd/src/lib.rs
+++ b/rust/nvnmosd/src/lib.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Library surface for unit tests. The `nvnmosd` binary adds the gRPC
-//! service and NvNmos integration in `main.rs`.
+//! Minimal library surface for in-crate tests. The `nvnmosd` binary implements
+//! the gRPC service in `main.rs` (with its own private `mod` tree).
 
 pub mod uds;

--- a/rust/nvnmosd/src/main.rs
+++ b/rust/nvnmosd/src/main.rs
@@ -19,13 +19,17 @@
 // uniformly allow the lint at the crate root instead.
 #![allow(clippy::result_large_err)]
 
+mod env_config;
 mod log_bridge;
 mod malloc_trim;
+mod session_gc;
 mod state;
 
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
+use std::task::{Context as TaskContext, Poll};
 
 use anyhow::Context;
 use clap::Parser;
@@ -40,8 +44,10 @@ use nvnmos_rpc::v1::{
 use tokio::net::UnixListener;
 use tokio::sync::mpsc as tokio_mpsc;
 use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
+use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 
+use crate::session_gc::SessionGc;
 use crate::state::{AckOutcome, ActivationDispatch, Side, State};
 
 /// Bound on the per-session activations stream. Small because activations
@@ -63,13 +69,14 @@ struct Args {
 
 struct Daemon {
     state: Arc<Mutex<State>>,
+    session_gc: SessionGc,
 }
 
 impl Daemon {
     fn new() -> Self {
-        Self {
-            state: Arc::new(Mutex::new(State::new())),
-        }
+        let state = Arc::new(Mutex::new(State::new()));
+        let session_gc = SessionGc::new(state.clone());
+        Self { state, session_gc }
     }
 
     fn lock_state(&self) -> std::sync::MutexGuard<'_, State> {
@@ -78,22 +85,6 @@ impl Daemon {
         // no useful recovery and silently continuing risks compounding the
         // inconsistency that triggered the original panic.
         self.state.lock().expect("daemon state mutex poisoned")
-    }
-
-    /// Trim when a node was removed or has no senders/receivers left.
-    fn maybe_malloc_trim(&self, node_seed: &str, via: &'static str, node_removed: bool) {
-        if !malloc_trim::trim_enabled() {
-            return;
-        }
-        let should_trim = if node_removed {
-            true
-        } else {
-            let state = self.lock_state();
-            state.resource_count_for_node(node_seed) == 0
-        };
-        if should_trim {
-            malloc_trim::run(via, node_seed);
-        }
     }
 }
 
@@ -131,14 +122,15 @@ impl NvnmosDaemon for Daemon {
         let req = request.into_inner();
         let outcome = {
             let mut state = self.lock_state();
-            state.remove_node(&req.node_seed)?
+            let outcome = state.remove_node(&req.node_seed)?;
+            malloc_trim::maybe_after_remove_node(&state, &req.node_seed);
+            outcome
         };
         tracing::info!(
             node_seed = %req.node_seed,
             node_id = %outcome.node_id,
             "RemoveNode",
         );
-        self.maybe_malloc_trim(&req.node_seed, "remove_node", true);
         Ok(Response::new(Empty {}))
     }
 
@@ -165,6 +157,8 @@ impl NvnmosDaemon for Daemon {
                 build_node_server(&config, state_for_callback, seed_for_callback)
             })?
         };
+        self.session_gc
+            .start_subscribe_timeout(&outcome.session_handle);
 
         tracing::info!(
             node_seed = %seed,
@@ -186,9 +180,12 @@ impl NvnmosDaemon for Daemon {
         request: Request<CloseSessionRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
+        self.session_gc.cancel_timeout(&req.session_handle);
         let outcome = {
             let mut state = self.lock_state();
-            state.close_session(&req.session_handle)?
+            let outcome = state.close_session(&req.session_handle)?;
+            malloc_trim::maybe_after_close_session(&state, &outcome);
+            outcome
         };
         tracing::info!(
             session_handle = %req.session_handle,
@@ -199,7 +196,6 @@ impl NvnmosDaemon for Daemon {
             node_destroyed = outcome.node_destroyed,
             "CloseSession",
         );
-        self.maybe_malloc_trim(&outcome.node_seed, "close_session", outcome.node_destroyed);
         Ok(Response::new(Empty {}))
     }
 
@@ -270,7 +266,10 @@ impl NvnmosDaemon for Daemon {
         let req = request.into_inner();
         let outcome = {
             let mut state = self.lock_state();
-            state.remove_resource(&req.session_handle, &req.resource_handle)?
+            let outcome =
+                state.remove_resource(&req.session_handle, &req.resource_handle)?;
+            malloc_trim::maybe_after_remove_resource(&state, &outcome.node_seed);
+            outcome
         };
         tracing::info!(
             session_handle = %req.session_handle,
@@ -280,11 +279,10 @@ impl NvnmosDaemon for Daemon {
             side = outcome.side.label(),
             "RemoveResource",
         );
-        self.maybe_malloc_trim(&outcome.node_seed, "remove_resource", false);
         Ok(Response::new(Empty {}))
     }
 
-    type SubscribeActivationsStream = ReceiverStream<Result<ActivationEvent, Status>>;
+    type SubscribeActivationsStream = SubscriptionStream;
 
     async fn subscribe_activations(
         &self,
@@ -295,12 +293,19 @@ impl NvnmosDaemon for Daemon {
         {
             let mut state = self.lock_state();
             state.subscribe_activations(&req.session_handle, tx)?;
+            self.session_gc.cancel_timeout(&req.session_handle);
         }
         tracing::info!(
             session_handle = %req.session_handle,
             "SubscribeActivations",
         );
-        Ok(Response::new(ReceiverStream::new(rx)))
+        let stream = SubscriptionStream {
+            inner: ReceiverStream::new(rx),
+            session_handle: req.session_handle,
+            state: self.state.clone(),
+            session_gc: self.session_gc.clone(),
+        };
+        Ok(Response::new(stream))
     }
 
     async fn ack_activation(
@@ -351,6 +356,40 @@ impl NvnmosDaemon for Daemon {
             "SyncResourceState",
         );
         Ok(Response::new(Empty {}))
+    }
+}
+
+/// Server-streaming wrapper that arms the resubscribe watchdog when the
+/// client drops the `SubscribeActivations` stream.
+struct SubscriptionStream {
+    inner: ReceiverStream<Result<ActivationEvent, Status>>,
+    session_handle: String,
+    state: Arc<Mutex<State>>,
+    session_gc: SessionGc,
+}
+
+impl Stream for SubscriptionStream {
+    type Item = Result<ActivationEvent, Status>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl Drop for SubscriptionStream {
+    fn drop(&mut self) {
+        let session_handle = self.session_handle.clone();
+        let state = self.state.clone();
+        let session_gc = self.session_gc.clone();
+        tokio::spawn(async move {
+            let arm = {
+                let mut guard = state.lock().expect("daemon state mutex poisoned");
+                guard.on_subscription_stream_ended(&session_handle)
+            };
+            if arm {
+                session_gc.start_resubscribe_timeout(&session_handle);
+            }
+        });
     }
 }
 

--- a/rust/nvnmosd/src/malloc_trim.rs
+++ b/rust/nvnmosd/src/malloc_trim.rs
@@ -8,39 +8,48 @@
 
 use std::sync::OnceLock;
 
-const ENABLE_TOKENS: &[&str] = &["1", "true", "TRUE", "yes", "YES", "on", "ON"];
-const DISABLE_TOKENS: &[&str] = &["0", "false", "FALSE", "off", "OFF", "no", "NO"];
-
-/// How an env var is interpreted when unset vs when set to a known token.
-enum EnvDefault {
-    /// Unset → enabled; known disable tokens → disabled; anything else → enabled.
-    OptOut,
-    /// Unset → disabled; known enable tokens → enabled; anything else → disabled.
-    OptIn,
-}
-
-fn read_env_bool(name: &str, default: EnvDefault) -> bool {
-    match std::env::var(name) {
-        Ok(value) => {
-            let value = value.trim();
-            match default {
-                EnvDefault::OptOut => !DISABLE_TOKENS.contains(&value),
-                EnvDefault::OptIn => ENABLE_TOKENS.contains(&value),
-            }
-        }
-        Err(_) => matches!(default, EnvDefault::OptOut),
-    }
-}
+use crate::env_config::{self, EnvDefault};
+use crate::state::{CloseOutcome, State};
 
 /// True unless `NVNMOSD_MALLOC_TRIM` is set to a disabling value (`0`, `false`, `off`, `no`).
 pub fn trim_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| read_env_bool("NVNMOSD_MALLOC_TRIM", EnvDefault::OptOut))
+    *ENABLED.get_or_init(|| env_config::read_env_bool("NVNMOSD_MALLOC_TRIM", EnvDefault::OptOut))
 }
 
 fn info_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| read_env_bool("NVNMOSD_MALLOC_INFO", EnvDefault::OptIn))
+    *ENABLED.get_or_init(|| env_config::read_env_bool("NVNMOSD_MALLOC_INFO", EnvDefault::OptIn))
+}
+
+/// After [`State::close_session`] (explicit RPC or session GC).
+pub fn maybe_after_close_session(state: &State, outcome: &CloseOutcome) {
+    maybe_trim(
+        state,
+        &outcome.node_seed,
+        "close_session",
+        outcome.node_destroyed,
+    );
+}
+
+/// After [`State::remove_resource`].
+pub fn maybe_after_remove_resource(state: &State, node_seed: &str) {
+    maybe_trim(state, node_seed, "remove_resource", false);
+}
+
+/// After [`State::remove_node`].
+pub fn maybe_after_remove_node(state: &State, node_seed: &str) {
+    maybe_trim(state, node_seed, "remove_node", true);
+}
+
+fn maybe_trim(state: &State, node_seed: &str, via: &'static str, node_removed: bool) {
+    if !trim_enabled() {
+        return;
+    }
+    let should_trim = node_removed || state.resource_count_for_node(node_seed) == 0;
+    if should_trim {
+        run(via, node_seed);
+    }
 }
 
 /// Run `malloc_trim` when enabled. `via` names the RPC that triggered the check

--- a/rust/nvnmosd/src/session_gc.rs
+++ b/rust/nvnmosd/src/session_gc.rs
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implicit [`State::close_session`] when clients abandon a session.
+//!
+//! One watchdog per session; two configured durations (`T_subscribe` after
+//! `OpenSession`, `T_resubscribe` after the activation stream ends).
+//! [`SessionGc::cancel_timeout`] runs synchronously on successful
+//! `SubscribeActivations`; re-check for a live subscription before closing
+//! when the watchdog fires.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::task::AbortHandle;
+
+use crate::env_config::{self, EnvDefault};
+use crate::malloc_trim;
+use crate::state::State;
+
+const DEFAULT_SUBSCRIBE_TIMEOUT_SEC: u64 = 60;
+const DEFAULT_RESUBSCRIBE_TIMEOUT_SEC: u64 = 5;
+
+/// Session GC configuration read once at daemon startup.
+#[derive(Debug, Clone)]
+pub struct SessionGcConfig {
+    pub enabled: bool,
+    pub subscribe_timeout: Duration,
+    pub resubscribe_timeout: Duration,
+}
+
+impl SessionGcConfig {
+    pub fn from_env() -> Self {
+        let enabled = env_config::read_env_bool("NVNMOSD_SESSION_GC", EnvDefault::OptOut);
+        let subscribe_timeout = env_config::read_timeout_secs(
+            "NVNMOSD_SESSION_SUBSCRIBE_TIMEOUT_SEC",
+            DEFAULT_SUBSCRIBE_TIMEOUT_SEC,
+        );
+        let resubscribe_timeout = env_config::read_timeout_secs(
+            "NVNMOSD_SESSION_RESUBSCRIBE_TIMEOUT_SEC",
+            DEFAULT_RESUBSCRIBE_TIMEOUT_SEC,
+        );
+        Self {
+            enabled,
+            subscribe_timeout,
+            resubscribe_timeout,
+        }
+    }
+
+    pub fn log_effective(&self) {
+        tracing::info!(
+            enabled = self.enabled,
+            subscribe_timeout_sec = self.subscribe_timeout.as_secs(),
+            resubscribe_timeout_sec = self.resubscribe_timeout.as_secs(),
+            "session GC configuration"
+        );
+    }
+}
+
+/// Per-session watchdog scheduler.
+#[derive(Clone)]
+pub struct SessionGc {
+    config: SessionGcConfig,
+    state: Arc<Mutex<State>>,
+    watchdogs: Arc<Mutex<HashMap<String, AbortHandle>>>,
+}
+
+impl SessionGc {
+    pub fn new(state: Arc<Mutex<State>>) -> Self {
+        let config = SessionGcConfig::from_env();
+        config.log_effective();
+        Self {
+            config,
+            state,
+            watchdogs: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn cancel_timeout(&self, session_handle: &str) {
+        if let Some(handle) = self.watchdogs.lock().expect("watchdog mutex poisoned").remove(session_handle)
+        {
+            handle.abort();
+        }
+    }
+
+    pub fn start_subscribe_timeout(&self, session_handle: &str) {
+        self.start_timeout(session_handle, self.config.subscribe_timeout);
+    }
+
+    pub fn start_resubscribe_timeout(&self, session_handle: &str) {
+        self.start_timeout(session_handle, self.config.resubscribe_timeout);
+    }
+
+    fn start_timeout(&self, session_handle: &str, timeout: Duration) {
+        if !self.config.enabled {
+            return;
+        }
+        self.cancel_timeout(session_handle);
+        let state = self.state.clone();
+        let handle = session_handle.to_string();
+        let watchdogs = self.watchdogs.clone();
+        let join = tokio::spawn(async move {
+            tokio::time::sleep(timeout).await;
+            let outcome = {
+                let mut guard = state.lock().expect("daemon state mutex poisoned");
+                if !guard.sessions_contains(&handle) {
+                    return;
+                }
+                if guard.has_active_subscription(&handle) {
+                    return;
+                }
+                let outcome = match guard.close_session(&handle) {
+                    Ok(outcome) => outcome,
+                    Err(_) => return,
+                };
+                malloc_trim::maybe_after_close_session(&guard, &outcome);
+                outcome
+            };
+            tracing::info!(
+                session_handle = %handle,
+                node_seed = %outcome.node_seed,
+                node_id = %outcome.node_id,
+                lifetime = outcome.lifetime.label(),
+                remaining_sessions = outcome.remaining_sessions,
+                node_destroyed = outcome.node_destroyed,
+                implicit = true,
+                "CloseSession",
+            );
+            let _ = watchdogs.lock().expect("watchdog mutex poisoned").remove(&handle);
+        });
+        self.watchdogs
+            .lock()
+            .expect("watchdog mutex poisoned")
+            .insert(session_handle.to_string(), join.abort_handle());
+    }
+}

--- a/rust/nvnmosd/src/state.rs
+++ b/rust/nvnmosd/src/state.rs
@@ -735,6 +735,13 @@ impl State {
             return Err(Status::invalid_argument("name must be non-empty"));
         }
 
+        self.reap_closed_subscription(session_handle);
+        if !self.has_active_subscription(session_handle) {
+            return Err(Status::failed_precondition(
+                "SubscribeActivations required before adding a resource",
+            ));
+        }
+
         let session = self.sessions.get(session_handle).ok_or_else(|| {
             Status::not_found(format!(
                 "session_handle {session_handle:?} is not known to this daemon"
@@ -974,6 +981,39 @@ impl State {
         self.subscriptions
             .insert(session_handle.to_string(), ActivationSubscriber { tx });
         Ok(())
+    }
+
+    /// True when `session_handle` has a `SubscribeActivations` slot whose
+    /// receiver is still connected.
+    pub fn has_active_subscription(&self, session_handle: &str) -> bool {
+        self.subscriptions
+            .get(session_handle)
+            .is_some_and(|s| !s.tx.is_closed())
+    }
+
+    /// Remove a subscription entry whose receiver has been dropped.
+    pub fn reap_closed_subscription(&mut self, session_handle: &str) {
+        if self
+            .subscriptions
+            .get(session_handle)
+            .is_some_and(|s| s.tx.is_closed())
+        {
+            self.subscriptions.remove(session_handle);
+        }
+    }
+
+    /// Called when a `SubscribeActivations` server stream is dropped.
+    /// Returns `true` when the session still exists and has no live
+    /// subscription (caller should arm the resubscribe watchdog).
+    pub fn on_subscription_stream_ended(&mut self, session_handle: &str) -> bool {
+        self.reap_closed_subscription(session_handle);
+        self.sessions.contains_key(session_handle)
+            && !self.has_active_subscription(session_handle)
+    }
+
+    /// Whether `session_handle` is still open.
+    pub fn sessions_contains(&self, session_handle: &str) -> bool {
+        self.sessions.contains_key(session_handle)
     }
 
     /// Activation router — called synchronously from a libnvnmos worker

--- a/rust/nvnmosd/tests/session_gc.rs
+++ b/rust/nvnmosd/tests/session_gc.rs
@@ -1,0 +1,419 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for implicit `CloseSession` (session GC).
+
+use std::net::UdpSocket;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use hyper_util::rt::TokioIo;
+use nvnmos_rpc::v1::nvnmos_daemon_client::NvnmosDaemonClient;
+use nvnmos_rpc::v1::{
+    AddSenderRequest, CloseSessionRequest, NodeConfig, OpenSessionRequest, RemoveResourceRequest,
+    SubscribeActivationsRequest, Transport as ProtoTransport,
+};
+use tempfile::TempDir;
+use tokio::net::UnixStream;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tonic::Code;
+use tower::service_fn;
+
+struct DaemonHarness {
+    _dir: TempDir,
+    uds: PathBuf,
+    child: Child,
+}
+
+impl DaemonHarness {
+    fn spawn(subscribe_sec: u64, resubscribe_sec: u64) -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let uds = dir.path().join("nvnmosd.sock");
+        nvnmosd::uds::prepare_listen_path(&uds).expect("prepare UDS path");
+        let bin = env!("CARGO_BIN_EXE_nvnmosd");
+        let lib_dir = find_libnvnmos_dir();
+        let ld_library_path = prepend_ld_library_path(&lib_dir);
+        let child = Command::new(bin)
+            .arg("--uds")
+            .arg(&uds)
+            .env("NVNMOSD_SESSION_GC", "1")
+            .env(
+                "NVNMOSD_SESSION_SUBSCRIBE_TIMEOUT_SEC",
+                subscribe_sec.to_string(),
+            )
+            .env(
+                "NVNMOSD_SESSION_RESUBSCRIBE_TIMEOUT_SEC",
+                resubscribe_sec.to_string(),
+            )
+            .env("NVNMOSD_MALLOC_TRIM", "0")
+            .env("RUST_LOG", "error")
+            .env("LD_LIBRARY_PATH", &ld_library_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn nvnmosd");
+        Self {
+            _dir: dir,
+            uds,
+            child,
+        }
+    }
+
+    async fn ready(&mut self) {
+        wait_for_daemon(&self.uds, &mut self.child).await;
+    }
+}
+
+/// Directory containing `libnvnmos.so` for the spawned child process.
+fn find_libnvnmos_dir() -> String {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(dir) = std::env::var("NVNMOS_LIB_DIR") {
+        candidates.push(PathBuf::from(dir));
+    }
+    candidates.push(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../build"),
+    );
+    if let Ok(cwd) = std::env::current_dir() {
+        candidates.push(cwd.join("../build"));
+        candidates.push(cwd.join("build"));
+    }
+
+    for candidate in candidates {
+        if let Some(abs) = absolutize_lib_dir(&candidate) {
+            return abs;
+        }
+    }
+
+    panic!(
+        "could not find libnvnmos.so; build the C++ library (cmake --build build) \
+         or set NVNMOS_LIB_DIR to the directory containing libnvnmos.so"
+    );
+}
+
+fn absolutize_lib_dir(path: &Path) -> Option<String> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    let abs = abs.canonicalize().ok()?;
+    if abs.join("libnvnmos.so").is_file() {
+        Some(abs.to_string_lossy().into_owned())
+    } else {
+        None
+    }
+}
+
+fn prepend_ld_library_path(dir: &str) -> String {
+    match std::env::var("LD_LIBRARY_PATH") {
+        Ok(existing) if !existing.is_empty() => format!("{dir}:{existing}"),
+        _ => dir.to_string(),
+    }
+}
+
+fn child_stderr(child: &mut Child) -> String {
+    use std::io::Read;
+    child
+        .stderr
+        .take()
+        .and_then(|mut stderr| {
+            let mut buf = String::new();
+            stderr.read_to_string(&mut buf).ok()?;
+            Some(buf)
+        })
+        .unwrap_or_default()
+}
+
+impl Drop for DaemonHarness {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+async fn wait_for_daemon(uds: &Path, child: &mut Child) {
+    for _ in 0..200 {
+        if let Ok(Some(status)) = child.try_wait() {
+            let stderr = child_stderr(child);
+            panic!(
+                "nvnmosd exited before binding UDS (status={status}); \
+                 ensure libnvnmos.so is in LD_LIBRARY_PATH (build the C++ \
+                 library under ../../build or set NVNMOS_LIB_DIR). stderr:\n{stderr}"
+            );
+        }
+        if UnixStream::connect(uds).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let stderr = child_stderr(child);
+    panic!(
+        "nvnmosd did not become ready on {}; stderr:\n{stderr}",
+        uds.display()
+    );
+}
+
+async fn connect(uds: &Path) -> NvnmosDaemonClient<Channel> {
+    let uds = uds.to_path_buf();
+    let endpoint = Endpoint::try_from("http://[::1]:50051").expect("endpoint uri");
+    let channel = endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let uds = uds.clone();
+            async move {
+                let stream = UnixStream::connect(uds).await?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await
+        .expect("connect UDS");
+    NvnmosDaemonClient::new(channel)
+}
+
+fn autodetect_iface_ip() -> String {
+    let sock = match UdpSocket::bind("0.0.0.0:0") {
+        Ok(sock) => sock,
+        Err(_) => return "127.0.0.1".to_string(),
+    };
+    if sock.connect("8.8.8.8:80").is_err() {
+        return "127.0.0.1".to_string();
+    }
+    sock.local_addr()
+        .map(|a| a.ip().to_string())
+        .unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+fn minimal_sender_sdp(name: &str, iface_ip: &str) -> String {
+    format!(
+        "v=0\r\n\
+         o=- 0 0 IN IP4 {iface_ip}\r\n\
+         s=session-gc-test\r\n\
+         t=0 0\r\n\
+         a=x-nvnmos-name:{name}\r\n\
+         m=video 5020 RTP/AVP 96\r\n\
+         c=IN IP4 233.252.0.0/64\r\n\
+         a=source-filter: incl IN IP4 233.252.0.0 {iface_ip}\r\n\
+         a=x-nvnmos-iface-ip:{iface_ip}\r\n\
+         a=rtpmap:96 raw/90000\r\n\
+         a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; \
+         exactframerate=50; depth=10; TCS=SDR; colorimetry=BT709; \
+         PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN;\r\n\
+         a=mediaclk:direct=0\r\n\
+         a=x-nvnmos-src-port:5004\r\n\
+         a=ts-refclk:localmac=CA-FE-01-CA-FE-02\r\n"
+    )
+}
+
+async fn open_session(client: &mut NvnmosDaemonClient<Channel>, seed: &str) -> String {
+    client
+        .open_session(OpenSessionRequest {
+            node_config: Some(NodeConfig {
+                seed: seed.to_string(),
+                http_port: 18_010,
+                ..Default::default()
+            }),
+        })
+        .await
+        .expect("OpenSession")
+        .into_inner()
+        .session_handle
+}
+
+fn expect_code(err: tonic::Status, expected: Code) {
+    assert_eq!(
+        err.code(),
+        expected,
+        "unexpected gRPC status: {err}"
+    );
+}
+
+/// Case A — subscribe before add.
+#[tokio::test]
+async fn subscribe_required_before_add() {
+    let mut harness = DaemonHarness::spawn(5, 2);
+    harness.ready().await;
+    let mut client = connect(&harness.uds).await;
+    let seed = "session-gc-a";
+    let iface = autodetect_iface_ip();
+    let session = open_session(&mut client, seed).await;
+
+    let err = client
+        .add_sender(AddSenderRequest {
+            session_handle: session.clone(),
+            name: "sender-a".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: minimal_sender_sdp("sender-a", &iface),
+        })
+        .await
+        .expect_err("AddSender without subscribe");
+    expect_code(err, Code::FailedPrecondition);
+
+    let _sub = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session.clone(),
+        })
+        .await
+        .expect("SubscribeActivations")
+        .into_inner();
+
+    client
+        .add_sender(AddSenderRequest {
+            session_handle: session.clone(),
+            name: "sender-a".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: minimal_sender_sdp("sender-a", &iface),
+        })
+        .await
+        .expect("AddSender after subscribe");
+
+    let _ = client
+        .close_session(CloseSessionRequest {
+            session_handle: session,
+        })
+        .await;
+}
+
+/// Case B — resubscribe within timeout; watchdog cancelled while stream open.
+#[tokio::test]
+async fn resubscribe_cancels_watchdog() {
+    let mut harness = DaemonHarness::spawn(5, 2);
+    harness.ready().await;
+    let mut client = connect(&harness.uds).await;
+    let seed = "session-gc-b";
+    let iface = autodetect_iface_ip();
+    let session = open_session(&mut client, seed).await;
+
+    let _sub = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session.clone(),
+        })
+        .await
+        .expect("first subscribe")
+        .into_inner();
+
+    let add = client
+        .add_sender(AddSenderRequest {
+            session_handle: session.clone(),
+            name: "sender-b".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: minimal_sender_sdp("sender-b", &iface),
+        })
+        .await
+        .expect("AddSender")
+        .into_inner();
+
+    drop(_sub);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let _sub2 = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session.clone(),
+        })
+        .await
+        .expect("resubscribe")
+        .into_inner();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    client
+        .remove_resource(RemoveResourceRequest {
+            session_handle: session.clone(),
+            resource_handle: add.resource_handle,
+        })
+        .await
+        .expect("RemoveResource after long hold");
+
+    client
+        .close_session(CloseSessionRequest {
+            session_handle: session,
+        })
+        .await
+        .expect("CloseSession");
+}
+
+/// Case C — resubscribe timeout triggers implicit CloseSession.
+#[tokio::test]
+async fn resubscribe_timeout_closes_session() {
+    let mut harness = DaemonHarness::spawn(5, 2);
+    harness.ready().await;
+    let mut client = connect(&harness.uds).await;
+    let seed = "session-gc-c";
+    let iface = autodetect_iface_ip();
+    let session = open_session(&mut client, seed).await;
+
+    let _sub = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session.clone(),
+        })
+        .await
+        .expect("subscribe")
+        .into_inner();
+
+    client
+        .add_sender(AddSenderRequest {
+            session_handle: session.clone(),
+            name: "sender-c".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: minimal_sender_sdp("sender-c", &iface),
+        })
+        .await
+        .expect("AddSender");
+
+    drop(_sub);
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let err = client
+        .close_session(CloseSessionRequest {
+            session_handle: session.clone(),
+        })
+        .await
+        .expect_err("old session should be gone");
+    expect_code(err, Code::NotFound);
+
+    let session2 = open_session(&mut client, seed).await;
+    let _sub2 = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session2.clone(),
+        })
+        .await
+        .expect("subscribe on new session")
+        .into_inner();
+
+    client
+        .add_sender(AddSenderRequest {
+            session_handle: session2.clone(),
+            name: "sender-c".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: minimal_sender_sdp("sender-c", &iface),
+        })
+        .await
+        .expect("reuse name after implicit close");
+
+    let _ = client
+        .close_session(CloseSessionRequest {
+            session_handle: session2,
+        })
+        .await;
+}
+
+/// Case D — subscribe timeout after OpenSession.
+#[tokio::test]
+async fn subscribe_timeout_closes_session() {
+    let mut harness = DaemonHarness::spawn(5, 2);
+    harness.ready().await;
+    let mut client = connect(&harness.uds).await;
+    let seed = "session-gc-d";
+    let session = open_session(&mut client, seed).await;
+
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    let err = client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session.clone(),
+        })
+        .await
+        .expect_err("session should be gone");
+    expect_code(err, Code::NotFound);
+
+    open_session(&mut client, seed).await;
+}


### PR DESCRIPTION
Add per-session watchdog timers (subscribe and resubscribe deadlines) so orphaned sessions are torn down like an explicit CloseSession. Require SubscribeActivations before AddSender/AddReceiver, document the policy in the proto, and add env-config helpers plus integration tests.