### PR TITLE
gst-nmos-rs: Allow NMOS resource name from transport-file when property unset

### DIFF
--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -153,6 +153,10 @@ Alternate caps are used by demo **Node 4** for wide-receiver reroute tests
 | Flip / process | [`1080p25-flipper-mxl.sh`](scripts/example-pipelines/1080p25-flipper-mxl.sh) | [`1080p25-flipper-udp.sh`](scripts/example-pipelines/1080p25-flipper-udp.sh) | Node 3 video |
 | Deferred sender | [`1080p25-deferred-sender-mxl.sh`](scripts/example-pipelines/1080p25-deferred-sender-mxl.sh) | [`1080p25-deferred-sender-udp.sh`](scripts/example-pipelines/1080p25-deferred-sender-udp.sh) | — |
 | Multi-flow sender | [`multi-flow-sender-mxl.sh`](scripts/example-pipelines/multi-flow-sender-mxl.sh) | [`multi-flow-sender-udp.sh`](scripts/example-pipelines/multi-flow-sender-udp.sh) | Node 1 (video + audio) |
+| Minimal sender (properties) | [`minimal-prop-sender-mxl.sh`](scripts/example-pipelines/minimal-prop-sender-mxl.sh) | [`minimal-prop-sender-udp.sh`](scripts/example-pipelines/minimal-prop-sender-udp.sh) | — |
+| Minimal receiver (properties) | [`minimal-prop-receiver-mxl.sh`](scripts/example-pipelines/minimal-prop-receiver-mxl.sh) | [`minimal-prop-receiver-udp.sh`](scripts/example-pipelines/minimal-prop-receiver-udp.sh) | — |
+| Minimal sender (transport file) | [`minimal-file-sender-mxl.sh`](scripts/example-pipelines/minimal-file-sender-mxl.sh) | [`minimal-file-sender-udp.sh`](scripts/example-pipelines/minimal-file-sender-udp.sh) | — |
+| Minimal receiver (transport file) | [`minimal-file-receiver-mxl.sh`](scripts/example-pipelines/minimal-file-receiver-mxl.sh) | [`minimal-file-receiver-udp.sh`](scripts/example-pipelines/minimal-file-receiver-udp.sh) | — |
 | Full lab + IS-05 | — | — | [`gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh) |
 
 ### 1080p25 Sender
@@ -277,6 +281,68 @@ multicast + `source-ip`).
 Expected log sequence: `no resource added` at NULL→READY, then
 `deferred AddSender complete` at READY→PAUSED (MXL synthesises `flow_def`
 JSON; UDP synthesises configuring SDP).
+
+### Minimal (controller-driven IS-05)
+
+[`minimal-prop-sender-mxl.sh`](scripts/example-pipelines/minimal-prop-sender-mxl.sh) ·
+[`minimal-prop-sender-udp.sh`](scripts/example-pipelines/minimal-prop-sender-udp.sh) ·
+[`minimal-prop-receiver-mxl.sh`](scripts/example-pipelines/minimal-prop-receiver-mxl.sh) ·
+[`minimal-prop-receiver-udp.sh`](scripts/example-pipelines/minimal-prop-receiver-udp.sh)
+
+[`minimal-file-sender-mxl.sh`](scripts/example-pipelines/minimal-file-sender-mxl.sh) ·
+[`minimal-file-sender-udp.sh`](scripts/example-pipelines/minimal-file-sender-udp.sh) ·
+[`minimal-file-receiver-mxl.sh`](scripts/example-pipelines/minimal-file-receiver-mxl.sh) ·
+[`minimal-file-receiver-udp.sh`](scripts/example-pipelines/minimal-file-receiver-udp.sh)
+
+Smallest NULL→READY AddSender / AddReceiver paths with
+`auto-activate=false`. Resources register on IS-04 at READY; the controller
+PATCHes `/single/{senders,receivers}/{id}/staged` to bring the data path
+live.
+
+**Properties-driven (`minimal-prop-*`)** — `sender-name` / `receiver-name`
+plus `caps` (and `source-ip` / `interface-ip` for RTP/UDP, or
+`mxl-domain-*` for MXL) synthesise the configuring transport at NULL→READY.
+
+**MXL:**
+
+```sh
+./scripts/example-pipelines/minimal-prop-sender-mxl.sh
+./scripts/example-pipelines/minimal-prop-receiver-mxl.sh
+```
+
+**UDP:**
+
+```sh
+./scripts/example-pipelines/minimal-prop-sender-udp.sh
+./scripts/example-pipelines/minimal-prop-receiver-udp.sh
+```
+
+**Transport-file-driven (`minimal-file-*`)** — configuring SDP / flow_def
+from [`fixtures/minimal-video.sdp.in`](scripts/example-pipelines/fixtures/minimal-video.sdp.in)
+and
+[`fixtures/minimal-video.mxl.json.in`](scripts/example-pipelines/fixtures/minimal-video.mxl.json.in)
+via `transport-file-path`. Resource name comes from the file
+(`a=x-nvnmos-name` or `urn:x-nvnmos:tag:name`); NMOS label from SDP `s=`
+or flow_def `label`. [`render_transport_fixture`](scripts/env.sh) substitutes
+`@NIC_IP@`, `@MXL_DOMAIN_ID@`, and `@LABEL@`. Upstream caps must still
+match the file essence. File-driven MXL scripts need only `mxl-domain-path`
+(`bootstrap_mxl_domain`); they omit `mxl-domain-id`, `caps`, and name
+properties. UDP fixtures set `a=x-nvnmos-iface-ip` only — wire destinations
+via IS-05 PATCH.
+
+**MXL:**
+
+```sh
+./scripts/example-pipelines/minimal-file-sender-mxl.sh
+./scripts/example-pipelines/minimal-file-receiver-mxl.sh
+```
+
+**UDP:**
+
+```sh
+./scripts/example-pipelines/minimal-file-sender-udp.sh
+./scripts/example-pipelines/minimal-file-receiver-udp.sh
+```
 
 ### Multi-Flow (Video + Audio on One Node)
 

--- a/rust/gst-nmos-rs/scripts/env.sh
+++ b/rust/gst-nmos-rs/scripts/env.sh
@@ -185,3 +185,17 @@ bootstrap_mxl_domain() {
     printf '{"id":"%s","label":"gst-nmos-rs example domain"}\n' "$DEMO_MXL_DOMAIN_ID" \
         >"$def"
 }
+
+# Substitute @NIC_IP@, @MXL_DOMAIN_ID@, and @LABEL@ in example-pipeline fixtures.
+render_transport_fixture() {
+    local template=$1
+    local output=$2
+    local label=${3-}
+    local escaped_label
+    # Prepare label for sed substitution (escape slashes and ampersands).
+    escaped_label=$(printf '%s' "$label" | sed 's/[\/&]/\\&/g')
+    sed -e "s/@NIC_IP@/${DEMO_NIC_IP}/g" \
+        -e "s/@MXL_DOMAIN_ID@/${DEMO_MXL_DOMAIN_ID}/g" \
+        -e "s/@LABEL@/${escaped_label}/g" \
+        "$template" >"$output"
+}

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.mxl.json.in
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.mxl.json.in
@@ -1,0 +1,21 @@
+{
+  "format": "urn:x-nmos:format:video",
+  "label": "@LABEL@",
+  "description": "",
+  "media_type": "video/v210",
+  "grain_rate": {"numerator": 25, "denominator": 1},
+  "frame_width": 1920,
+  "frame_height": 1080,
+  "interlace_mode": "progressive",
+  "colorspace": "BT709",
+  "components": [
+    {"name": "Y", "width": 1920, "height": 1080, "bit_depth": 10},
+    {"name": "Cb", "width": 960, "height": 1080, "bit_depth": 10},
+    {"name": "Cr", "width": 960, "height": 1080, "bit_depth": 10}
+  ],
+  "tags": {
+    "urn:x-nmos:tag:grouphint/v1.0": ["video1:Video"],
+    "urn:x-nvnmos:tag:name": ["video1"],
+    "urn:x-nvnmos:tag:mxl-domain-id": ["@MXL_DOMAIN_ID@"]
+  }
+}

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.mxl.json.in.license
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.mxl.json.in.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.sdp.in
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.sdp.in
@@ -1,0 +1,11 @@
+v=0
+o=- 1 0 IN IP4 @NIC_IP@
+s=@LABEL@
+t=0 0
+a=x-nvnmos-name:video1
+m=video 5004 RTP/AVP 96
+c=IN IP4 0.0.0.0
+a=rtpmap:96 raw/90000
+a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25; depth=10; colorimetry=BT709; PM=2110GPM; SSN=ST2110-20:2017
+a=x-nvnmos-iface-ip:@NIC_IP@
+a=mediaclk:direct=0

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.sdp.in.license
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video.sdp.in.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-mxl.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal transport-file MXL receiver for controller-driven IS-05 activation.
+#
+# AddReceiver at NULL→READY with configuring flow_def from `transport-file-path`.
+# The resource name comes from `urn:x-nvnmos:tag:name` in the file (no
+# `receiver-name`). Domain identity comes from `mxl-domain-path` / `domain_def.json`
+# (no `mxl-domain-id` property). The NMOS label comes from flow_def `label`
+# in the file (no `label` property).
+# Subscription identity (`mxl-flow-id`) and the data path arrive via
+# IS-05 PATCH on /single/receivers/{id}/staged.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+transport_path="$(mktemp "${TMPDIR:-/tmp}/nvnmos-minimal-video.XXXXXX.mxl.json")"
+trap 'rm -f "$transport_path"' EXIT
+transport_label="minimal ${DEMO_MXL_VIDEO_LABEL} receiver (file)"
+render_transport_fixture \
+    "$SCRIPT_DIR/fixtures/minimal-video.mxl.json.in" \
+    "$transport_path" \
+    "$transport_label"
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-minimal-consumer \
+        http-port=18112 \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        transport-file-path="$transport_path" \
+        auto-activate=false ! \
+    $(demo_video_queue) ! \
+    videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-udp.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal transport-file RTP/UDP receiver for controller-driven IS-05 activation.
+#
+# AddReceiver at NULL→READY with configuring SDP from `transport-file-path`.
+# The resource name comes from `a=x-nvnmos-name` in the file (no `receiver-name`).
+# The NMOS label comes from SDP `s=` in the file (no `label` property).
+# Subscription identity (e.g., `multicast-ip`, `destination-port`)
+# and the data path arrive via IS-05 PATCH on
+# /single/receivers/{id}/staged.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../env.sh"
+require_nvnmosd
+
+transport_path="$(mktemp "${TMPDIR:-/tmp}/nvnmos-minimal-video.XXXXXX.sdp")"
+trap 'rm -f "$transport_path"' EXIT
+transport_label="minimal ${DEMO_UDP_VIDEO_LABEL} receiver (file)"
+render_transport_fixture \
+    "$SCRIPT_DIR/fixtures/minimal-video.sdp.in" \
+    "$transport_path" \
+    "$transport_label"
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-consumer \
+        http-port=18112 \
+        $(udp_video_buffer_props) \
+        transport-file-path="$transport_path" \
+        auto-activate=false ! \
+    $(demo_video_queue) ! \
+    videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-mxl.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal transport-file MXL sender for controller-driven IS-05 activation.
+#
+# AddSender at NULL→READY with configuring flow_def from `transport-file-path`.
+# The resource name comes from `urn:x-nvnmos:tag:name` in the file (no
+# `sender-name`). Domain identity comes from `mxl-domain-path` / `domain_def.json`
+# (no `mxl-domain-id` property). The NMOS label comes from flow_def `label`
+# in the file (no `label` property).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../env.sh"
+require_nvnmosd
+bootstrap_mxl_domain
+
+transport_path="$(mktemp "${TMPDIR:-/tmp}/nvnmos-minimal-video.XXXXXX.mxl.json")"
+trap 'rm -f "$transport_path"' EXIT
+transport_label="minimal ${DEMO_MXL_VIDEO_LABEL} sender (file)"
+render_transport_fixture \
+    "$SCRIPT_DIR/fixtures/minimal-video.mxl.json.in" \
+    "$transport_path" \
+    "$transport_label"
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_MXL_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport=mxl \
+        node-seed=example-minimal-producer \
+        http-port=18111 \
+        mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
+        transport-file-path="$transport_path" \
+        auto-activate=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-udp.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal transport-file RTP/UDP sender for controller-driven IS-05 activation.
+#
+# AddSender at NULL→READY with configuring SDP from `transport-file-path`.
+# The resource name comes from `a=x-nvnmos-name` in the file (no `sender-name`).
+# The NMOS label comes from SDP `s=` in the file (no `label` property).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../env.sh"
+require_nvnmosd
+
+transport_path="$(mktemp "${TMPDIR:-/tmp}/nvnmos-minimal-video.XXXXXX.sdp")"
+trap 'rm -f "$transport_path"' EXIT
+transport_label="minimal ${DEMO_UDP_VIDEO_LABEL} sender (file)"
+render_transport_fixture \
+    "$SCRIPT_DIR/fixtures/minimal-video.sdp.in" \
+    "$transport_path" \
+    "$transport_label"
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_CAPS" ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-producer \
+        http-port=18111 \
+        $(udp_video_buffer_props) \
+        transport-file-path="$transport_path" \
+        auto-activate=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-receiver-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-receiver-mxl.sh
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Minimal MXL receiver for controller-driven IS-05 activation.
+# Minimal properties-driven MXL receiver for controller-driven IS-05 activation.
 #
-# AddReceiver at NULL→READY with configuring flow_def from `caps`
-# and `mxl-domain-*` only.
+# AddReceiver at NULL→READY with configuring flow_def synthesised from `caps`,
+# `mxl-domain-*`, and `receiver-name`.
 # Subscription identity (`mxl-flow-id`) and the data path arrive via
 # IS-05 PATCH on /single/receivers/{id}/staged.
 set -euo pipefail

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-receiver-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-receiver-udp.sh
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Minimal RTP/UDP receiver for controller-driven IS-05 activation.
+# Minimal properties-driven RTP/UDP receiver for controller-driven IS-05 activation.
 #
-# AddReceiver at NULL→READY with configuring SDP from `caps` and
-# `interface-ip` only.
+# AddReceiver at NULL→READY with configuring SDP synthesised from `caps`,
+# `interface-ip`, and `receiver-name`.
 # Subscription identity (e.g., `multicast-ip`, `destination-port`)
 # and the data path arrive via IS-05 PATCH on
 # /single/receivers/{id}/staged.

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-mxl.sh
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Minimal MXL sender for controller-driven IS-05 activation.
+# Minimal properties-driven MXL sender for controller-driven IS-05 activation.
 #
-# AddSender at NULL→READY with configuring flow_def from `caps` and
-# `mxl-domain-*` only.
+# AddSender at NULL→READY with configuring flow_def synthesised from `caps`,
+# `mxl-domain-*`, and `sender-name`.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
 require_nvnmosd

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-udp.sh
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Minimal RTP/UDP sender for controller-driven IS-05 activation.
+# Minimal properties-driven RTP/UDP sender for controller-driven IS-05 activation.
 #
-# AddSender at NULL→READY with configuring SDP from `caps` and
-# `source-ip` only.
+# AddSender at NULL→READY with configuring SDP synthesised from `caps`,
+# `source-ip`, and `sender-name`.
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
 require_nvnmosd

--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -201,6 +201,22 @@ pub(crate) fn read_flow_def_meta(text: &str) -> Result<FlowDefMeta, FlowDefError
     Ok(FlowDefMeta { id, format })
 }
 
+const NAME_TAG: &str = "urn:x-nvnmos:tag:name";
+
+/// `tags["urn:x-nvnmos:tag:name"]` from configuring flow_def JSON.
+pub(crate) fn resource_name_from_transport(text: &str) -> Result<Option<String>, FlowDefError> {
+    let raw: serde_json::Value =
+        serde_json::from_str(text).map_err(|source| FlowDefError::Parse { source })?;
+    Ok(raw
+        .get("tags")
+        .and_then(|tags| tags.get(NAME_TAG))
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned))
+}
+
 /// Combine the user's `mxl-flow-id` property and the caps-derived
 /// [`FlowFormat`] with `id` / `format` read from the transport file.
 /// See the module docs for the truth table. `property_format` is
@@ -791,6 +807,25 @@ mod tests {
         let m = read_flow_def_meta(&video_flow_def(UUID_A)).unwrap();
         assert_eq!(m.id, UUID_A);
         assert_eq!(m.format, FlowFormat::Video);
+    }
+
+    #[test]
+    fn resource_name_from_transport_reads_name_tag() {
+        let json = format!(
+            r#"{{"id":"{UUID_A}","format":"urn:x-nmos:format:video","tags":{{"urn:x-nvnmos:tag:name":["cam-a"]}}}}"#
+        );
+        assert_eq!(
+            resource_name_from_transport(&json).expect("parse"),
+            Some("cam-a".to_owned()),
+        );
+    }
+
+    #[test]
+    fn resource_name_from_transport_none_when_tag_absent() {
+        assert_eq!(
+            resource_name_from_transport(&video_flow_def(UUID_A)).expect("parse"),
+            None,
+        );
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -975,6 +975,27 @@ fn install_initial_fake_chain(bin: &gst::Bin) -> Result<gst::GhostPad, glib::Boo
     Ok(ghost)
 }
 
+/// Transport file → enriched essence caps (for capssetter / fake chain).
+fn caps_from_transport_file(
+    transport: Transport,
+    transport_file: &str,
+) -> Result<Option<gst::Caps>, anyhow::Error> {
+    if transport_file.is_empty() {
+        return Ok(None);
+    }
+    match transport {
+        Transport::Mxl => caps_from_flow_def(Some(transport_file)),
+        Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => {
+            let media = crate::sdp::parse_sdp(transport_file).map_err(|e| {
+                anyhow::anyhow!("caps from SDP transport file: {e}")
+            })?;
+            let caps = crate::essence_caps::caps_from(&media.raw_caps, Some(&media.rtp_caps));
+            gst::info!(CAT, "nmossrc: caps `{caps}` from SDP transport file");
+            Ok(Some(caps))
+        }
+    }
+}
+
 /// Flow-def transport file → enriched essence caps (for capssetter / fake chain).
 fn caps_from_flow_def(
     transport_file: Option<&str>,
@@ -1083,9 +1104,9 @@ fn udp_capssetter_caps(
 /// Best-available caps for the bin's fake chain, resolved from
 /// current `Settings` in priority order:
 ///   1. `caps` property (user-supplied; authoritative).
-///   2. Caps synthesised from the literal `transport-file` JSON.
-///   3. Caps synthesised from the JSON loaded from
-///      `transport-file-path`.
+///   2. Caps derived from the literal `transport-file` (MXL flow_def
+///      JSON or RTP/UDP SDP depending on `transport`).
+///   3. Caps derived from the file loaded via `transport-file-path`.
 ///
 /// Returns `Ok(None)` only when none of the three sources is
 /// available (e.g. neither `caps` nor `transport-file*` has been
@@ -1100,7 +1121,7 @@ fn fake_caps_from_settings(
         return Ok(Some(caps.clone()));
     }
     if !settings.transport_file.is_empty() {
-        return caps_from_flow_def(Some(&settings.transport_file));
+        return caps_from_transport_file(settings.transport, &settings.transport_file);
     }
     if !settings.transport_file_path.is_empty() {
         let text = std::fs::read_to_string(&settings.transport_file_path).map_err(|e| {
@@ -1109,7 +1130,7 @@ fn fake_caps_from_settings(
                 settings.transport_file_path
             )
         })?;
-        return caps_from_flow_def(Some(&text));
+        return caps_from_transport_file(settings.transport, &text);
     }
     Ok(None)
 }

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -715,6 +715,15 @@ fn session_attribute_value<'a>(msg: &'a SDPMessage, key: &str) -> Option<&'a str
     })
 }
 
+/// Session-level `a=x-nvnmos-name` from configuring SDP text.
+pub(crate) fn resource_name_from_transport(text: &str) -> Result<Option<String>, SdpError> {
+    let msg = SDPMessage::parse_buffer(text.as_bytes())
+        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    Ok(session_attribute_value(&msg, "x-nvnmos-name")
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned))
+}
+
 /// Build an SDP transport-file text from a [`UdpMedia`] plus the
 /// caller-supplied [`SdpSession`] session-level descriptors.
 ///
@@ -2501,6 +2510,28 @@ mod tests {
         let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("a=x-nvnmos-iface-ip:192.0.2.11\r\n", "");
         let media = parse_sdp(&sdp).expect("parse");
         assert_eq!(media.primary.interface_ip, None);
+    }
+
+    #[test]
+    fn resource_name_from_transport_reads_session_attribute() {
+        init_gst();
+        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace(
+            "t=0 0\r\n",
+            "t=0 0\r\na=x-nvnmos-name:cam-a\r\n",
+        );
+        assert_eq!(
+            resource_name_from_transport(&sdp).expect("parse"),
+            Some("cam-a".to_owned()),
+        );
+    }
+
+    #[test]
+    fn resource_name_from_transport_none_when_attribute_absent() {
+        init_gst();
+        assert_eq!(
+            resource_name_from_transport(VIDEO_YCBCR_422_10BIT_1080P50_SDP).expect("parse"),
+            None,
+        );
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -133,7 +133,8 @@ pub(crate) const SENDER_NAME_BLURB: &str =
      `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` \
      flow-def tag in the transport file). Unique across Senders on the \
      Node; a Receiver on the same Node may share the same name (the \
-     daemon scopes names by side). Overrides the transport file's value \
+     daemon scopes names by side). Required unless the name is already \
+     carried in `transport-file*`. Overrides the transport file's value \
      when both are supplied.";
 
 pub(crate) const RECEIVER_NAME_BLURB: &str =
@@ -141,7 +142,8 @@ pub(crate) const RECEIVER_NAME_BLURB: &str =
      `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` \
      flow-def tag in the transport file). Unique across Receivers on the \
      Node; a Sender on the same Node may share the same name (the \
-     daemon scopes names by side). Overrides the transport file's value \
+     daemon scopes names by side). Required unless the name is already \
+     carried in `transport-file*`. Overrides the transport file's value \
      when both are supplied.";
 
 pub(crate) const LABEL_BLURB_SENDER: &str =
@@ -687,6 +689,39 @@ fn udp_inner_summary(
     }
 }
 
+/// NMOS resource `name` for AddSender / AddReceiver: property when set,
+/// else read from `transport-file` when one is supplied (caps-only and
+/// deferred AddSender synthesis still require the property).
+pub(crate) fn resolve_resource_name(
+    element: &str,
+    settings: &CommonSettings,
+    transport_file: Option<&str>,
+) -> Result<String, anyhow::Error> {
+    if !settings.name.is_empty() {
+        return Ok(settings.name.clone());
+    }
+    let prop = settings.side.name_property();
+    let Some(text) = transport_file.filter(|t| !t.is_empty()) else {
+        bail!(
+            "{element}: `{prop}` is required (set the property or carry the name \
+             in `transport-file` as `a=x-nvnmos-name` or `urn:x-nvnmos:tag:name`)"
+        );
+    };
+    let from_file = match settings.transport {
+        Transport::Mxl => mxl::resource_name_from_transport_file(text).map_err(anyhow::Error::from)?,
+        Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => {
+            udp::resource_name_from_transport_file(text).map_err(anyhow::Error::from)?
+        }
+    };
+    match from_file {
+        Some(name) => Ok(name),
+        None => bail!(
+            "{element}: `{prop}` is unset and `transport-file` does not carry a name \
+             (`a=x-nvnmos-name` for SDP, `urn:x-nvnmos:tag:name` for flow_def)"
+        ),
+    }
+}
+
 /// Validate the settings snapshot and open a session via the shared
 /// tokio runtime. On success the session is stored under `session`
 /// and the returned [`InnerConfig`] tells the element how to wire its
@@ -701,12 +736,6 @@ pub(crate) fn validate_and_open(
 ) -> Result<InnerConfig, anyhow::Error> {
     if settings.node_seed.is_empty() {
         bail!("{element}: `node-seed` is required");
-    }
-    if settings.name.is_empty() {
-        bail!(
-            "{element}: `{}` is required",
-            settings.side.name_property()
-        );
     }
 
     let resolved_transport_file = resolve_transport_file(element, settings)?;
@@ -738,7 +767,7 @@ pub(crate) fn validate_and_open(
 
     let transport = transport_to_proto(settings.transport);
     let side = settings.side;
-    let name = settings.name.clone();
+    let name = resolve_resource_name(element, settings, transport_file.as_deref())?;
 
     let new_session = SHARED_RUNTIME
         .block_on(async {
@@ -794,7 +823,7 @@ pub(crate) fn validate_and_open(
         new_session.created_node,
         settings.node_seed,
         side,
-        settings.name,
+        name,
         settings.transport,
         resource_summary,
         inner_summary,
@@ -981,7 +1010,7 @@ fn finish_deferred_add_sender(
 ) -> Result<InnerConfig, anyhow::Error> {
     let transport = transport_to_proto(settings.transport);
     let side = settings.side;
-    let name = settings.name.clone();
+    let name = resolve_resource_name(element, settings, Some(transport_file))?;
     // Take the Session out of the std::Mutex before doing async work
     // (clippy's `await_holding_lock` lint, same pattern `close()` uses).
     // Put it back before checking the RPC result so READY→NULL always
@@ -1691,6 +1720,83 @@ mod tests {
             assert!(
                 err.to_string().contains("interface-ip"),
                 "expected interface-ip requirement: {err:#}"
+            );
+        }
+    }
+
+    mod resolve_resource_name {
+        use super::*;
+
+        const SDP_WITH_NAME: &str = concat!(
+            "v=0\r\n",
+            "o=- 1 0 IN IP4 192.0.2.10\r\n",
+            "s=test\r\n",
+            "t=0 0\r\n",
+            "a=x-nvnmos-name:from-file\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 239.1.1.1/64\r\n",
+            "a=rtpmap:96 raw/90000\r\n",
+        );
+
+        const FLOW_DEF_WITH_NAME: &str = r#"{
+            "id":"00000000-0000-0000-0000-000000000001",
+            "format":"urn:x-nmos:format:video",
+            "tags":{"urn:x-nvnmos:tag:name":["from-file"]}
+        }"#;
+
+        #[test]
+        fn property_wins_when_set() {
+            let mut s = settings(Side::Sender);
+            s.name = "from-property".to_owned();
+            let name = super::resolve_resource_name("nmossink", &s, Some(SDP_WITH_NAME))
+                .expect("property name");
+            assert_eq!(name, "from-property");
+        }
+
+        #[test]
+        fn rtp_reads_name_from_transport_file() {
+            cat();
+            let mut s = settings(Side::Receiver);
+            s.transport = Transport::Udp;
+            s.name.clear();
+            let name = super::resolve_resource_name("nmossrc", &s, Some(SDP_WITH_NAME))
+                .expect("SDP name");
+            assert_eq!(name, "from-file");
+        }
+
+        #[test]
+        fn mxl_reads_name_from_transport_file() {
+            let mut s = settings(Side::Sender);
+            s.name.clear();
+            let name =
+                super::resolve_resource_name("nmossink", &s, Some(FLOW_DEF_WITH_NAME)).expect(
+                    "flow_def name",
+                );
+            assert_eq!(name, "from-file");
+        }
+
+        #[test]
+        fn requires_property_when_no_transport_file() {
+            let mut s = settings(Side::Sender);
+            s.name.clear();
+            let err = super::resolve_resource_name("nmossink", &s, None).unwrap_err();
+            assert!(
+                err.to_string().contains("sender-name"),
+                "expected sender-name requirement: {err:#}"
+            );
+        }
+
+        #[test]
+        fn rejects_transport_file_without_name() {
+            cat();
+            let mut s = settings(Side::Receiver);
+            s.transport = Transport::Udp;
+            s.name.clear();
+            let sdp = "v=0\r\no=- 1 0 IN IP4 192.0.2.10\r\ns=test\r\nt=0 0\r\n";
+            let err = super::resolve_resource_name("nmossrc", &s, Some(sdp)).unwrap_err();
+            assert!(
+                err.to_string().contains("does not carry a name"),
+                "expected missing-name error: {err:#}"
             );
         }
     }

--- a/rust/gst-nmos-rs/src/session/mxl.rs
+++ b/rust/gst-nmos-rs/src/session/mxl.rs
@@ -15,6 +15,16 @@ use crate::domain::{self, DomainIdOrigin};
 use crate::flow_def::{self, FlowDefBuildInput, FlowDefOverrides, ValueOrigin};
 use crate::types::FlowFormat;
 
+/// Read the NMOS resource name from a flow_def transport file.
+///
+/// Used when the element already has a `transport-file` at NULL→READY.
+/// Caps-only synthesis and deferred AddSender still require the name property.
+pub(super) fn resource_name_from_transport_file(
+    text: &str,
+) -> Result<Option<String>, flow_def::FlowDefError> {
+    flow_def::resource_name_from_transport(text)
+}
+
 pub(crate) fn synthesise_or_passthrough_mxl(
     cat: &gst::DebugCategory,
     element: &str,

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -13,6 +13,14 @@ use super::types::Side;
 use crate::sdp::{self, DualLegPassthroughPolicy, SdpOverrides};
 use crate::types::{CapsMode, Transport};
 
+/// Read the NMOS resource name from an SDP transport file.
+///
+/// Used when the element already has a `transport-file` at NULL→READY.
+/// Caps-only synthesis and deferred AddSender still require the name property.
+pub(super) fn resource_name_from_transport_file(text: &str) -> Result<Option<String>, sdp::SdpError> {
+    sdp::resource_name_from_transport(text)
+}
+
 /// Which factory family to use for the UDP socket and RTP
 /// (de)payloader elements.
 ///


### PR DESCRIPTION
Resolve `sender-name`/`receiver-name` from `a=x-nvnmos-name` or `urn:x-nvnmos:tag:name` when the GObject property is empty and a `transport-file` is supplied. Add `minimal-file-*` example pipelines and shared fixtures; rename existing minimal scripts to `minimal-prop-*`.

This provides now two different kinds of minimal config, one using a transport file (SDP or flow_def.json) and as few element properties as possible around that, and the other not needing a transport file (with the exception of ST 2022-7), with as few properties as possible (where you don't want auto-activation).