### PR TITLE
Add CONTRIBUTING.md and SECURITY.md with README links.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Contributing
+
+Thank you for your interest in contributing to NvNmos.
+
+If you find a bug, please report it via the issues tracker, or suggest a fix
+via a pull request. If you have ideas or would like to work on new features,
+please open an issue for discussion with use cases before opening a PR, so
+that others can contribute to the design or in case it turns out to be
+something we are already working on internally.
+
+## Signing Your Work
+
+We require that all contributors "sign-off" on their commits. This certifies
+that the contribution is your original work, or you have rights to submit it
+under the same license, or a compatible license.
+
+Any contribution which contains commits that are not signed off will not be
+accepted.
+
+To sign off on a commit you simply use the `--signoff` (or `-s`) option when
+committing your changes:
+
+```bash
+$ git commit -s -m "Add cool feature."
+```
+
+This will append the following to your commit message:
+
+```text
+Signed-off-by: Your Name <your@email.com>
+```
+
+## Full text of the DCO
+
+The canonical DCO text is available at <https://developercertificate.org/>.
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The NvNmos library supports the following specifications, using the [Sony nmos-c
 - Session Description Protocol conforming to SMPTE ST 2110-20, -22, -30, -40, and ST 2022-7
 - MXL flow definition JSON as consumed by the [MXL SDK](https://github.com/dmf-mxl/mxl)
 
+## Contributing
+
+- How to contribute: [CONTRIBUTING.md](https://github.com/NVIDIA/nvnmos/blob/main/CONTRIBUTING.md)
+- How to report a vulnerability: [SECURITY.md](https://github.com/NVIDIA/nvnmos/blob/main/SECURITY.md)
+
 ## Supported Platforms
 
 The library is intended to be portable to different environments.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Security
+
+NVIDIA is dedicated to the security and trust of our software products and
+services, including all source code repositories managed through our
+organization.
+
+If you need to report a security issue, please use the appropriate contact
+points outlined below. **Please do not report security vulnerabilities through
+GitHub issues or pull requests.** If a potential security issue is inadvertently
+reported through a public channel, NVIDIA maintainers may limit public
+discussion and redirect the reporter to the appropriate private disclosure
+channels.
+
+## Supported Versions
+
+Security fixes are handled for maintained release branches and the current main
+development branch at NVIDIA's discretion. Please include the affected commit,
+tag, branch, or container image digest when reporting an issue.
+
+## Reporting Potential Security Vulnerability in an NVIDIA Product
+
+To report a potential security vulnerability in any NVIDIA product:
+
+- Web: [Report Vulnerability](https://www.nvidia.com/en-us/security/report-vulnerability/)
+- E-mail: psirt@nvidia.com
+
+If reporting by e-mail, NVIDIA encourages encrypting the report with the
+[NVIDIA public PGP key](https://www.nvidia.com/en-us/product-security/pgp-key/).
+Please include:
+
+- Product name and affected version, branch, commit, or container image digest.
+- Type of vulnerability, such as code execution, denial of service, buffer
+  overflow, or privilege escalation.
+- Instructions to reproduce the vulnerability.
+- Proof-of-concept or exploit code, when available.
+- Potential impact, including how an attacker could exploit the vulnerability.
+
+NVIDIA currently has a closed bug bounty program, but continues to acknowledge
+externally reported security issues resolved under its coordinated vulnerability
+disclosure policy. See the
+[NVIDIA PSIRT policies](https://www.nvidia.com/en-us/product-security/psirt-policies/)
+page for details.
+
+## NVIDIA Product Security
+
+For all security-related concerns, visit the
+[NVIDIA Product Security portal](https://www.nvidia.com/en-us/security/).

--- a/rust/README.md
+++ b/rust/README.md
@@ -14,6 +14,8 @@ Rust components for the NMOS daemon and GStreamer plugin family.
 | [`gst-nmos-rs/README.md`](gst-nmos-rs/README.md) | `nmossrc` / `nmossink` property reference |
 | [`gst-nmos-rs/pipeline-examples.md`](gst-nmos-rs/pipeline-examples.md) | Full pipeline catalog (MXL, flipper, demo script, …) |
 | [`doc/designs/nvnmosd/README.md`](../doc/designs/nvnmosd/README.md) | Architecture and design history |
+| [`CONTRIBUTING.md`](../CONTRIBUTING.md) | Contribution guidelines (sign-off, DCO) |
+| [`SECURITY.md`](../SECURITY.md) | Security vulnerability reporting |
 
 ## Quick Start
 


### PR DESCRIPTION
Copy NVIDIA governance boilerplate from the repo template; link from the top-level README via GitHub blob URLs so Doxygen Pages readers reach the repo docs without adding markdown to Doxyfile INPUT.