### PR TITLE
Bug fix for VS 2026 / msvc 195 / MSVC Build Tools 14.51

### DIFF
--- a/.github/workflows/conan-canary.yml
+++ b/.github/workflows/conan-canary.yml
@@ -36,11 +36,19 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # VS 2026 (MSVC 195) needs cmake >= 4.2 for the "Visual Studio 18 2026"
+          # generator when nmos-cpp and dependencies build from source.
+          # See conan-io/conan-center-index#28884.
           $profile = conan profile path default
           (Get-Content $profile) `
             -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
             -replace '^compiler\.version=.*$', 'compiler.version=195' |
             Set-Content $profile
+          Add-Content -Path $profile -Value @(
+            '',
+            '[replace_tool_requires]',
+            'cmake/*: cmake/[>=4.2.0 <5]'
+          )
       - name: Install dependencies without lockfile
         id: conan_install
         run: |
@@ -114,11 +122,19 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # VS 2026 (MSVC 195) needs cmake >= 4.2 for the "Visual Studio 18 2026"
+          # generator when nmos-cpp and dependencies build from source.
+          # See conan-io/conan-center-index#28884.
           $profile = conan profile path default
           (Get-Content $profile) `
             -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
             -replace '^compiler\.version=.*$', 'compiler.version=195' |
             Set-Content $profile
+          Add-Content -Path $profile -Value @(
+            '',
+            '[replace_tool_requires]',
+            'cmake/*: cmake/[>=4.2.0 <5]'
+          )
       - name: Install dependencies without lockfile
         id: conan_install
         run: |

--- a/.github/workflows/conan-canary.yml
+++ b/.github/workflows/conan-canary.yml
@@ -36,19 +36,11 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          # VS 2026 (MSVC 195) needs cmake >= 4.2 for the "Visual Studio 18 2026"
-          # generator when nmos-cpp and dependencies build from source.
-          # See conan-io/conan-center-index#28884.
           $profile = conan profile path default
           (Get-Content $profile) `
             -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
-            -replace '^compiler\.version=.*$', 'compiler.version=195' |
+            -replace '^compiler\.version=.*$', 'compiler.version=194' |
             Set-Content $profile
-          Add-Content -Path $profile -Value @(
-            '',
-            '[replace_tool_requires]',
-            'cmake/*: cmake/[>=4.2.0 <5]'
-          )
       - name: Install dependencies without lockfile
         id: conan_install
         run: |

--- a/.github/workflows/conan-canary.yml
+++ b/.github/workflows/conan-canary.yml
@@ -39,7 +39,7 @@ jobs:
           $profile = conan profile path default
           (Get-Content $profile) `
             -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
-            -replace '^compiler\.version=.*$', 'compiler.version=194' |
+            -replace '^compiler\.version=.*$', 'compiler.version=195' |
             Set-Content $profile
       - name: Install dependencies without lockfile
         id: conan_install
@@ -117,7 +117,7 @@ jobs:
           $profile = conan profile path default
           (Get-Content $profile) `
             -replace '^compiler\.cppstd=.*$', 'compiler.cppstd=17' `
-            -replace '^compiler\.version=.*$', 'compiler.version=194' |
+            -replace '^compiler\.version=.*$', 'compiler.version=195' |
             Set-Content $profile
       - name: Install dependencies without lockfile
         id: conan_install


### PR DESCRIPTION
After sony/nmos-cpp#497 fixed detection to not pick `<experimental/filesystem>` there are a few more problems to resolve.

First, no "Visual Studio 18 2026" generator in CMake 3.31. It may get backported but for now we need CMake >=4.2.
See https://github.com/conan-io/conan-center-index/issues/28884.

Next, cpprestsdk uses `std::ios_base::_Openprot` which has been removed by https://github.com/microsoft/STL/commit/e2ef398685f7e470dbaeaf65ff919de72bda7489. Possible fix submitted as sony/nmos-cpp#498.
