### PR TITLE
gst-nmos-rs: pass caps features from `caps` through to the inner chain

### DIFF
--- a/rust/gst-nmos-rs/src/essence_caps.rs
+++ b/rust/gst-nmos-rs/src/essence_caps.rs
@@ -28,6 +28,46 @@ pub(crate) fn caps_from(raw_caps: &gst::Caps, rtp_caps: Option<&gst::Caps>) -> g
     }
 }
 
+/// Copy the caps features (e.g. `memory:NVMM`) from `source`'s first
+/// structure onto a clone of `base`.
+///
+/// Transport files (SDP, MXL `flow_def`) have no representation for
+/// caps features, so essence caps reconstructed from a transport file
+/// have an empty feature set (which GStreamer treats as the default
+/// system-memory feature). When a `caps` property requests a non-default
+/// feature set, this re-attaches it onto the file-derived essence caps
+/// that configure the inner element. A `source` with an empty feature
+/// set or `ANY` leaves `base` unchanged.
+pub(crate) fn overlay_features(base: &gst::Caps, source: Option<&gst::Caps>) -> gst::Caps {
+    let Some(features) = source.and_then(|c| c.features(0)) else {
+        return base.clone();
+    };
+    // No structure 0 to attach to (empty or any base), or nothing to
+    // overlay (empty or any source feature set).
+    if base.structure(0).is_none() || features.is_any() || features.is_empty() {
+        return base.clone();
+    }
+    let features = features.to_owned();
+    let mut out = base.clone();
+    out.make_mut().set_features(0, Some(features));
+    out
+}
+
+/// Clone `caps` with every structure's feature set emptied (the
+/// system-memory default). The essence-shape cross-check intersects
+/// the `caps` property against caps parsed from the transport file;
+/// because the file cannot express features, a requested feature must
+/// be dropped here so it does not read as a shape mismatch. Complements
+/// [`overlay_features`].
+pub(crate) fn without_features(caps: &gst::Caps) -> gst::Caps {
+    let mut out = caps.clone();
+    let out_mut = out.make_mut();
+    for i in 0..out_mut.size() {
+        out_mut.set_features(i, Some(gst::CapsFeatures::new_empty()));
+    }
+    out
+}
+
 fn audio_caps_from(caps: &gst::Caps, channel_order: Option<&str>) -> gst::Caps {
     let Some(s) = caps.structure(0) else {
         return caps.clone();
@@ -134,6 +174,39 @@ mod tests {
             s.get::<gst::Bitmask>("channel-mask").unwrap(),
             gst::Bitmask::new((1u64 << 6) - 1),
         );
+    }
+
+    #[test]
+    fn overlay_features_reattaches_non_default_feature() {
+        init_gst();
+        let base = gst::Caps::from_str("video/x-raw,format=UYVY,width=1920,height=1080")
+            .expect("base caps");
+        let source =
+            gst::Caps::from_str("video/x-raw(memory:NVMM),format=UYVY").expect("source caps");
+        let out = overlay_features(&base, Some(&source));
+        assert!(out.features(0).unwrap().contains("memory:NVMM"));
+        // essence fields untouched
+        assert_eq!(out.structure(0).unwrap().get::<i32>("width").unwrap(), 1920);
+    }
+
+    #[test]
+    fn overlay_features_ignores_system_memory_and_none() {
+        init_gst();
+        let base = gst::Caps::from_str("video/x-raw,format=UYVY").expect("base caps");
+        let plain = gst::Caps::from_str("video/x-raw,format=UYVY").expect("plain caps");
+        assert_eq!(overlay_features(&base, None).to_string(), base.to_string());
+        assert_eq!(
+            overlay_features(&base, Some(&plain)).to_string(),
+            base.to_string(),
+        );
+    }
+
+    #[test]
+    fn without_features_resets_to_system_memory() {
+        init_gst();
+        let caps = gst::Caps::from_str("video/x-raw(memory:NVMM),format=UYVY").expect("caps");
+        let out = without_features(&caps);
+        assert!(out.features(0).unwrap().is_empty());
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -1226,7 +1226,12 @@ fn cross_check_essence_format_family(media: &UdpMedia, caps: &gst::Caps) -> Resu
 
 fn cross_check_essence_caps(media: &UdpMedia, caps: &gst::Caps) -> Result<(), SdpError> {
     cross_check_essence_format_family(media, caps)?;
-    let intersect = caps.intersect(&media.raw_caps);
+    // Caps parsed from the SDP always carry system memory; a caps-property
+    // feature (e.g. `memory:NVMM`) the file cannot express must not read as
+    // a shape mismatch. It is re-attached onto the inner-chain essence caps
+    // separately (see `essence_caps::overlay_features`).
+    let stripped = crate::essence_caps::without_features(caps);
+    let intersect = stripped.intersect(&media.raw_caps);
     if intersect.is_empty() {
         return Err(SdpError::EssenceShapeMismatch {
             caps: caps.to_string(),

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -334,7 +334,7 @@ fn finish_udp_inner_config(
     if transport != Transport::NvDsUdp && sdp::sdp_media_block_count(text)? > 1 {
         return Err(anyhow::Error::new(sdp::SdpError::DualLegNotSupported));
     }
-    let media = sdp::parse_sdp(text).with_context(|| {
+    let mut media = sdp::parse_sdp(text).with_context(|| {
         format!(
             "{element}: parsing SDP transport file for transport={transport:?}"
         )
@@ -357,6 +357,10 @@ fn finish_udp_inner_config(
             detail: "all legs inactive (rtp_enabled: false)".into(),
         });
     }
+    // The SDP cannot carry caps features; re-attach any requested on
+    // the `caps` property (e.g. `memory:NVMM`) so the inner element
+    // (for example, nvdsudpsrc) sees them and negotiates accordingly.
+    media.raw_caps = crate::essence_caps::overlay_features(&media.raw_caps, settings.caps.as_ref());
     Ok(build_real(media))
 }
 


### PR DESCRIPTION
### Summary

Lets users request GStreamer caps features (e.g. `memory:NVMM`) via the `caps` property on `nmossrc`/`nmossink` and have them reach the underlying transport element — most importantly `nvdsudpsrc`, which accepts `memory:NVMM` for GPU-direct buffers.

### Motivation

Transport files (SDP, MXL flow_def) have no representation for caps features, so essence caps reconstructed from a transport file always have an empty feature set. Any feature requested on the `caps` property was therefore silently dropped before it could reach the inner element, and (when a transport file was also supplied) a feature like `memory:NVMM` made the essence-shape cross-check fail as a false shape mismatch.

### What changed

- **`essence_caps::overlay_features`** — re-attaches the `caps` property's feature set onto file-derived essence caps that configure the inner element. **`essence_caps::without_features`** — empties a caps' feature set for comparison.
- **`cross_check_essence_caps`** — strips features before the essence-shape `intersect`, so a feature the transport file cannot express is not read as a shape mismatch.
- **`finish_udp_inner_config`** — after the cross-check, overlays the feature onto `media.raw_caps`, so the transport source (`nvdsudpsrc`) receives it.

### Design notes

- **Generic, not element-specific.** Features are passed through transparently; an inner element that cannot honour a requested feature fails negotiation and reports its own error, exactly like any other caps field. This keeps the door open for other features / transports without special-casing.
- **No feature reaches the synthesised transport file** — SDP/MXL flow_def serialization only ever emitted structure fields, and the overlay happens on the parsed essence caps, not the file text.
- **Audited every consumption site**, so the single overlay lands only where it's meaningful:
  - `nvdsudpsrc.caps` — genuinely produces the memory type (the main goal!)
  - `capssetter` (plain UDP receiver) — merges structure fields only and **ignores** caps features (verified empirically), so the overlay is a harmless no-op there
  - `packetization::from_media` (sender) — reads fields only
  - fake `appsrc`/`fakesink` placeholders — push no mislabelled buffers; advertising the feature is consistent with (and required for) the real chain's negotiation

### Testing

- Added unit tests for `overlay_features` (re-attach, and no-op for empty/any/absent source) and `without_features`.
