### PR TITLE
nvnmosd: Fix flaky session_gc test from parallel http_port collision.

### DIFF
--- a/rust/nvnmosd/tests/session_gc.rs
+++ b/rust/nvnmosd/tests/session_gc.rs
@@ -209,7 +209,10 @@ async fn open_session(client: &mut NvnmosDaemonClient<Channel>, seed: &str) -> S
         .open_session(OpenSessionRequest {
             node_config: Some(NodeConfig {
                 seed: seed.to_string(),
-                http_port: 18_010,
+                // Let the daemon allocate from NVNMOSD_HTTP_PORT_MIN..MAX.
+                // A fixed port races when these tests run in parallel (default
+                // `cargo test` uses multiple threads).
+                http_port: 0,
                 ..Default::default()
             }),
         })


### PR DESCRIPTION
All four integration tests shared http_port 18010; when cargo test runs them concurrently, OpenSession can fail while another test's Node still holds the port. Use http_port 0 so each daemon allocates from NVNMOSD_HTTP_PORT_MIN..MAX.

https://github.com/NVIDIA/nvnmos/actions/runs/27715335051/job/81986986665