### PR TITLE
gst-nmos-rs: Add end-to-end A/V + caption sync testing, and fix the sync issues it exposes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
       # Unit tests instantiate real elements (udpsrc, rtpvrawdepay, …) from
       # gst-plugins-base / gst-plugins-good, and nmosaudiochannelmap uses
       # audiomixmatrix from gst-plugins-bad — dev packages alone are not enough.
+      # cairo / pango are needed to build (and load) the gst-plugins-rs
+      # closedcaption plugin below (its overlay elements link pangocairo).
       - name: Install Rust system dependencies
         run: |
           sudo apt-get update
@@ -102,7 +104,9 @@ jobs:
             libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good \
-            gstreamer1.0-plugins-bad
+            gstreamer1.0-plugins-bad \
+            libcairo2-dev \
+            libpango1.0-dev
 
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
         with:
@@ -122,13 +126,37 @@ jobs:
           NVNMOS_LIB_DIR: ${{ github.workspace }}/build
         run: cargo clippy --workspace --locked --all-targets -- -D warnings
 
+      # Build the gst-plugins-rs elements the sync tests need — st2038extractor /
+      # st2038combiner (closedcaption), rtpsmpte291pay / rtpsmpte291depay (rtp) and
+      # udpsrc2 (udp) — at a pinned main commit that carries the st2038combiner skew
+      # and rtpsmpte291depay multi-ANC fixes (and, unlike the 0.15 branch, udpsrc2),
+      # and put them on GST_PLUGIN_PATH so the udp av_sync case (and udp2 tests) run
+      # here instead of self-skipping. The mxl and nvdsudp cases still self-skip
+      # (no libmxl / DeepStream on the runner).
+      - name: Build gst-plugins-rs plugins (pinned)
+        env:
+          GST_PLUGINS_RS_REF: 8d5c60f0a67d3aa8120bf940b46fc3c18209661c
+          RUSTUP_TOOLCHAIN: "1.92"
+        run: |
+          git init "${RUNNER_TEMP}/gst-plugins-rs"
+          cd "${RUNNER_TEMP}/gst-plugins-rs"
+          git remote add origin https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
+          git fetch --depth 1 origin "${GST_PLUGINS_RS_REF}"
+          git checkout FETCH_HEAD
+          cargo build --release \
+            -p gst-plugin-closedcaption \
+            -p gst-plugin-rtp \
+            -p gst-plugin-udp
+
       # The daemon-backed integration tests self-gate: they run here because
-      # nvnmosd + libnvnmos.so are present.
+      # nvnmosd + libnvnmos.so are present. GST_PLUGIN_PATH adds the pinned
+      # gst-plugins-rs plugins built above.
       - name: Cargo test (workspace)
         working-directory: rust
         env:
           NVNMOS_LIB_DIR: ${{ github.workspace }}/build
           LD_LIBRARY_PATH: ${{ github.workspace }}/build
+          GST_PLUGIN_PATH: ${{ runner.temp }}/gst-plugins-rs/target/release
         shell: bash
         # --show-output surfaces the `test <name> ... skipped, <reason>` lines
         # that test-skip's `skip!` prints (libtest captures them otherwise and

--- a/docker/gst-nmos-rs/Dockerfile
+++ b/docker/gst-nmos-rs/Dockerfile
@@ -32,7 +32,7 @@ ARG RUST_TOOLCHAIN=1.92
 ARG MXL_REPO=https://github.com/dmf-mxl/mxl.git
 ARG MXL_REF=81738a15adb55119a6855343bc1053a4389bf6df
 ARG GST_PLUGINS_RS_REPO=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
-ARG GST_PLUGINS_RS_REF=207b1f4eeef4c192696181ce2ddb69da8ff73c8a
+ARG GST_PLUGINS_RS_REF=8d5c60f0a67d3aa8120bf940b46fc3c18209661c
 
 # Final image arguments
 ARG NVNMOS_UID=10001

--- a/docker/gst-nmos-rs/README.md
+++ b/docker/gst-nmos-rs/README.md
@@ -33,7 +33,7 @@ The nvnmos tree is taken from the build context (`COPY src/`, `COPY rust/` via t
 | `MXL_REPO` | `https://github.com/dmf-mxl/mxl.git` | MXL source repository (`libmxl`, `gst-mxl-rs`). |
 | `MXL_REF` | `81738a15adb55119a6855343bc1053a4389bf6df` | Pinned MXL commit (`81738a1`, tip of `release/v1.1` at time of writing). Use a full 40-character SHA or a branch/tag name. |
 | `GST_PLUGINS_RS_REPO` | `https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git` | gst-plugins-rs source for `transport=udp2`. |
-| `GST_PLUGINS_RS_REF` | `207b1f4eeef4c192696181ce2ddb69da8ff73c8a` | Pinned gst-plugins-rs commit (`udpsrc2` landed after tag `0.15.2`). Builds `gst-plugin-udp` + `gst-plugin-rtp`. Use a full 40-character SHA or a branch/tag name. |
+| `GST_PLUGINS_RS_REF` | `8d5c60f0a67d3aa8120bf940b46fc3c18209661c` | Pinned gst-plugins-rs commit on `main` (`udpsrc2` is main-only; this commit also carries the `st2038combiner` skew and `rtpsmpte291depay` multi-ANC fixes). Builds `gst-plugin-udp` + `gst-plugin-rtp`. Use a full 40-character SHA or a branch/tag name. |
 | `NVNMOS_UID` | `10001` | Fixed runtime user UID (`nvnmos`). |
 | `NVNMOS_GID` | `10001` | Fixed runtime group GID (`nvnmos`). |
 | `EXTRA_APT_PACKAGES` | *(empty)* | Optional space-separated apt package names added in the final image stage (e.g. `gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly`). Installed to the default GStreamer plugin path. |

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -579,7 +579,9 @@ name = "gst-nmos-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cdp-types",
  "glib",
+ "gst-avsynctest-rs",
  "gst-plugin-version-helper",
  "gstreamer",
  "gstreamer-app",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -203,6 +203,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cdp-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "332ca05a88e143d80a245f9aa6c65b6e6383ee3e332017005647c27c6a62f902"
+dependencies = [
+ "cea708-types",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "cea708-types"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de28b1d549e7f8f53a746fb36ae4c10c776a8e004950b527be1669a58667ae0b"
+dependencies = [
+ "log",
+ "muldiv",
+ "thiserror",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +560,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gst-avsynctest-rs"
+version = "0.1.0"
+dependencies = [
+ "cdp-types",
+ "cea708-types",
+ "glib",
+ "gst-plugin-version-helper",
+ "gstreamer",
+ "gstreamer-app",
+ "gstreamer-audio",
+ "gstreamer-base",
+ "gstreamer-video",
+]
+
+[[package]]
 name = "gst-nmos-rs"
 version = "0.1.0"
 dependencies = [
@@ -717,6 +754,36 @@ dependencies = [
  "cfg-if",
  "glib-sys",
  "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gstreamer-video"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d9ba5295b206563a990a087c6541d57f650dcd4be4ca8a5a149a758e8df8a0"
+dependencies = [
+ "cfg-if",
+ "futures-channel",
+ "glib",
+ "gstreamer",
+ "gstreamer-base",
+ "gstreamer-video-sys",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gstreamer-video-sys"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20236fa412d7a50e59aa234b46828a99e3e5f06c4f80d271a49ecd2a1d3bfcbe"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
  "libc",
  "system-deps",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "nvnmosd",
     "nvnmosd-example",
     "nvnmosd-bench",
+    "gst-avsynctest-rs",
     "gst-nmos-rs",
     "test-skip",
 ]

--- a/rust/README.md
+++ b/rust/README.md
@@ -167,6 +167,7 @@ using DeepStream and Rivermax SDK, see
 | `nvnmosd-example`  | binary      | Example/regression client modelled on the C `nvnmos-example`.        |
 | `nvnmosd-bench`    | binary      | Scale smoke / benchmark client for `nvnmosd`.                        |
 | `gst-nmos-rs`      | GStreamer plugin (cdylib) | `nmos` plugin — `nmossrc` / `nmossink` elements. See [`gst-nmos-rs/README.md`](gst-nmos-rs/README.md). |
+| `gst-avsynctest-rs` | GStreamer plugin (cdylib) | `avsynctest` plugin — `avsyncvideotestsrc` / `avsyncaudiotestsrc` phase-locked A/V test sources (with a public `analyze` module) used by the `gst-nmos-rs` sync test. |
 
 ## Container Image
 

--- a/rust/gst-avsynctest-rs/Cargo.toml
+++ b/rust/gst-avsynctest-rs/Cargo.toml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "gst-avsynctest-rs"
+description = "Aligned audio/video test sources for sync testing"
+repository.workspace = true
+edition.workspace = true
+publish.workspace = true
+version.workspace = true
+license.workspace = true
+
+[dependencies]
+cdp-types = "0.3"
+cea708-types = "0.4.1"
+glib = "0.21.5"
+gstreamer = "0.24.4"
+gstreamer-audio = "0.24.4"
+gstreamer-base = "0.24.4"
+gstreamer-video = { version = "0.24.5", features = ["v1_24"] }
+
+[dev-dependencies]
+gstreamer-app = "0.24.4"
+
+[lib]
+name = "gstavsynctest"
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+
+[build-dependencies]
+gst-plugin-version-helper = { version = "0.8.3" }

--- a/rust/gst-avsynctest-rs/build.rs
+++ b/rust/gst-avsynctest-rs/build.rs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    gst_plugin_version_helper::info()
+}

--- a/rust/gst-avsynctest-rs/src/analyze.rs
+++ b/rust/gst-avsynctest-rs/src/analyze.rs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Recovery-side analysis for the aligned A/V test signal: locate the video
+//! bar, the audio pips, and the phase-locked caption produced by
+//! [`avsyncvideotestsrc`](crate::videosrc) and
+//! [`avsyncaudiotestsrc`](crate::audiosrc). Kept transport-agnostic so any
+//! pipeline under test — a bare `videoconvert`, an MXL round-trip, an NMOS
+//! sender/receiver — can assert A/V (and caption) alignment on recovered
+//! samples the same way.
+
+use cdp_types::CDPParser;
+use gstreamer as gst;
+use gstreamer_video as gst_video;
+use gstreamer_video::prelude::*;
+
+use crate::captions;
+
+/// Brightest-column centroid of the top row, decoded to `GRAY8`. `None` if the
+/// row has no bright pixels (should not happen for the always-present bar).
+pub fn bar_centroid(sample: &gst::Sample) -> Option<f64> {
+    let caps = sample.caps()?;
+    let info = gst_video::VideoInfo::from_caps(caps).ok()?;
+    let buffer = sample.buffer()?;
+    let frame = gst_video::VideoFrameRef::from_buffer_ref_readable(buffer, &info).ok()?;
+    let stride = frame.plane_stride()[0] as usize;
+    let row = &frame.plane_data(0).ok()?[..stride];
+    let width = info.width() as usize;
+    let mut sum = 0.0f64;
+    let mut count = 0.0f64;
+    for (x, &v) in row.iter().take(width).enumerate() {
+        if v > 128 {
+            sum += x as f64;
+            count += 1.0;
+        }
+    }
+    (count > 0.0).then_some(sum / count)
+}
+
+/// Reinterpret an F32LE audio buffer's bytes as native `f32` samples (the host
+/// is little-endian). Panics if the buffer is not `f32`-aligned. Typically used
+/// to turn a recovered audio buffer into the `(time_ns, amplitude)` pairs
+/// [`detect_pips`] consumes.
+pub fn f32le_samples(bytes: &[u8]) -> &[f32] {
+    let (head, body, tail) = unsafe { bytes.align_to::<f32>() };
+    assert!(
+        head.is_empty() && tail.is_empty(),
+        "misaligned F32LE buffer"
+    );
+    body
+}
+
+/// Running-time centre of each tone pip from `(time_ns, amplitude)` samples. The
+/// envelope is binned (5 ms bins, so a 1 kHz tone's zero-crossings never split a
+/// pip) and contiguous bins whose energy clears a fraction of the peak are
+/// grouped; each pip's time is the *midpoint* of its group. A midpoint is
+/// unbiased for the symmetric burst `avsyncaudiotestsrc` emits, whereas an
+/// energy-weighted centroid is skewed by how the burst's samples fall across the
+/// bin edges.
+pub fn detect_pips(audio: &[(u64, f32)]) -> Vec<u64> {
+    if audio.is_empty() {
+        return Vec::new();
+    }
+    const BIN_NS: u64 = 5_000_000;
+    let t0 = audio.first().unwrap().0;
+    let tn = audio.last().unwrap().0;
+    let nbins = ((tn - t0) / BIN_NS + 1) as usize;
+    let mut energy = vec![0.0f64; nbins];
+    for &(t, a) in audio {
+        let b = ((t - t0) / BIN_NS) as usize;
+        energy[b] += (a as f64) * (a as f64);
+    }
+    let peak = energy.iter().copied().fold(0.0, f64::max);
+    let threshold = peak * 0.1;
+    let bin_centre = |b: usize| t0 + b as u64 * BIN_NS + BIN_NS / 2;
+    let mut pips = Vec::new();
+    let mut i = 0;
+    while i < nbins {
+        if energy[i] > threshold {
+            let first = i;
+            while i < nbins && energy[i] > threshold {
+                i += 1;
+            }
+            pips.push((bin_centre(first) + bin_centre(i - 1)) / 2);
+        } else {
+            i += 1;
+        }
+    }
+    pips
+}
+
+/// Low byte of the first user-data word of every ancillary packet with DID `did`
+/// (matched on its low 8 bits) carried by the frame, in attachment order. Reads
+/// back the per-frame index [`avsyncvideotestsrc`](crate::videosrc) stamps in the
+/// data flow (DID [`ANC_DID`](crate::signal::ANC_DID)). Usually one entry per
+/// frame; a lossy live round-trip whose flows aren't co-timed can land two
+/// packets on one frame (and none on a neighbour) — never more than two — so the
+/// caller can verify every packet was received and placed within one frame of its
+/// home index.
+pub fn ancillary_indices(buffer: &gst::BufferRef, did: u8) -> Vec<u8> {
+    buffer
+        .iter_meta::<gst_video::video_meta::AncillaryMeta>()
+        .filter(|m| (m.did() & 0xFF) as u8 == did)
+        .filter_map(|m| m.data().iter().next().map(|&w| (w & 0xFF) as u8))
+        .collect()
+}
+
+/// Raw CDP bytes of every CEA-708 caption ancillary carried by the frame (DID
+/// [`CC_DID`](captions::CC_DID)), in attachment order — the caption companion to
+/// [`ancillary_indices`], so a frame that collected two ST-2038 packets exposes
+/// both captions. Decode each with [`decode_caption`].
+pub fn caption_cdps(buffer: &gst::BufferRef) -> Vec<Vec<u8>> {
+    buffer
+        .iter_meta::<gst_video::video_meta::AncillaryMeta>()
+        .filter(|m| (m.did() & 0xFF) as u8 == captions::CC_DID)
+        .map(|m| m.data().iter().map(|&w| (w & 0xFF) as u8).collect())
+        .collect()
+}
+
+/// The CEA-708 CDP the video source attaches (DID [`CC_DID`](captions::CC_DID) /
+/// SDID [`CC_SDID`](captions::CC_SDID)), as raw bytes recovered from the
+/// ancillary meta's 10-bit words. `None` if the frame carries no caption
+/// ancillary.
+pub fn caption_cdp_bytes(buffer: &gst::BufferRef) -> Option<Vec<u8>> {
+    buffer
+        .iter_meta::<gst_video::video_meta::AncillaryMeta>()
+        .find(|m| (m.did() & 0xFF) as u8 == captions::CC_DID)
+        .map(|m| m.data().iter().map(|&w| (w & 0xFF) as u8).collect())
+}
+
+/// The caption text carried by one frame's CDP (service
+/// [`CC_SERVICE_NO`](captions::CC_SERVICE_NO)), or `None` for a null CDP.
+pub fn decode_caption(parser: &mut CDPParser, cdp: &[u8]) -> Option<String> {
+    parser.parse(cdp).expect("valid CDP");
+    let packet = parser.pop_packet()?;
+    let mut text = String::new();
+    for service in packet.services() {
+        if service.number() == captions::CC_SERVICE_NO {
+            text.extend(service.codes().iter().filter_map(|code| code.char()));
+        }
+    }
+    (!text.is_empty()).then_some(text)
+}

--- a/rust/gst-avsynctest-rs/src/audiosrc/imp.rs
+++ b/rust/gst-avsynctest-rs/src/audiosrc/imp.rs
@@ -1,0 +1,437 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `avsyncaudiotestsrc`: silence with a short tone pip centred on each pip
+//! instant (`running_time` a multiple of the pip interval). Paired with
+//! `avsyncvideotestsrc` it is phase-locked to the bar-centre crossing.
+//!
+//! Modelled on the gst-plugins-rs `sinesrc` tutorial element (live clock
+//! waiting, timestamps from a sample counter). `num-buffers` is handled by
+//! `GstBaseSrc`.
+
+use std::f64::consts::PI;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+use gst::glib;
+use gst::prelude::*;
+use gst::subclass::prelude::*;
+use gst_base::prelude::*;
+use gst_base::subclass::base_src::CreateSuccess;
+use gst_base::subclass::prelude::*;
+use gstreamer as gst;
+use gstreamer_audio as gst_audio;
+use gstreamer_base as gst_base;
+
+use crate::signal;
+
+static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        "avsyncaudiotestsrc",
+        gst::DebugColorFlags::empty(),
+        Some("A/V sync test audio source"),
+    )
+});
+
+#[derive(Debug, Clone, Copy)]
+struct Settings {
+    pip_interval: gst::ClockTime,
+    pip_duration: gst::ClockTime,
+    pip_freq: f64,
+    pip_volume: f64,
+    samples_per_buffer: u32,
+    is_live: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            pip_interval: signal::DEFAULT_PIP_INTERVAL,
+            pip_duration: signal::DEFAULT_PIP_DURATION,
+            pip_freq: signal::DEFAULT_PIP_FREQ_HZ,
+            pip_volume: signal::DEFAULT_PIP_VOLUME,
+            samples_per_buffer: signal::DEFAULT_SAMPLES_PER_BUFFER as u32,
+            is_live: false,
+        }
+    }
+}
+
+#[derive(Default)]
+struct State {
+    info: Option<gst_audio::AudioInfo>,
+    sample_offset: u64,
+}
+
+struct ClockWait {
+    clock_id: Option<gst::SingleShotClockId>,
+    flushing: bool,
+}
+
+impl Default for ClockWait {
+    fn default() -> ClockWait {
+        ClockWait {
+            clock_id: None,
+            flushing: true,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct AvSyncAudioTestSrc {
+    settings: Mutex<Settings>,
+    state: Mutex<State>,
+    clock_wait: Mutex<ClockWait>,
+}
+
+/// Tone amplitude at `running` for a pip signal, `0.0` in the silent gaps. The
+/// pip at `running_time == 0` is skipped so every emitted pip is a full window.
+fn pip_value(running: gst::ClockTime, settings: &Settings) -> f64 {
+    let p = settings.pip_interval.nseconds();
+    let half = settings.pip_duration.nseconds() / 2;
+    let running_ns = running.nseconds();
+    let k = (running_ns + p / 2) / p;
+    let centre = k * p;
+    if centre < half || running_ns.abs_diff(centre) >= half {
+        return 0.0;
+    }
+    let t = running_ns as f64 / gst::ClockTime::SECOND.nseconds() as f64;
+    settings.pip_volume * (2.0 * PI * settings.pip_freq * t).sin()
+}
+
+fn write_sample(format: gst_audio::AudioFormat, value: f64, dst: &mut [u8]) {
+    if format == gst_audio::AudioFormat::F32le {
+        dst.copy_from_slice(&(value as f32).to_le_bytes());
+    } else if format == gst_audio::AudioFormat::S16be {
+        let v = (value.clamp(-1.0, 1.0) * i16::MAX as f64) as i16;
+        dst.copy_from_slice(&v.to_be_bytes());
+    } else if format == gst_audio::AudioFormat::S24be {
+        let v = (value.clamp(-1.0, 1.0) * 8_388_607.0) as i32;
+        dst[0] = (v >> 16) as u8;
+        dst[1] = (v >> 8) as u8;
+        dst[2] = v as u8;
+    }
+}
+
+impl AvSyncAudioTestSrc {
+    fn fill(data: &mut [u8], info: &gst_audio::AudioInfo, sample_offset: u64, settings: &Settings) {
+        let rate = info.rate() as u64;
+        let channels = info.channels() as usize;
+        let format = info.format();
+        let bpf = info.bpf() as usize;
+        let bytes_per_sample = bpf / channels;
+        let second = gst::ClockTime::SECOND.nseconds() as u128;
+        for (i, frame) in data.chunks_exact_mut(bpf).enumerate() {
+            let g = sample_offset + i as u64;
+            let running_ns = (g as u128 * second / rate as u128) as u64;
+            let value = pip_value(gst::ClockTime::from_nseconds(running_ns), settings);
+            for sample in frame.chunks_exact_mut(bytes_per_sample) {
+                write_sample(format, value, sample);
+            }
+        }
+    }
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for AvSyncAudioTestSrc {
+    const NAME: &'static str = "GstAvSyncAudioTestSrc";
+    type Type = super::AvSyncAudioTestSrc;
+    type ParentType = gst_base::PushSrc;
+}
+
+impl ObjectImpl for AvSyncAudioTestSrc {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
+            vec![
+                glib::ParamSpecUInt64::builder("pip-interval")
+                    .nick("Pip Interval")
+                    .blurb("Nanoseconds between pips (must match the video source)")
+                    .minimum(1)
+                    .default_value(signal::DEFAULT_PIP_INTERVAL.nseconds())
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecUInt64::builder("pip-duration")
+                    .nick("Pip Duration")
+                    .blurb("Nanoseconds each tone pip lasts")
+                    .minimum(1)
+                    .default_value(signal::DEFAULT_PIP_DURATION.nseconds())
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecDouble::builder("pip-freq")
+                    .nick("Pip Frequency")
+                    .blurb("Tone frequency of the pip in Hz")
+                    .minimum(1.0)
+                    .default_value(signal::DEFAULT_PIP_FREQ_HZ)
+                    .mutable_playing()
+                    .build(),
+                glib::ParamSpecDouble::builder("pip-volume")
+                    .nick("Pip Volume")
+                    .blurb("Peak amplitude of the pip (0.0-1.0)")
+                    .minimum(0.0)
+                    .maximum(1.0)
+                    .default_value(signal::DEFAULT_PIP_VOLUME)
+                    .mutable_playing()
+                    .build(),
+                glib::ParamSpecUInt::builder("samples-per-buffer")
+                    .nick("Samples Per Buffer")
+                    .blurb("Number of samples per output buffer")
+                    .minimum(1)
+                    .default_value(signal::DEFAULT_SAMPLES_PER_BUFFER as u32)
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecBoolean::builder("is-live")
+                    .nick("Is Live")
+                    .blurb("Whether to pace output against the pipeline clock")
+                    .default_value(false)
+                    .mutable_ready()
+                    .build(),
+            ]
+        });
+
+        PROPERTIES.as_ref()
+    }
+
+    fn constructed(&self) {
+        self.parent_constructed();
+        let obj = self.obj();
+        obj.set_live(false);
+        obj.set_format(gst::Format::Time);
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        let mut settings = self.settings.lock().unwrap();
+        match pspec.name() {
+            "pip-interval" => {
+                settings.pip_interval = gst::ClockTime::from_nseconds(value.get().unwrap());
+            }
+            "pip-duration" => {
+                settings.pip_duration = gst::ClockTime::from_nseconds(value.get().unwrap());
+            }
+            "pip-freq" => settings.pip_freq = value.get().unwrap(),
+            "pip-volume" => settings.pip_volume = value.get().unwrap(),
+            "samples-per-buffer" => settings.samples_per_buffer = value.get().unwrap(),
+            "is-live" => settings.is_live = value.get().unwrap(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        let settings = self.settings.lock().unwrap();
+        match pspec.name() {
+            "pip-interval" => settings.pip_interval.nseconds().to_value(),
+            "pip-duration" => settings.pip_duration.nseconds().to_value(),
+            "pip-freq" => settings.pip_freq.to_value(),
+            "pip-volume" => settings.pip_volume.to_value(),
+            "samples-per-buffer" => settings.samples_per_buffer.to_value(),
+            "is-live" => settings.is_live.to_value(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl GstObjectImpl for AvSyncAudioTestSrc {}
+
+impl ElementImpl for AvSyncAudioTestSrc {
+    fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+        static ELEMENT_METADATA: LazyLock<gst::subclass::ElementMetadata> = LazyLock::new(|| {
+            gst::subclass::ElementMetadata::new(
+                "A/V Sync Test Audio Source",
+                "Source/Audio",
+                "Emits tone pips phase-locked to avsyncvideotestsrc for A/V sync testing",
+                "NVIDIA Corporation",
+            )
+        });
+
+        Some(&*ELEMENT_METADATA)
+    }
+
+    fn pad_templates() -> &'static [gst::PadTemplate] {
+        static PAD_TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
+            let caps = gst_audio::AudioCapsBuilder::new_interleaved()
+                .format_list([
+                    gst_audio::AudioFormat::F32le,
+                    gst_audio::AudioFormat::S24be,
+                    gst_audio::AudioFormat::S16be,
+                ])
+                .build();
+            let src_pad_template = gst::PadTemplate::new(
+                "src",
+                gst::PadDirection::Src,
+                gst::PadPresence::Always,
+                &caps,
+            )
+            .unwrap();
+
+            vec![src_pad_template]
+        });
+
+        PAD_TEMPLATES.as_ref()
+    }
+
+    fn change_state(
+        &self,
+        transition: gst::StateChange,
+    ) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
+        if let gst::StateChange::ReadyToPaused = transition {
+            self.obj().set_live(self.settings.lock().unwrap().is_live);
+        }
+        self.parent_change_state(transition)
+    }
+}
+
+impl BaseSrcImpl for AvSyncAudioTestSrc {
+    fn set_caps(&self, caps: &gst::Caps) -> Result<(), gst::LoggableError> {
+        let info = gst_audio::AudioInfo::from_caps(caps).map_err(|_| {
+            gst::loggable_error!(CAT, "Failed to build `AudioInfo` from caps {}", caps)
+        })?;
+
+        self.obj()
+            .set_blocksize(info.bpf() * self.settings.lock().unwrap().samples_per_buffer);
+
+        self.state.lock().unwrap().info = Some(info);
+
+        let _ = self
+            .obj()
+            .post_message(gst::message::Latency::builder().src(&*self.obj()).build());
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), gst::ErrorMessage> {
+        *self.state.lock().unwrap() = Default::default();
+        self.unlock_stop()?;
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), gst::ErrorMessage> {
+        *self.state.lock().unwrap() = Default::default();
+        self.unlock()?;
+        Ok(())
+    }
+
+    fn query(&self, query: &mut gst::QueryRef) -> bool {
+        if let gst::QueryViewMut::Latency(q) = query.view_mut() {
+            let settings = *self.settings.lock().unwrap();
+            let state = self.state.lock().unwrap();
+            if let Some(ref info) = state.info {
+                let latency = gst::ClockTime::SECOND
+                    .mul_div_floor(settings.samples_per_buffer as u64, info.rate() as u64)
+                    .unwrap();
+                q.set(settings.is_live, latency, gst::ClockTime::NONE);
+                return true;
+            }
+            return false;
+        }
+        BaseSrcImplExt::parent_query(self, query)
+    }
+
+    fn fixate(&self, mut caps: gst::Caps) -> gst::Caps {
+        caps.truncate();
+        {
+            let caps = caps.make_mut();
+            let s = caps.structure_mut(0).unwrap();
+            s.fixate_field_nearest_int("rate", signal::DEFAULT_RATE);
+            s.fixate_field_nearest_int("channels", signal::DEFAULT_CHANNELS);
+        }
+        self.parent_fixate(caps)
+    }
+
+    fn is_seekable(&self) -> bool {
+        false
+    }
+
+    fn unlock(&self) -> Result<(), gst::ErrorMessage> {
+        let mut clock_wait = self.clock_wait.lock().unwrap();
+        if let Some(clock_id) = clock_wait.clock_id.take() {
+            clock_id.unschedule();
+        }
+        clock_wait.flushing = true;
+        Ok(())
+    }
+
+    fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
+        self.clock_wait.lock().unwrap().flushing = false;
+        Ok(())
+    }
+}
+
+impl PushSrcImpl for AvSyncAudioTestSrc {
+    fn create(
+        &self,
+        _buffer: Option<&mut gst::BufferRef>,
+    ) -> Result<CreateSuccess, gst::FlowError> {
+        let settings = *self.settings.lock().unwrap();
+
+        let mut state = self.state.lock().unwrap();
+        let info = match state.info {
+            None => {
+                gst::element_imp_error!(self, gst::CoreError::Negotiation, ["Have no caps yet"]);
+                return Err(gst::FlowError::NotNegotiated);
+            }
+            Some(ref info) => info.clone(),
+        };
+
+        let n_samples = settings.samples_per_buffer as u64;
+        let mut buffer = gst::Buffer::with_size(n_samples as usize * info.bpf() as usize).unwrap();
+        {
+            let buffer = buffer.get_mut().unwrap();
+            let pts = state
+                .sample_offset
+                .mul_div_floor(gst::ClockTime::SECOND.nseconds(), info.rate() as u64)
+                .map(gst::ClockTime::from_nseconds)
+                .unwrap();
+            let next_pts = (state.sample_offset + n_samples)
+                .mul_div_floor(gst::ClockTime::SECOND.nseconds(), info.rate() as u64)
+                .map(gst::ClockTime::from_nseconds)
+                .unwrap();
+            buffer.set_pts(pts);
+            buffer.set_duration(next_pts - pts);
+
+            let mut map = buffer.map_writable().unwrap();
+            Self::fill(map.as_mut_slice(), &info, state.sample_offset, &settings);
+        }
+        state.sample_offset += n_samples;
+        drop(state);
+
+        self.sync_to_clock(&buffer)?;
+
+        Ok(CreateSuccess::NewBuffer(buffer))
+    }
+}
+
+impl AvSyncAudioTestSrc {
+    /// In live mode, wait on the pipeline clock until the last sample's running
+    /// time, cancellable from `unlock()` (see `sinesrc`).
+    fn sync_to_clock(&self, buffer: &gst::Buffer) -> Result<(), gst::FlowError> {
+        if !self.obj().is_live() {
+            return Ok(());
+        }
+        let Some((clock, base_time)) = Option::zip(self.obj().clock(), self.obj().base_time())
+        else {
+            return Ok(());
+        };
+        let segment = self
+            .obj()
+            .segment()
+            .downcast::<gst::format::Time>()
+            .unwrap();
+        let running_time = segment.to_running_time(buffer.pts().opt_add(buffer.duration()));
+        let Some(wait_until) = running_time.opt_add(base_time) else {
+            return Ok(());
+        };
+
+        let mut clock_wait = self.clock_wait.lock().unwrap();
+        if clock_wait.flushing {
+            return Err(gst::FlowError::Flushing);
+        }
+        let id = clock.new_single_shot_id(wait_until);
+        clock_wait.clock_id = Some(id.clone());
+        drop(clock_wait);
+
+        let (res, _) = id.wait();
+        self.clock_wait.lock().unwrap().clock_id.take();
+        if res == Err(gst::ClockError::Unscheduled) {
+            return Err(gst::FlowError::Flushing);
+        }
+        Ok(())
+    }
+}

--- a/rust/gst-avsynctest-rs/src/audiosrc/mod.rs
+++ b/rust/gst-avsynctest-rs/src/audiosrc/mod.rs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use gst::glib;
+use gst::prelude::*;
+use gstreamer as gst;
+use gstreamer_base as gst_base;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct AvSyncAudioTestSrc(ObjectSubclass<imp::AvSyncAudioTestSrc>)
+        @extends gst_base::PushSrc, gst_base::BaseSrc, gst::Element, gst::Object;
+}
+
+pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    gst::Element::register(
+        Some(plugin),
+        "avsyncaudiotestsrc",
+        gst::Rank::NONE,
+        AvSyncAudioTestSrc::static_type(),
+    )
+}

--- a/rust/gst-avsynctest-rs/src/captions.rs
+++ b/rust/gst-avsynctest-rs/src/captions.rs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Phase-locked CEA-708 captions for `avsyncvideotestsrc`.
+//!
+//! The frame whose interval contains a pip instant carries a pop-on caption,
+//! alternating "TICK" (odd pip) and "TOCK" (even pip); every other frame carries
+//! a null CDP. Which frame is the caption frame is derived from the frame's PTS
+//! and the pip interval `P`, so it stays locked to the pips even at fractional
+//! frame rates (e.g. `30000/1001`) with no accumulated drift.
+//!
+//! Output is a CEA-708 CDP, the payload of an SMPTE 291 ancillary packet
+//! (DID 0x61 / SDID 0x01), built with `cdp-types`/`cea708-types` — the same
+//! crates GStreamer's closed-caption elements use.
+
+use cdp_types::{CDPWriter, Framerate};
+use cea708_types::tables::{Anchor, Code, DefineWindowArgs, SetPenLocationArgs, WindowBits};
+use cea708_types::{DTVCCPacket, Service};
+
+use gstreamer as gst;
+
+/// SMPTE 334 CEA-708 CDP ancillary identifier (DID 0x61 / SDID 0x01).
+pub const CC_DID: u8 = 0x61;
+pub const CC_SDID: u8 = 0x01;
+/// Ancillary line for the caption packet (distinct from the frame-index line).
+pub const CC_LINE: u16 = 10;
+/// The single CEA-708 service the captions are written to.
+pub const CC_SERVICE_NO: u8 = 1;
+
+pub const CC_TICK: &str = "TICK";
+pub const CC_TOCK: &str = "TOCK";
+
+/// The CDP framerate for a GStreamer framerate, or `None` if it has no CDP
+/// identifier (CDP only encodes the eight broadcast rates).
+pub fn cdp_framerate(fps: gst::Fraction) -> Option<Framerate> {
+    let id = match (fps.numer(), fps.denom()) {
+        (24000, 1001) => 0x1,
+        (24, 1) => 0x2,
+        (25, 1) => 0x3,
+        (30000, 1001) => 0x4,
+        (30, 1) => 0x5,
+        (50, 1) => 0x6,
+        (60000, 1001) => 0x7,
+        (60, 1) => 0x8,
+        _ => return None,
+    };
+    Framerate::from_id(id)
+}
+
+/// The caption for the frame spanning `[pts, next_pts)`: `TICK`/`TOCK` if a pip
+/// instant `k * P` (`k >= 1`) falls in that span, else `None`. Purely a function
+/// of the frame's running time, so it never drifts from the pips.
+pub fn caption_for(
+    pts: gst::ClockTime,
+    next_pts: gst::ClockTime,
+    pip_interval: gst::ClockTime,
+) -> Option<&'static str> {
+    let p = pip_interval.nseconds();
+    let k = pts.nseconds().div_ceil(p); // smallest k with k*P >= pts
+    (k >= 1 && k * p < next_pts.nseconds()).then_some(if k % 2 == 1 { CC_TICK } else { CC_TOCK })
+}
+
+/// A stateful CDP writer: one CDP per frame, so the CEA-708 sequence numbering
+/// stays continuous across the stream (as a real caption service does).
+#[derive(Default)]
+pub struct CaptionWriter {
+    cdp: CDPWriter,
+    dtvcc_seq: u8,
+}
+
+impl CaptionWriter {
+    /// Build the next frame's CDP. `text` present -> a pop-on caption; `None` ->
+    /// a null CDP (padding only). `sequence_count` is the CDP header counter.
+    pub fn next_cdp(
+        &mut self,
+        framerate: Framerate,
+        sequence_count: u16,
+        text: Option<&str>,
+    ) -> Vec<u8> {
+        if let Some(text) = text {
+            let mut packet = DTVCCPacket::new(self.dtvcc_seq & 0x3);
+            let mut service = Service::new(CC_SERVICE_NO);
+            for code in caption_codes(text) {
+                let _ = service.push_code(&code);
+            }
+            let _ = packet.push_service(service);
+            self.cdp.push_packet(packet);
+            self.dtvcc_seq = self.dtvcc_seq.wrapping_add(1);
+        }
+        self.cdp.set_sequence_count(sequence_count);
+        let mut out = Vec::new();
+        let _ = self.cdp.write(framerate, &mut out);
+        out
+    }
+}
+
+/// Pop-on caption codes: clear the windows, define + show a one-row window,
+/// reset the pen, then the text (clear + pen reset + text, as ANSI/CTA-708-E
+/// pop-on captioning does).
+fn caption_codes(text: &str) -> Vec<Code> {
+    let mut codes = vec![
+        Code::DeleteWindows(!WindowBits::NONE),
+        Code::DefineWindow(DefineWindowArgs::new(
+            0,
+            0,
+            Anchor::BottomLeft,
+            true,
+            100,
+            0,
+            0,
+            31,
+            true,
+            true,
+            true,
+            1,
+            1,
+        )),
+        Code::SetPenLocation(SetPenLocationArgs::new(0, 0)),
+    ];
+    codes.extend(text.chars().filter_map(Code::from_char));
+    codes.push(Code::ETX);
+    codes
+}

--- a/rust/gst-avsynctest-rs/src/lib.rs
+++ b/rust/gst-avsynctest-rs/src/lib.rs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GStreamer test sources that emit a *phase-locked* audio/video pair for
+//! end-to-end synchronisation testing.
+//!
+//! Both elements derive their content purely from each buffer's running time and
+//! a shared pip interval `P` (default 1 s), so when they run in one pipeline they
+//! are aligned by construction and any A/V skew observed downstream was
+//! introduced by the pipeline under test.
+//!
+//! - [`avsyncvideotestsrc`](videosrc): a white vertical bar on black that is at
+//!   screen centre exactly at every pip instant (`running_time` a multiple of
+//!   `P`) and sweeps across in one `P`. Emits `video/x-raw` (v210 or UYVP) with a
+//!   `GstAncillaryMeta` carrying the frame index and a second one carrying a
+//!   phase-locked CEA-708 caption (alternating "TICK"/"TOCK" on each pip frame).
+//! - [`avsyncaudiotestsrc`](audiosrc): silence except a short tone pip centred on
+//!   each pip instant. Emits `audio/x-raw` (F32LE, S24BE or S16BE).
+//!
+//! Eyeball/ear demo (bar crosses centre exactly on the beep):
+//!
+//! ```sh
+//! gst-launch-1.0 \
+//!   avsyncvideotestsrc is-live=true ! videoconvert ! autovideosink \
+//!   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
+//! ```
+
+use gst::glib;
+use gstreamer as gst;
+
+pub mod analyze;
+pub mod audiosrc;
+pub mod captions;
+pub mod signal;
+pub mod videosrc;
+
+fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    videosrc::register(plugin)?;
+    audiosrc::register(plugin)?;
+    Ok(())
+}
+
+gst::plugin_define!(
+    avsynctest,
+    env!("CARGO_PKG_DESCRIPTION"),
+    plugin_init,
+    concat!(env!("CARGO_PKG_VERSION"), "-", env!("COMMIT_ID")),
+    "Apache-2.0",
+    env!("CARGO_PKG_NAME"),
+    env!("CARGO_PKG_NAME"),
+    env!("CARGO_PKG_REPOSITORY"),
+    env!("BUILD_REL_DATE")
+);

--- a/rust/gst-avsynctest-rs/src/signal.rs
+++ b/rust/gst-avsynctest-rs/src/signal.rs
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared parameters and phase maths for the aligned A/V test sources.
+//!
+//! The two elements never share state; they agree only on the pip interval `P`
+//! and these functions of running time, which is what makes their output
+//! phase-locked when they run under one clock.
+
+use gstreamer as gst;
+
+/// Default pip interval `P`: one second between beeps / bar-centre crossings.
+pub const DEFAULT_PIP_INTERVAL: gst::ClockTime = gst::ClockTime::from_seconds(1);
+
+pub const DEFAULT_FRAMERATE_NUM: i32 = 30_000;
+pub const DEFAULT_FRAMERATE_DEN: i32 = 1_001;
+pub const DEFAULT_WIDTH: i32 = 1_280;
+pub const DEFAULT_HEIGHT: i32 = 720;
+
+pub const DEFAULT_RATE: i32 = 48_000;
+pub const DEFAULT_CHANNELS: i32 = 1;
+pub const DEFAULT_SAMPLES_PER_BUFFER: i32 = 1_024;
+pub const DEFAULT_PIP_FREQ_HZ: f64 = 1_000.0;
+pub const DEFAULT_PIP_VOLUME: f64 = 0.8;
+/// Default pip length: a short tone burst (a handful of `pip-freq` cycles, like
+/// `audiotestsrc wave=ticks`), so the pip marks its instant sharply rather than
+/// spanning a large fraction of a video frame.
+pub const DEFAULT_PIP_DURATION: gst::ClockTime = gst::ClockTime::from_mseconds(4);
+
+/// SMPTE 291 ancillary identifier carrying the frame index, in the user
+/// application space (DID 0x5F / SDID 0xFF); not exposed as a property.
+pub const ANC_DID: u8 = 0x5F;
+pub const ANC_SDID: u8 = 0xFF;
+pub const ANC_LINE: u16 = 9;
+pub const ANC_OFFSET: u16 = 0;
+
+/// 10-bit narrow-range luma for black / white and neutral chroma.
+pub const LUMA_BLACK: u16 = 64;
+pub const LUMA_WHITE: u16 = 940;
+pub const CHROMA_NEUTRAL: u16 = 512;
+
+/// Phase within the current pip interval, in `[0, 1)`. Zero at every pip instant.
+pub fn phase(running: gst::ClockTime, pip_interval: gst::ClockTime) -> f64 {
+    let p = pip_interval.nseconds();
+    (running.nseconds() % p) as f64 / p as f64
+}
+
+/// Column the bar centre sits at for a given phase: screen centre at `phase == 0`,
+/// sweeping right and wrapping once per interval.
+pub fn bar_centre_column(phase: f64, width: u32) -> u32 {
+    let w = width as f64;
+    ((phase * w + w / 2.0).rem_euclid(w)) as u32 % width
+}
+
+/// Circular column distance, so the bar wraps cleanly at the frame edge.
+pub fn circular_distance(a: u32, b: u32, width: u32) -> u32 {
+    let d = a.abs_diff(b);
+    d.min(width - d)
+}

--- a/rust/gst-avsynctest-rs/src/videosrc/imp.rs
+++ b/rust/gst-avsynctest-rs/src/videosrc/imp.rs
@@ -1,0 +1,550 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `avsyncvideotestsrc`: a white vertical bar on black that is at screen centre
+//! exactly at each pip instant (`running_time` a multiple of the pip interval)
+//! and sweeps across in one interval. The frame index is written into payload
+//! byte 0 and into a `GstAncillaryMeta` (DID/SDID in the user space), so an
+//! `st2038extractor` can split off a matching data flow. A second ancillary
+//! carries a phase-locked CEA-708 CDP caption (see [`captions`](crate::captions)).
+//!
+//! Emits v210 or UYVP. Modelled on the gst-plugins-rs `sinesrc` tutorial
+//! element; `num-buffers` is handled by `GstBaseSrc`.
+
+use std::sync::LazyLock;
+use std::sync::Mutex;
+
+use gst::glib;
+use gst::prelude::*;
+use gst::subclass::prelude::*;
+use gst_base::prelude::*;
+use gst_base::subclass::base_src::CreateSuccess;
+use gst_base::subclass::prelude::*;
+use gstreamer as gst;
+use gstreamer_base as gst_base;
+use gstreamer_video as gst_video;
+
+use crate::{captions, signal};
+
+static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        "avsyncvideotestsrc",
+        gst::DebugColorFlags::empty(),
+        Some("A/V sync test video source"),
+    )
+});
+
+#[derive(Debug, Clone, Copy)]
+struct Settings {
+    pip_interval: gst::ClockTime,
+    width: i32,
+    height: i32,
+    framerate: gst::Fraction,
+    is_live: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Settings {
+            pip_interval: signal::DEFAULT_PIP_INTERVAL,
+            width: signal::DEFAULT_WIDTH,
+            height: signal::DEFAULT_HEIGHT,
+            framerate: gst::Fraction::new(
+                signal::DEFAULT_FRAMERATE_NUM,
+                signal::DEFAULT_FRAMERATE_DEN,
+            ),
+            is_live: false,
+        }
+    }
+}
+
+#[derive(Default)]
+struct State {
+    info: Option<gst_video::VideoInfo>,
+    n_frames: u64,
+    bar_width: u32,
+    cdp_framerate: Option<cdp_types::Framerate>,
+    caption_writer: captions::CaptionWriter,
+}
+
+struct ClockWait {
+    clock_id: Option<gst::SingleShotClockId>,
+    flushing: bool,
+}
+
+impl Default for ClockWait {
+    fn default() -> ClockWait {
+        ClockWait {
+            clock_id: None,
+            flushing: true,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct AvSyncVideoTestSrc {
+    settings: Mutex<Settings>,
+    state: Mutex<State>,
+    clock_wait: Mutex<ClockWait>,
+}
+
+fn luma_at(x: usize, width: u32, bar_centre: u32, bar_width: u32) -> u16 {
+    if x >= width as usize {
+        return signal::LUMA_BLACK;
+    }
+    if signal::circular_distance(x as u32, bar_centre, width) <= bar_width / 2 {
+        signal::LUMA_WHITE
+    } else {
+        signal::LUMA_BLACK
+    }
+}
+
+/// Pack three 10-bit components into one little-endian v210 word.
+fn v210_word(a: u16, b: u16, c: u16) -> u32 {
+    (a as u32) | ((b as u32) << 10) | ((c as u32) << 20)
+}
+
+fn fill_v210(data: &mut [u8], info: &gst_video::VideoInfo, bar_centre: u32, bar_width: u32) {
+    let width = info.width();
+    let stride = info.stride()[0] as usize;
+    let groups = width.div_ceil(6) as usize;
+    let c = signal::CHROMA_NEUTRAL;
+    for y in 0..info.height() as usize {
+        let row = &mut data[y * stride..][..stride];
+        for g in 0..groups {
+            let l = |i: usize| luma_at(6 * g + i, width, bar_centre, bar_width);
+            let words = [
+                v210_word(c, l(0), c),
+                v210_word(l(1), c, l(2)),
+                v210_word(c, l(3), c),
+                v210_word(l(4), c, l(5)),
+            ];
+            for (w, chunk) in words.iter().zip(row[g * 16..].chunks_exact_mut(4)) {
+                chunk.copy_from_slice(&w.to_le_bytes());
+            }
+        }
+    }
+}
+
+fn fill_uyvp(data: &mut [u8], info: &gst_video::VideoInfo, bar_centre: u32, bar_width: u32) {
+    let width = info.width();
+    let stride = info.stride()[0] as usize;
+    let pairs = width.div_ceil(2) as usize;
+    let c = signal::CHROMA_NEUTRAL as u64;
+    for y in 0..info.height() as usize {
+        let row = &mut data[y * stride..][..stride];
+        for p in 0..pairs {
+            let y0 = luma_at(2 * p, width, bar_centre, bar_width) as u64;
+            let y1 = luma_at(2 * p + 1, width, bar_centre, bar_width) as u64;
+            // MSB-first 40-bit [U, Y0, V, Y1] over 5 bytes (GStreamer UYVP).
+            let val = (c << 30) | (y0 << 20) | (c << 10) | y1;
+            let base = p * 5;
+            row[base] = (val >> 32) as u8;
+            row[base + 1] = (val >> 24) as u8;
+            row[base + 2] = (val >> 16) as u8;
+            row[base + 3] = (val >> 8) as u8;
+            row[base + 4] = val as u8;
+        }
+    }
+}
+
+fn extend_with_even_odd_parity(v: u8) -> u16 {
+    if v.count_ones() & 1 == 0 {
+        0x1_00 | (v as u16)
+    } else {
+        0x2_00 | (v as u16)
+    }
+}
+
+fn compute_checksum(did_10bit: u16, sdid_10bit: u16, dc_10bit: u16, data: &[u16]) -> u16 {
+    let mut checksum = 0u16;
+    checksum = checksum.wrapping_add(did_10bit & 0x1ff);
+    checksum = checksum.wrapping_add(sdid_10bit & 0x1ff);
+    checksum = checksum.wrapping_add(dc_10bit & 0x1ff);
+    for &w in data {
+        checksum = checksum.wrapping_add(w & 0x1ff);
+    }
+    checksum &= 0x1ff;
+    checksum |= ((!(checksum >> 8)) & 0x01) << 9;
+    checksum
+}
+
+/// Attach one `GstAncillaryMeta` carrying `payload` under `did`/`sdid` on `line`,
+/// as `st2038extractor` expects (10-bit even/odd-parity words plus checksum).
+fn add_ancillary(buffer: &mut gst::BufferRef, did: u8, sdid: u8, line: u16, payload: &[u8]) {
+    let mut meta = gst_video::video_meta::AncillaryMeta::add(buffer);
+    meta.set_c_not_y_channel(false);
+    meta.set_line(line);
+    meta.set_offset(signal::ANC_OFFSET);
+    let did_10bit = extend_with_even_odd_parity(did);
+    let sdid_10bit = extend_with_even_odd_parity(sdid);
+    let dc_10bit = extend_with_even_odd_parity(payload.len() as u8);
+    meta.set_did(did_10bit);
+    meta.set_sdid_block_number(sdid_10bit);
+    let data: Vec<u16> = payload
+        .iter()
+        .copied()
+        .map(extend_with_even_odd_parity)
+        .collect();
+    meta.set_checksum(compute_checksum(did_10bit, sdid_10bit, dc_10bit, &data));
+    meta.set_data(glib::Slice::from(data));
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for AvSyncVideoTestSrc {
+    const NAME: &'static str = "GstAvSyncVideoTestSrc";
+    type Type = super::AvSyncVideoTestSrc;
+    type ParentType = gst_base::PushSrc;
+}
+
+impl ObjectImpl for AvSyncVideoTestSrc {
+    fn properties() -> &'static [glib::ParamSpec] {
+        static PROPERTIES: LazyLock<Vec<glib::ParamSpec>> = LazyLock::new(|| {
+            vec![
+                glib::ParamSpecUInt64::builder("pip-interval")
+                    .nick("Pip Interval")
+                    .blurb("Nanoseconds between bar-centre crossings (must match the audio source)")
+                    .minimum(1)
+                    .default_value(signal::DEFAULT_PIP_INTERVAL.nseconds())
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecInt::builder("width")
+                    .nick("Width")
+                    .blurb("Default output width when downstream leaves it open")
+                    .minimum(1)
+                    .default_value(signal::DEFAULT_WIDTH)
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecInt::builder("height")
+                    .nick("Height")
+                    .blurb("Default output height when downstream leaves it open")
+                    .minimum(1)
+                    .default_value(signal::DEFAULT_HEIGHT)
+                    .mutable_ready()
+                    .build(),
+                gst::ParamSpecFraction::builder("framerate")
+                    .nick("Framerate")
+                    .blurb("Default output framerate when downstream leaves it open")
+                    .minimum(gst::Fraction::new(1, 1))
+                    .maximum(gst::Fraction::new(i32::MAX, 1))
+                    .default_value(gst::Fraction::new(
+                        signal::DEFAULT_FRAMERATE_NUM,
+                        signal::DEFAULT_FRAMERATE_DEN,
+                    ))
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecBoolean::builder("is-live")
+                    .nick("Is Live")
+                    .blurb("Whether to pace output against the pipeline clock")
+                    .default_value(false)
+                    .mutable_ready()
+                    .build(),
+            ]
+        });
+
+        PROPERTIES.as_ref()
+    }
+
+    fn constructed(&self) {
+        self.parent_constructed();
+        let obj = self.obj();
+        obj.set_live(false);
+        obj.set_format(gst::Format::Time);
+    }
+
+    fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
+        let mut settings = self.settings.lock().unwrap();
+        match pspec.name() {
+            "pip-interval" => {
+                settings.pip_interval = gst::ClockTime::from_nseconds(value.get().unwrap());
+            }
+            "width" => settings.width = value.get().unwrap(),
+            "height" => settings.height = value.get().unwrap(),
+            "framerate" => settings.framerate = value.get().unwrap(),
+            "is-live" => settings.is_live = value.get().unwrap(),
+            _ => unimplemented!(),
+        }
+    }
+
+    fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
+        let settings = self.settings.lock().unwrap();
+        match pspec.name() {
+            "pip-interval" => settings.pip_interval.nseconds().to_value(),
+            "width" => settings.width.to_value(),
+            "height" => settings.height.to_value(),
+            "framerate" => settings.framerate.to_value(),
+            "is-live" => settings.is_live.to_value(),
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl GstObjectImpl for AvSyncVideoTestSrc {}
+
+impl ElementImpl for AvSyncVideoTestSrc {
+    fn metadata() -> Option<&'static gst::subclass::ElementMetadata> {
+        static ELEMENT_METADATA: LazyLock<gst::subclass::ElementMetadata> = LazyLock::new(|| {
+            gst::subclass::ElementMetadata::new(
+                "A/V Sync Test Video Source",
+                "Source/Video",
+                "Emits a sweeping bar phase-locked to avsyncaudiotestsrc for A/V sync testing",
+                "NVIDIA Corporation",
+            )
+        });
+
+        Some(&*ELEMENT_METADATA)
+    }
+
+    fn pad_templates() -> &'static [gst::PadTemplate] {
+        static PAD_TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
+            // Only CDP-representable frame rates: every frame carries a CEA-708
+            // CDP whose header encodes one of these eight broadcast rates.
+            let framerates = [
+                gst::Fraction::new(24000, 1001),
+                gst::Fraction::new(24, 1),
+                gst::Fraction::new(25, 1),
+                gst::Fraction::new(30000, 1001),
+                gst::Fraction::new(30, 1),
+                gst::Fraction::new(50, 1),
+                gst::Fraction::new(60000, 1001),
+                gst::Fraction::new(60, 1),
+            ];
+            let caps = gst_video::VideoCapsBuilder::new()
+                .format_list([gst_video::VideoFormat::V210, gst_video::VideoFormat::Uyvp])
+                .framerate_list(framerates)
+                .build();
+            let src_pad_template = gst::PadTemplate::new(
+                "src",
+                gst::PadDirection::Src,
+                gst::PadPresence::Always,
+                &caps,
+            )
+            .unwrap();
+
+            vec![src_pad_template]
+        });
+
+        PAD_TEMPLATES.as_ref()
+    }
+
+    fn change_state(
+        &self,
+        transition: gst::StateChange,
+    ) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
+        if let gst::StateChange::ReadyToPaused = transition {
+            self.obj().set_live(self.settings.lock().unwrap().is_live);
+        }
+        self.parent_change_state(transition)
+    }
+}
+
+impl BaseSrcImpl for AvSyncVideoTestSrc {
+    fn set_caps(&self, caps: &gst::Caps) -> Result<(), gst::LoggableError> {
+        let info = gst_video::VideoInfo::from_caps(caps).map_err(|_| {
+            gst::loggable_error!(CAT, "Failed to build `VideoInfo` from caps {}", caps)
+        })?;
+        if !matches!(
+            info.format(),
+            gst_video::VideoFormat::V210 | gst_video::VideoFormat::Uyvp
+        ) {
+            return Err(gst::loggable_error!(
+                CAT,
+                "Unsupported video format (expected v210 or UYVP): {:?}",
+                info.format()
+            ));
+        }
+
+        let pip_interval = self.settings.lock().unwrap().pip_interval;
+        // Bar width is one frame's horizontal step, so the sweep tiles gap-free
+        // and the bar thins as the frame rate rises.
+        let fps = info.fps().numer() as f64 / info.fps().denom() as f64;
+        let frames_per_interval =
+            (pip_interval.nseconds() as f64 / gst::ClockTime::SECOND.nseconds() as f64) * fps;
+        let bar_width = (info.width() as f64 / frames_per_interval).round().max(1.0) as u32;
+
+        let mut state = self.state.lock().unwrap();
+        state.bar_width = bar_width;
+        state.cdp_framerate = captions::cdp_framerate(info.fps());
+        state.info = Some(info);
+        drop(state);
+
+        let _ = self
+            .obj()
+            .post_message(gst::message::Latency::builder().src(&*self.obj()).build());
+
+        Ok(())
+    }
+
+    fn start(&self) -> Result<(), gst::ErrorMessage> {
+        *self.state.lock().unwrap() = Default::default();
+        self.unlock_stop()?;
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), gst::ErrorMessage> {
+        *self.state.lock().unwrap() = Default::default();
+        self.unlock()?;
+        Ok(())
+    }
+
+    fn query(&self, query: &mut gst::QueryRef) -> bool {
+        if let gst::QueryViewMut::Latency(q) = query.view_mut() {
+            let is_live = self.settings.lock().unwrap().is_live;
+            let state = self.state.lock().unwrap();
+            if let Some(ref info) = state.info {
+                let latency = gst::ClockTime::SECOND
+                    .mul_div_floor(info.fps().denom() as u64, info.fps().numer() as u64)
+                    .unwrap();
+                q.set(is_live, latency, gst::ClockTime::NONE);
+                return true;
+            }
+            return false;
+        }
+        BaseSrcImplExt::parent_query(self, query)
+    }
+
+    fn fixate(&self, mut caps: gst::Caps) -> gst::Caps {
+        let settings = *self.settings.lock().unwrap();
+        caps.truncate();
+        {
+            let caps = caps.make_mut();
+            let s = caps.structure_mut(0).unwrap();
+            s.fixate_field_nearest_int("width", settings.width);
+            s.fixate_field_nearest_int("height", settings.height);
+            s.fixate_field_nearest_fraction("framerate", settings.framerate);
+        }
+        self.parent_fixate(caps)
+    }
+
+    fn is_seekable(&self) -> bool {
+        false
+    }
+
+    fn unlock(&self) -> Result<(), gst::ErrorMessage> {
+        let mut clock_wait = self.clock_wait.lock().unwrap();
+        if let Some(clock_id) = clock_wait.clock_id.take() {
+            clock_id.unschedule();
+        }
+        clock_wait.flushing = true;
+        Ok(())
+    }
+
+    fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
+        self.clock_wait.lock().unwrap().flushing = false;
+        Ok(())
+    }
+}
+
+impl PushSrcImpl for AvSyncVideoTestSrc {
+    fn create(
+        &self,
+        _buffer: Option<&mut gst::BufferRef>,
+    ) -> Result<CreateSuccess, gst::FlowError> {
+        let settings = *self.settings.lock().unwrap();
+
+        let mut state = self.state.lock().unwrap();
+        let info = match state.info {
+            None => {
+                gst::element_imp_error!(self, gst::CoreError::Negotiation, ["Have no caps yet"]);
+                return Err(gst::FlowError::NotNegotiated);
+            }
+            Some(ref info) => info.clone(),
+        };
+        let bar_width = state.bar_width;
+        let n = state.n_frames;
+
+        let num = info.fps().numer() as u64;
+        let den = info.fps().denom() as u64;
+        let pts = gst::ClockTime::SECOND.mul_div_floor(n * den, num).unwrap();
+        let next_pts = gst::ClockTime::SECOND
+            .mul_div_floor((n + 1) * den, num)
+            .unwrap();
+        let bar_centre =
+            signal::bar_centre_column(signal::phase(pts, settings.pip_interval), info.width());
+        let frame_idx = n as u8;
+
+        // Phase-locked CEA-708 CDP: a TICK/TOCK caption on each pip frame, a null
+        // CDP otherwise (only when the frame rate is CDP-representable).
+        let cdp = state.cdp_framerate.map(|framerate| {
+            let text = captions::caption_for(pts, next_pts, settings.pip_interval);
+            state.caption_writer.next_cdp(framerate, n as u16, text)
+        });
+
+        let mut buffer = gst::Buffer::with_size(info.size()).unwrap();
+        {
+            let buffer = buffer.get_mut().unwrap();
+            buffer.set_pts(pts);
+            buffer.set_duration(next_pts - pts);
+            {
+                let mut map = buffer.map_writable().unwrap();
+                let data = map.as_mut_slice();
+                match info.format() {
+                    gst_video::VideoFormat::V210 => fill_v210(data, &info, bar_centre, bar_width),
+                    gst_video::VideoFormat::Uyvp => fill_uyvp(data, &info, bar_centre, bar_width),
+                    _ => unreachable!("format validated in set_caps"),
+                }
+                data[0] = frame_idx;
+            }
+            add_ancillary(
+                buffer,
+                signal::ANC_DID,
+                signal::ANC_SDID,
+                signal::ANC_LINE,
+                &[frame_idx],
+            );
+            if let Some(cdp) = &cdp {
+                add_ancillary(
+                    buffer,
+                    captions::CC_DID,
+                    captions::CC_SDID,
+                    captions::CC_LINE,
+                    cdp,
+                );
+            }
+        }
+        state.n_frames += 1;
+        drop(state);
+
+        self.sync_to_clock(&buffer)?;
+
+        Ok(CreateSuccess::NewBuffer(buffer))
+    }
+}
+
+impl AvSyncVideoTestSrc {
+    /// In live mode, wait on the pipeline clock until this frame's running time,
+    /// cancellable from `unlock()` (see `sinesrc`).
+    fn sync_to_clock(&self, buffer: &gst::Buffer) -> Result<(), gst::FlowError> {
+        if !self.obj().is_live() {
+            return Ok(());
+        }
+        let Some((clock, base_time)) = Option::zip(self.obj().clock(), self.obj().base_time())
+        else {
+            return Ok(());
+        };
+        let segment = self
+            .obj()
+            .segment()
+            .downcast::<gst::format::Time>()
+            .unwrap();
+        let running_time = segment.to_running_time(buffer.pts().opt_add(buffer.duration()));
+        let Some(wait_until) = running_time.opt_add(base_time) else {
+            return Ok(());
+        };
+
+        let mut clock_wait = self.clock_wait.lock().unwrap();
+        if clock_wait.flushing {
+            return Err(gst::FlowError::Flushing);
+        }
+        let id = clock.new_single_shot_id(wait_until);
+        clock_wait.clock_id = Some(id.clone());
+        drop(clock_wait);
+
+        let (res, _) = id.wait();
+        self.clock_wait.lock().unwrap().clock_id.take();
+        if res == Err(gst::ClockError::Unscheduled) {
+            return Err(gst::FlowError::Flushing);
+        }
+        Ok(())
+    }
+}

--- a/rust/gst-avsynctest-rs/src/videosrc/mod.rs
+++ b/rust/gst-avsynctest-rs/src/videosrc/mod.rs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use gst::glib;
+use gst::prelude::*;
+use gstreamer as gst;
+use gstreamer_base as gst_base;
+
+mod imp;
+
+glib::wrapper! {
+    pub struct AvSyncVideoTestSrc(ObjectSubclass<imp::AvSyncVideoTestSrc>)
+        @extends gst_base::PushSrc, gst_base::BaseSrc, gst::Element, gst::Object;
+}
+
+pub fn register(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
+    gst::Element::register(
+        Some(plugin),
+        "avsyncvideotestsrc",
+        gst::Rank::NONE,
+        AvSyncVideoTestSrc::static_type(),
+    )
+}

--- a/rust/gst-avsynctest-rs/tests/generator.rs
+++ b/rust/gst-avsynctest-rs/tests/generator.rs
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Standalone checks for the aligned A/V test sources, before any MXL round-trip
+//! is involved. `videoconvert`/`audioconvert` act as ground truth: they decode
+//! the native v210/UYVP and S24BE/S16BE packings, so a bad packer shows up as a
+//! misplaced bar or a missing pip.
+//!
+//! The core property: at every pip instant the audio energy peaks *and* the
+//! video bar is at screen centre. Both elements derive content from running
+//! time (segment start 0, so `running_time == pts`), so the two sources are
+//! compared on the same absolute timeline even when run in separate pipelines.
+
+use std::sync::Once;
+
+use gstreamer as gst;
+use gstreamer_app as gst_app;
+use gstreamer_audio as gst_audio;
+use gstreamer_video as gst_video;
+use gstreamer_video::prelude::*;
+
+const PIP_INTERVAL_NS: u64 = 200_000_000; // 200 ms
+const FPS: i32 = 25; // integer fps -> an exact frame sits on every pip
+const WIDTH: i32 = 192;
+const HEIGHT: i32 = 4;
+const VIDEO_FRAMES: i32 = 27; // ~1.08 s
+const RATE: i32 = 48_000;
+const SAMPLES_PER_BUFFER: i32 = 1_024;
+const AUDIO_BUFFERS: i32 = 50; // ~1.07 s
+
+fn init() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        gst::init().unwrap();
+        gst::Element::register(
+            None,
+            "avsyncvideotestsrc",
+            gst::Rank::NONE,
+            gstavsynctest::videosrc::AvSyncVideoTestSrc::static_type(),
+        )
+        .unwrap();
+        gst::Element::register(
+            None,
+            "avsyncaudiotestsrc",
+            gst::Rank::NONE,
+            gstavsynctest::audiosrc::AvSyncAudioTestSrc::static_type(),
+        )
+        .unwrap();
+    });
+}
+
+fn pull_all(sink: &gst_app::AppSink) -> Vec<gst::Sample> {
+    let mut out = Vec::new();
+    while let Ok(sample) = sink.pull_sample() {
+        out.push(sample);
+    }
+    out
+}
+
+fn appsink(pipeline: &gst::Pipeline) -> gst_app::AppSink {
+    pipeline
+        .by_name("sink")
+        .unwrap()
+        .downcast::<gst_app::AppSink>()
+        .unwrap()
+}
+
+fn run(desc: &str) -> Vec<gst::Sample> {
+    let pipeline = gst::parse::launch(desc)
+        .unwrap()
+        .downcast::<gst::Pipeline>()
+        .unwrap();
+    pipeline.set_state(gst::State::Playing).unwrap();
+    let samples = pull_all(&appsink(&pipeline));
+    pipeline.set_state(gst::State::Null).unwrap();
+    samples
+}
+
+fn argmax_column(sample: &gst::Sample) -> usize {
+    let caps = sample.caps().unwrap();
+    let info = gst_video::VideoInfo::from_caps(caps).unwrap();
+    let buffer = sample.buffer().unwrap();
+    let frame = gst_video::VideoFrameRef::from_buffer_ref_readable(buffer, &info).unwrap();
+    let stride = frame.plane_stride()[0] as usize;
+    let row = &frame.plane_data(0).unwrap()[..stride];
+    let width = info.width() as usize;
+    row.iter()
+        .take(width)
+        .enumerate()
+        .max_by_key(|&(_, &v)| v)
+        .map(|(x, _)| x)
+        .unwrap_or(0)
+}
+
+/// `(running_time_ns, amplitude)` for every mono F32LE sample in `samples`.
+fn audio_envelope(samples: &[gst::Sample]) -> Vec<(u64, f64)> {
+    let mut out = Vec::new();
+    for sample in samples {
+        let info = gst_audio::AudioInfo::from_caps(sample.caps().unwrap()).unwrap();
+        let rate = info.rate() as u64;
+        let buffer = sample.buffer().unwrap();
+        let pts = buffer.pts().unwrap().nseconds();
+        let map = buffer.map_readable().unwrap();
+        let samples_f32: &[f32] = gstavsynctest::analyze::f32le_samples(map.as_slice());
+        for (i, &v) in samples_f32.iter().enumerate() {
+            let t = pts + i as u64 * gst::ClockTime::SECOND.nseconds() / rate;
+            out.push((t, v as f64));
+        }
+    }
+    out
+}
+
+/// Number of full pips in an audio run of `duration_ns` (the pip at t=0 is
+/// skipped by the source).
+fn expected_pips(duration_ns: u64) -> u64 {
+    let half = gstavsynctest::signal::DEFAULT_PIP_DURATION.nseconds() / 2;
+    (1..)
+        .take_while(|k| k * PIP_INTERVAL_NS + half <= duration_ns)
+        .count() as u64
+}
+
+fn video_desc(format: &str) -> String {
+    format!(
+        "avsyncvideotestsrc num-buffers={VIDEO_FRAMES} pip-interval={PIP_INTERVAL_NS} is-live=false \
+           ! video/x-raw,format={format},width={WIDTH},height={HEIGHT},framerate={FPS}/1 \
+           ! videoconvert \
+           ! video/x-raw,format=GRAY8 \
+           ! appsink name=sink sync=false"
+    )
+}
+
+fn audio_desc(format: &str) -> String {
+    format!(
+        "avsyncaudiotestsrc num-buffers={AUDIO_BUFFERS} pip-interval={PIP_INTERVAL_NS} is-live=false \
+           ! audio/x-raw,format={format},channels=1,rate={RATE} \
+           ! audioconvert \
+           ! audio/x-raw,format=F32LE,channels=1,rate={RATE} \
+           ! appsink name=sink sync=false"
+    )
+}
+
+/// The bar is at screen centre on every pip frame and sweeps across the width.
+#[test]
+fn video_bar_sweeps_and_centres_on_pip() {
+    init();
+    let centre = WIDTH as f64 / 2.0;
+    for format in ["v210", "UYVP"] {
+        let samples = run(&video_desc(format));
+        assert_eq!(
+            samples.len(),
+            VIDEO_FRAMES as usize,
+            "{format}: expected {VIDEO_FRAMES} frames"
+        );
+
+        let frame_period = gst::ClockTime::SECOND.nseconds() / FPS as u64;
+        let frames_per_interval = PIP_INTERVAL_NS / frame_period;
+        // Bar width is one frame's step; centre frame lands within half of that.
+        let tol = (WIDTH as f64 / frames_per_interval as f64).max(2.0);
+
+        let centroids: Vec<(u64, f64)> = samples
+            .iter()
+            .map(|s| {
+                let pts = s.buffer().unwrap().pts().unwrap().nseconds();
+                (
+                    pts,
+                    gstavsynctest::analyze::bar_centroid(s).expect("bar present"),
+                )
+            })
+            .collect();
+
+        // Every pip frame (pts a multiple of the interval, except 0) is centred.
+        for (pts, c) in &centroids {
+            if *pts != 0 && pts.is_multiple_of(PIP_INTERVAL_NS) {
+                assert!(
+                    (c - centre).abs() <= tol,
+                    "{format}: bar off-centre at pip pts {pts}: centroid {c}, want ~{centre}"
+                );
+            }
+        }
+
+        // And the bar actually moves across most of the frame.
+        let cols: Vec<usize> = samples.iter().map(argmax_column).collect();
+        let spread = cols.iter().max().unwrap() - cols.iter().min().unwrap();
+        assert!(
+            spread as f64 >= WIDTH as f64 * 0.4,
+            "{format}: bar barely moved (spread {spread}px over width {WIDTH})"
+        );
+    }
+}
+
+/// The video source attaches a phase-locked CEA-708 caption: TICK/TOCK on each
+/// pip frame (alternating), a null CDP on every other frame. Round-tripped
+/// through `cdp-types`/`cea708-types` straight off the ancillary meta (before any
+/// `videoconvert`, which would drop it). 25 fps puts an exact frame on each pip.
+#[test]
+fn captions_tick_tock_on_pip_frames() {
+    init();
+    let desc = format!(
+        "avsyncvideotestsrc num-buffers={VIDEO_FRAMES} pip-interval={PIP_INTERVAL_NS} is-live=false \
+           ! video/x-raw,format=v210,width={WIDTH},height={HEIGHT},framerate={FPS}/1 \
+           ! appsink name=sink sync=false"
+    );
+    let samples = run(&desc);
+    assert_eq!(samples.len(), VIDEO_FRAMES as usize);
+    let frame_period = gst::ClockTime::SECOND.nseconds() / FPS as u64;
+
+    let mut parser = cdp_types::CDPParser::new();
+    let (mut ticks, mut tocks) = (0, 0);
+    for s in &samples {
+        let buffer = s.buffer().unwrap();
+        let pts = buffer.pts().unwrap().nseconds();
+        let n = pts / frame_period;
+        let cdp =
+            gstavsynctest::analyze::caption_cdp_bytes(buffer).expect("caption ancillary present");
+        let text = gstavsynctest::analyze::decode_caption(&mut parser, &cdp);
+        let on_pip = pts != 0 && pts.is_multiple_of(PIP_INTERVAL_NS);
+        match text {
+            Some(t) if on_pip => {
+                let want = if (pts / PIP_INTERVAL_NS) % 2 == 1 {
+                    "TICK"
+                } else {
+                    "TOCK"
+                };
+                assert_eq!(t, want, "frame {n} (pts {pts}): wrong caption");
+                if want == "TICK" {
+                    ticks += 1;
+                } else {
+                    tocks += 1;
+                }
+            }
+            Some(t) => panic!("frame {n} (pts {pts}): caption {t:?} off a pip frame"),
+            None => assert!(!on_pip, "frame {n} (pts {pts}): pip frame with no caption"),
+        }
+    }
+    assert!(
+        ticks >= 2 && tocks >= 2,
+        "too few captions: {ticks} ticks, {tocks} tocks"
+    );
+}
+
+/// Every native audio format decodes to a pip whose energy is centred on each
+/// pip instant.
+#[test]
+fn audio_pips_land_on_interval() {
+    init();
+    let duration_ns =
+        AUDIO_BUFFERS as u64 * SAMPLES_PER_BUFFER as u64 * gst::ClockTime::SECOND.nseconds()
+            / RATE as u64;
+    let n_pips = expected_pips(duration_ns);
+    assert!(n_pips >= 4, "test too short: only {n_pips} pips");
+    let tol = gstavsynctest::signal::DEFAULT_PIP_DURATION.nseconds() / 4;
+
+    for format in ["F32LE", "S24BE", "S16BE"] {
+        let env = audio_envelope(&run(&audio_desc(format)));
+        for k in 1..=n_pips {
+            let centre = k * PIP_INTERVAL_NS;
+            let lo = centre - PIP_INTERVAL_NS / 2;
+            let hi = centre + PIP_INTERVAL_NS / 2;
+            let mut energy = 0.0f64;
+            let mut weighted = 0.0f64;
+            for &(t, a) in &env {
+                if t > lo && t <= hi {
+                    let e = a * a;
+                    energy += e;
+                    weighted += t as f64 * e;
+                }
+            }
+            assert!(energy > 0.0, "{format}: no pip energy near {centre} ns");
+            let detected = (weighted / energy) as u64;
+            assert!(
+                detected.abs_diff(centre) <= tol,
+                "{format}: pip {k} centroid {detected} ns off from {centre} ns (tol {tol})"
+            );
+        }
+    }
+}

--- a/rust/gst-nmos-rs/Cargo.toml
+++ b/rust/gst-nmos-rs/Cargo.toml
@@ -51,6 +51,11 @@ test-skip = { path = "../test-skip" }
 # Used by the IS-08 audio integration test to push test tones into the
 # daemon-backed pipeline and pull samples back out of appsinks.
 gstreamer-app = "0.24.4"
+# Aligned A/V test sources (avsyncvideotestsrc / avsyncaudiotestsrc) and the
+# recovery-side analysis helpers used by the end-to-end sync test.
+gst-avsynctest-rs = { path = "../gst-avsynctest-rs" }
+# CDP parser for decoding the recovered CEA-708 captions in the sync test.
+cdp-types = "0.3"
 
 [build-dependencies]
 gst-plugin-version-helper = "0.8.3"

--- a/rust/gst-nmos-rs/README.md
+++ b/rust/gst-nmos-rs/README.md
@@ -242,3 +242,27 @@ See [`doc/designs/gst-nmos-rs-st2022-7-dual-leg-plan.md`](../../doc/designs/gst-
 **Not yet supported:** `video/x-jxsv`.
 
 Design notes: [`doc/designs/gst-nmos-rs-nvdsudp-plan.md`](../../doc/designs/gst-nmos-rs-nvdsudp-plan.md).
+
+## Sync Testing
+
+[`tests/av_sync.rs`](tests/av_sync.rs) is an end-to-end integration test that
+drives [`gst-avsynctest-rs`](../gst-avsynctest-rs)'s `avsyncvideotestsrc` /
+`avsyncaudiotestsrc` through real NMOS Senders and Receivers and asserts that
+video, audio-pip, and CEA-708 caption alignment survive the round-trip. The
+video's ancillary data (frame index plus a phase-locked TICK/TOCK caption) is
+split into its own Sender with `st2038extractor` and re-attached on the
+Receiver side with `st2038combiner`. It runs once per transport
+(`av_sync_via_mxl`, `av_sync_via_udp`, `av_sync_via_nvdsudp`), negotiating the
+essence format each transport expects (MXL: `v210`/`F32LE`, RTP/UDP:
+`UYVP`/`S24BE`).
+
+```sh
+cargo test -p gst-nmos-rs --test av_sync -- --test-threads=1
+```
+
+Each case **self-skips** (rather than fails) when its prerequisites are
+missing — `libnvnmos` / `nvnmosd` (see [workspace README](../README.md)), the
+transport's element factories on `GST_PLUGIN_PATH`, and, for MXL, `/dev/shm`.
+The `mxl` and `udp` cases additionally need current `st2038combiner`
+(`drop-late-st2038`) and `rtpsmpte291depay` builds on `GST_PLUGIN_PATH`; the
+`nvdsudp` case needs the DeepStream/Rivermax stack above.

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -908,6 +908,21 @@ pub(crate) fn build_udpsink(
         payloader.set_property("min-ptime", ns);
         payloader.set_property("max-ptime", ns);
     }
+    // Default the RTP timestamp base to 0 so the timestamp is a pure function of the
+    // buffer's running time (rtp_ts = running_time · clock_rate). This makes the
+    // advertised `a=mediaclk:direct=0` truthful and — because every flow of one
+    // Sender shares the pipeline base_time — yields equal RTP timestamps for equal
+    // PTS across flows (e.g. video and its extracted ancillary), which the stock
+    // random per-stream offset breaks. Set before `pay-properties` are applied so a
+    // caller can restore the GStreamer default with `timestamp-offset=-1`. V1
+    // payloaders type the property `guint`; the `pay2` siblings `gint64`.
+    if let Some(pspec) = payloader.class().find_property("timestamp-offset") {
+        if pspec.value_type() == glib::Type::U32 {
+            payloader.set_property("timestamp-offset", 0u32);
+        } else if pspec.value_type() == glib::Type::I64 {
+            payloader.set_property("timestamp-offset", 0i64);
+        }
+    }
 
     let udpsink = gst::ElementFactory::make("udpsink")
         .name("nmossink-udpsink")
@@ -1953,6 +1968,30 @@ mod tests {
             .static_pad("sink")
             .expect("inner bin missing `sink` ghost pad");
         assert!(ghost.is::<gst::GhostPad>());
+    }
+
+    #[test]
+    fn build_udpsink_defaults_timestamp_offset_zero_and_pay_properties_override() {
+        // Default: pin the RTP timestamp base to 0 so equal PTS yields equal RTP
+        // timestamps across a Sender's flows and `a=mediaclk:direct=0` is truthful.
+        let chain = build_udpsink(&minimal_udp_media(), UdpVariant::V1)
+            .expect("V1 video sender chain must construct");
+        assert_eq!(
+            chain.pay.property::<u32>("timestamp-offset"),
+            0,
+            "payloader timestamp-offset must default to 0",
+        );
+        // Overridable: `pay-properties` are applied after the default, so a caller can
+        // restore the GStreamer random default (`-1`, i.e. u32::MAX for the V1 spec).
+        let props = gst::Structure::builder("properties")
+            .field("timestamp-offset", u32::MAX)
+            .build();
+        apply_udp_sink_inner_properties(test_log_cat(), "nmossink", &chain, None, Some(&props));
+        assert_eq!(
+            chain.pay.property::<u32>("timestamp-offset"),
+            u32::MAX,
+            "pay-properties must override the pinned default",
+        );
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -682,9 +682,10 @@ pub(crate) struct UdpSrcChain {
 
 #[derive(Debug)]
 pub(crate) struct NvDsUdpSinkChain {
-    /// Inner `nvdsudpsink` added directly to the outer bin (same object as [`Self::bin`]).
+    /// Wrapper added to the outer bin: the bare `nvdsudpsink`, or (for ST-2038)
+    /// a sub-bin wrapping `capsfilter ! nvdsudpsink` that pins `alignment=frame`.
     pub bin: gst::Element,
-    /// Same element as [`Self::bin`].
+    /// Inner `nvdsudpsink` (same object as [`Self::bin`] unless wrapped).
     pub transport: gst::Element,
 }
 
@@ -1483,6 +1484,51 @@ pub(crate) fn build_nvdsudpsink(
     // drop this chain struct — keep the temp file on the GstObject.
     SdpFileGuard::attach_to_element(&sink, sdp_file);
 
+    // `nvdsudpsink`'s sink pad template is `ANY` (see gst-nvdsudp), so on its
+    // own it neither advertises nor rejects the per-frame ST-2038 grouping its
+    // Mode-3 ANC path assumes — a `packet`/`line` peer would be accepted and
+    // silently mis-packetized. `mxlsink` and `rtpsmpte291pay` get this from their
+    // real sink templates; for ANC we restore parity by standing in for the
+    // missing template with a `capsfilter`. Pin exactly what those templates pin
+    // — `meta/x-st-2038, alignment=frame`, nothing more — so it rejects a
+    // non-`frame` peer and fixates an alignment-less one without constraining
+    // framerate (which negotiates freely, as it does through their templates).
+    // Drop this if `nvdsudpsink` ever grows a real sink template.
+    if media.format == FlowFormat::Data {
+        let filter_caps = gst::Caps::builder("meta/x-st-2038")
+            .field("alignment", "frame")
+            .build();
+        let capsfilter = gst::ElementFactory::make("capsfilter")
+            .name("nmossink-nvdsudp-anc-align")
+            .property("caps", filter_caps)
+            .build()
+            .with_context(|| "instantiating `capsfilter` for nvdsudp ANC alignment")?;
+        let bin = gst::Bin::with_name("nmossink-nvdsudp");
+        bin.add_many([&capsfilter, &sink])
+            .map_err(|e| anyhow!("adding capsfilter + nvdsudpsink to inner bin: {e}"))?;
+        capsfilter
+            .link(&sink)
+            .with_context(|| "linking capsfilter to nvdsudpsink")?;
+        let cf_sink = capsfilter
+            .static_pad("sink")
+            .ok_or_else(|| anyhow!("capsfilter missing sink pad"))?;
+        let ghost = gst::GhostPad::builder(gst::PadDirection::Sink)
+            .name("sink")
+            .build();
+        ghost
+            .set_target(Some(&cf_sink))
+            .map_err(|e| anyhow!("setting inner ghost sink target: {e}"))?;
+        ghost
+            .set_active(true)
+            .map_err(|e| anyhow!("activating inner ghost sink: {e}"))?;
+        bin.add_pad(&ghost)
+            .map_err(|e| anyhow!("adding ghost sink to inner bin: {e}"))?;
+        return Ok(NvDsUdpSinkChain {
+            bin: bin.upcast(),
+            transport: sink,
+        });
+    }
+
     Ok(NvDsUdpSinkChain {
         bin: sink.clone(),
         transport: sink,
@@ -1519,20 +1565,34 @@ fn set_nvdsudp_ptp_src_from_sdp(
 /// No external depayloader.
 pub(crate) fn build_nvdsudpsrc(
     media: &UdpMedia,
-    caps: &gst::Caps,
     sdp_text: &str,
 ) -> Result<NvDsUdpSrcChain, anyhow::Error> {
     require_nvdsudp_factory("nvdsudpsrc")?;
-    let pkt = packetization::from_media(media.format, &media.raw_caps, &media.rtp_caps)?;
+    // ST-2038 essence caps carry no `alignment` (a buffer-grouping detail, not a
+    // transport property), but `nvdsudpsrc`'s src pad is `ANY` and can't advertise
+    // the per-frame grouping DeepStream's Mode-3 ANC path produces. Stamp `frame`
+    // onto the output caps so a downstream `st2038combiner` (which requires the
+    // field) sees it — the src-side mirror of the `capsfilter` `build_nvdsudpsink`
+    // inserts. Add only when absent; an explicit non-`frame` is left for
+    // `from_media`/`anc_from_raw_caps` to reject rather than silently relabel.
+    let mut caps = media.raw_caps.clone();
+    if media.format == FlowFormat::Data
+        && let Some(s) = caps.make_mut().structure_mut(0)
+        && s.name() == "meta/x-st-2038"
+        && s.get::<&str>("alignment").is_err()
+    {
+        s.set("alignment", "frame");
+    }
+    let pkt = packetization::from_media(media.format, &caps, &media.rtp_caps)?;
 
     let src = if let Some(secondary) = &media.secondary {
         let streams = format!("{},{}", host_port(&media.primary), host_port(secondary));
-        nvdsudpsrc_builder(caps)
+        nvdsudpsrc_builder(&caps)
             .property("st2022-7-streams", &streams)
             .build()
             .with_context(|| format!("instantiating `nvdsudpsrc` (st2022-7-streams={streams})"))?
     } else {
-        nvdsudpsrc_builder(caps)
+        nvdsudpsrc_builder(&caps)
             .property("address", &media.primary.destination_ip)
             .property("port", i32::from(media.primary.destination_port))
             .build()
@@ -1864,7 +1924,7 @@ mod tests {
             )
             .expect("static rtp caps parse"),
             raw_caps: gst::Caps::from_str(
-                "meta/x-st-2038,alignment=frame,framerate=60/1",
+                "meta/x-st-2038,framerate=60/1",
             )
             .expect("static raw caps parse"),
         }
@@ -2524,8 +2584,30 @@ mod tests {
         if !nvdsudp_available() {
             return;
         }
-        build_nvdsudpsink(&anc_smpte291_media(), ANC_NVDSUDP_SDP)
-            .expect("ANC nvdsudpsink chain");
+        let chain =
+            build_nvdsudpsink(&anc_smpte291_media(), ANC_NVDSUDP_SDP).expect("ANC nvdsudpsink chain");
+        // The bin wraps `capsfilter ! nvdsudpsink` so its sink pad advertises the
+        // per-frame grouping `nvdsudpsink`'s own `ANY` pad can't (see the wrap in
+        // build_nvdsudpsink): a `packet`/`line` peer must fail negotiation here.
+        assert_ne!(
+            chain.bin.as_ptr(),
+            chain.transport.as_ptr(),
+            "ANC sink must be wrapped behind an alignment capsfilter"
+        );
+        let sink_pad = chain.bin.static_pad("sink").expect("bin sink pad");
+        let advertised = sink_pad.query_caps(None);
+        assert!(
+            advertised.can_intersect(
+                &gst::Caps::from_str("meta/x-st-2038,alignment=frame").unwrap()
+            ),
+            "ANC sink bin must advertise alignment=frame, got {advertised}"
+        );
+        assert!(
+            advertised
+                .intersect(&gst::Caps::from_str("meta/x-st-2038,alignment=packet").unwrap())
+                .is_empty(),
+            "ANC sink bin must reject a non-frame peer, got {advertised}"
+        );
     }
 
     #[test]
@@ -2533,8 +2615,7 @@ mod tests {
         if !nvdsudp_available() {
             return;
         }
-        let caps = anc_smpte291_media().raw_caps.clone();
-        let chain = build_nvdsudpsrc(&anc_smpte291_media(), &caps, ANC_NVDSUDP_SDP)
+        let chain = build_nvdsudpsrc(&anc_smpte291_media(), ANC_NVDSUDP_SDP)
             .expect("ANC nvdsudpsrc chain");
         assert_eq!(chain.transport.property::<u32>("header-size"), 20);
     }
@@ -2549,7 +2630,7 @@ mod tests {
         let sdp = format!(
             "{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",
         );
-        let chain = build_nvdsudpsrc(&media, &media.raw_caps, &sdp).expect("nvdsudpsrc chain");
+        let chain = build_nvdsudpsrc(&media, &sdp).expect("nvdsudpsrc chain");
         assert_eq!(
             chain.transport.property::<String>("ptp-src"),
             "192.0.2.11",
@@ -2592,7 +2673,7 @@ mod tests {
         let sdp = format!(
             "{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",
         );
-        let chain = build_nvdsudpsrc(&media, &media.raw_caps, &sdp).expect("nvdsudpsrc chain");
+        let chain = build_nvdsudpsrc(&media, &sdp).expect("nvdsudpsrc chain");
         assert!(
             chain.transport.property::<Option<String>>("ptp-src").is_none(),
             "receiver ptp-src must require a=x-nvnmos-iface-ip, not source-filter source",

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -620,8 +620,7 @@ impl NmosSrc {
                     TransportConfig::NvDsUdp { media, transport_file, .. } => {
                         {
                             let sdp = transport_file.as_deref().unwrap_or("");
-                            let chain =
-                                inner::build_nvdsudpsrc(media, &media.raw_caps, sdp)?;
+                            let chain = inner::build_nvdsudpsrc(media, sdp)?;
                             let settings = self.settings.lock().unwrap();
                             inner::apply_nvdsudp_src_inner_properties(
                                 &CAT,
@@ -904,7 +903,7 @@ impl NmosSrc {
             InnerConfig::Real(TransportConfig::NvDsUdp { media, transport_file, .. }) => {
                 let settings = self.settings.lock().unwrap();
                 let sdp = transport_file.as_deref().unwrap_or("");
-                match inner::build_nvdsudpsrc(media, &media.raw_caps, sdp) {
+                match inner::build_nvdsudpsrc(media, sdp) {
                     Ok(chain) => {
                         inner::apply_nvdsudp_src_inner_properties(
                             &CAT,

--- a/rust/gst-nmos-rs/src/nvdsudp/packetization.rs
+++ b/rust/gst-nmos-rs/src/nvdsudp/packetization.rs
@@ -135,8 +135,15 @@ pub(crate) fn from_media(
     }
 }
 
-/// ST 2110-40 ANC (`meta/x-st-2038,alignment=frame`). DeepStream selects
-/// Mode 3 from sink/src caps; ANC RTP packet sizes vary.
+/// ST 2110-40 ANC (`meta/x-st-2038`). DeepStream Mode-3 ANC is inherently
+/// per-frame, but the `nvdsudpsink`/`nvdsudpsrc` pads are `ANY` so they can't
+/// carry that grouping in negotiation; it's materialised on the graph by the
+/// `capsfilter` `build_nvdsudpsink` inserts and the output caps `build_nvdsudpsrc`
+/// stamps. This build-time check complements them: classify the flow as ANC
+/// (drives `header-size`) and reject an *explicit* non-`frame` alignment before a
+/// chain is built. An absent alignment is fine —
+/// transport-file caps never carry the field (an explicit one can only appear
+/// when `caps` are applied directly rather than resynthesised).
 pub(crate) fn anc_from_raw_caps(raw_caps: &gst::Caps) -> Result<Packetization, anyhow::Error> {
     let s = raw_caps
         .structure(0)
@@ -148,9 +155,8 @@ pub(crate) fn anc_from_raw_caps(raw_caps: &gst::Caps) -> Result<Packetization, a
         );
     }
     match s.get::<&str>("alignment") {
-        Ok("frame") => {}
+        Ok("frame") | Err(_) => {}
         Ok(other) => bail!("nvdsudp ANC requires alignment=frame, got `{other}`"),
-        Err(_) => bail!("nvdsudp ANC requires alignment=frame on meta/x-st-2038 caps"),
     }
     Ok(Packetization::Anc)
 }
@@ -501,6 +507,18 @@ mod tests {
             .unwrap();
         let pkt = from_media(FlowFormat::Data, &caps, &gst::Caps::new_empty())
             .expect("ANC packetization");
+        assert!(matches!(pkt, Packetization::Anc));
+    }
+
+    #[test]
+    fn anc_accepts_missing_alignment() {
+        init_gst();
+        // Transport-file caps omit `alignment` (a buffer-grouping detail); the
+        // classifier tolerates that — the per-frame grouping is enforced on the
+        // graph by the nvdsudp capsfilter / output caps, not here.
+        let caps = gst::Caps::from_str("meta/x-st-2038,framerate=60/1").unwrap();
+        let pkt = from_media(FlowFormat::Data, &caps, &gst::Caps::new_empty())
+            .expect("ANC packetization with no alignment");
         assert!(matches!(pkt, Packetization::Anc));
     }
 

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -50,7 +50,8 @@
 //!     unsupported (out of scope for ST 2110-30).
 //!   * ANC: RFC 8331 `encoding-name=SMPTE291` over
 //!     `m=video` (SMPTE ST 2110-40), producing
-//!     `meta/x-st-2038, alignment=frame[, framerate=N/D]`.
+//!     `meta/x-st-2038[, framerate=N/D]` (no `alignment` —
+//!     buffer grouping is an element concern, not a transport one).
 //!     Conversion happens via the
 //!     [`rtpsmpte291pay`](https://gstreamer.freedesktop.org/documentation/rsrtp/rtpsmpte291pay.html)
 //!     / `rtpsmpte291depay` elements from `gst-plugins-rs`'
@@ -1976,13 +1977,14 @@ fn raw_caps_from_rtp_audio(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> 
 /// Derive `meta/x-st-2038,...` caps from an `application/x-rtp,...`
 /// caps that describes an RFC 8331 / SMPTE ST 2110-40 ANC media.
 ///
-/// The produced caps match the sink-pad template of `gst-plugins-rs`'
-/// `rtpsmpte291pay` (and the src-pad template of `rtpsmpte291depay`)
-/// and the existing `meta/x-st-2038, framerate=N/D` convention used
-/// by [`crate::flow_def::build_data_body`]:
+/// Matches the `meta/x-st-2038, framerate=N/D` convention used by
+/// [`crate::flow_def::build_data_body`] — deliberately without an
+/// `alignment` field, which is a GStreamer buffer-grouping detail
+/// (packet/line/frame) rather than a transport property. Pipeline
+/// elements declare the grouping they need themselves:
 ///
 /// ```text
-/// meta/x-st-2038, alignment=frame[, framerate=N/D]
+/// meta/x-st-2038[, framerate=N/D]
 /// ```
 ///
 /// `framerate` is hoisted from the `exactframerate` token on the
@@ -2008,7 +2010,12 @@ fn raw_caps_from_rtp_data(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
         .get::<&str>("exactframerate")
         .ok()
         .and_then(parse_exact_framerate);
-    let mut caps_text = String::from("meta/x-st-2038,alignment=frame");
+    // No `alignment` field: it describes how many ANC packets a GStreamer
+    // buffer groups (packet/line/frame), not anything the SDP carries. Each
+    // pipeline element declares the grouping it needs (`rtpsmpte291pay` /
+    // `mxlsink` sink templates require `frame`; `rtpsmpte291depay` emits
+    // `packet`); the transport-file-derived caps must not assert one.
+    let mut caps_text = String::from("meta/x-st-2038");
     if let Some((num, den)) = framerate {
         caps_text.push_str(&format!(",framerate={num}/{den}"));
     }
@@ -4296,10 +4303,10 @@ mod tests {
             "ANC raw caps must match the `rtpsmpte291*` element's pad template \
              and the existing `flow_def::build_data_body` convention",
         );
-        assert_eq!(
-            raw_s.get::<&str>("alignment").unwrap(),
-            "frame",
-            "`alignment=frame` matches `rtpsmpte291pay`'s sink pad template",
+        assert!(
+            raw_s.get::<&str>("alignment").is_err(),
+            "ANC raw caps must not carry `alignment` — buffer grouping is an \
+             element concern (sink templates require it), not a transport one",
         );
         assert_eq!(
             raw_s.get::<gst::Fraction>("framerate").unwrap(),
@@ -4337,10 +4344,9 @@ mod tests {
              exactframerate; downstream caps-merge (element property / \
              paired-flow context) fills it in",
         );
-        assert_eq!(
-            raw_s.get::<&str>("alignment").unwrap(),
-            "frame",
-            "alignment=frame must still be present without exactframerate",
+        assert!(
+            raw_s.get::<&str>("alignment").is_err(),
+            "ANC raw caps must not carry `alignment` regardless of exactframerate",
         );
     }
 
@@ -4364,9 +4370,10 @@ mod tests {
         let orig_raw = original.raw_caps.structure(0).unwrap();
         let rt_raw = round_tripped.raw_caps.structure(0).unwrap();
         assert_eq!(rt_raw.name(), orig_raw.name());
-        assert_eq!(
-            rt_raw.get::<&str>("alignment"),
-            orig_raw.get::<&str>("alignment"),
+        assert!(
+            orig_raw.get::<&str>("alignment").is_err()
+                && rt_raw.get::<&str>("alignment").is_err(),
+            "ANC raw caps carry no `alignment` on either side of the round-trip",
         );
         assert_eq!(
             rt_raw.get::<gst::Fraction>("framerate"),
@@ -4810,7 +4817,7 @@ mod tests {
     #[test]
     fn rtp_caps_from_raw_data_minimal_meta_x_st_2038() {
         init_gst();
-        let raw = gst::Caps::from_str("meta/x-st-2038,alignment=frame").expect("data caps");
+        let raw = gst::Caps::from_str("meta/x-st-2038").expect("data caps");
         let rtp = rtp_caps_from_raw_data(&raw, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
@@ -4826,14 +4833,14 @@ mod tests {
     #[test]
     fn rtp_caps_from_raw_data_propagates_framerate() {
         init_gst();
-        let raw = gst::Caps::from_str("meta/x-st-2038,alignment=frame,framerate=25/1")
+        let raw = gst::Caps::from_str("meta/x-st-2038,framerate=25/1")
             .expect("data caps");
         let rtp = rtp_caps_from_raw_data(&raw, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "25");
 
         let fractional = gst::Caps::from_str(
-            "meta/x-st-2038,alignment=frame,framerate=30000/1001",
+            "meta/x-st-2038,framerate=30000/1001",
         )
         .expect("data caps");
         let rtp = rtp_caps_from_raw_data(&fractional, 100).expect("synth");
@@ -4853,7 +4860,7 @@ mod tests {
     fn rtp_caps_from_raw_data_round_trips_through_raw_caps_from_rtp_data() {
         init_gst();
         let original = gst::Caps::from_str(
-            "meta/x-st-2038,alignment=frame,framerate=25/1",
+            "meta/x-st-2038,framerate=25/1",
         )
         .expect("data caps");
         let rtp = rtp_caps_from_raw_data(&original, 100).expect("synth");
@@ -5233,7 +5240,7 @@ mod tests {
     fn from_caps_data_synthesises_st2110_40_sdp() {
         init_gst();
         let essence = gst::Caps::from_str(
-            "meta/x-st-2038,alignment=frame,framerate=25/1",
+            "meta/x-st-2038,framerate=25/1",
         )
         .unwrap();
         let input = build_input(&essence, Side::Sender, None);
@@ -5336,7 +5343,7 @@ mod tests {
     fn from_caps_round_trips_through_parse_sdp_for_data() {
         init_gst();
         let essence = gst::Caps::from_str(
-            "meta/x-st-2038,alignment=frame,framerate=25/1",
+            "meta/x-st-2038,framerate=25/1",
         )
         .unwrap();
         let input = build_input(&essence, Side::Sender, None);

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -2110,7 +2110,7 @@ mod tests {
 
         fn anc_peer_caps() -> gst::Caps {
             init_gst();
-            gst::Caps::from_str("meta/x-st-2038,alignment=frame,framerate=30/1")
+            gst::Caps::from_str("meta/x-st-2038,framerate=30/1")
                 .expect("anc caps")
         }
 

--- a/rust/gst-nmos-rs/tests/av_sync.rs
+++ b/rust/gst-nmos-rs/tests/av_sync.rs
@@ -1,0 +1,872 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end audio/video/caption synchronisation through NMOS Senders and
+//! Receivers, parameterised over transport (`mxl`, `udp`, `nvdsudp`).
+//!
+//! The producer runs the phase-locked [`avsyncvideotestsrc`] and
+//! [`avsyncaudiotestsrc`] from the `gst-avsynctest-rs` crate. `st2038extractor`
+//! splits the video's ancillary data (the frame index plus a phase-locked
+//! CEA-708 TICK/TOCK caption) off into its own flow, so the Node exposes three
+//! Senders — video (v210/UYVP), data (ST 2038), audio (F32LE/S24BE):
+//!
+//! ```text
+//! avsyncvideotestsrc (video+data) ! ... ! st2038extractor ─ ext.src    ! queue ! nmossink (video)
+//!                                                         └ ext.st2038 ! queue ! nmossink (data)
+//! avsyncaudiotestsrc (audio) ! ...                                     ! queue ! nmossink (audio)
+//! ```
+//!
+//! The consumer's three Receivers read the flows back; `st2038combiner`
+//! re-attaches the ancillary data onto the recovered video frames, so the
+//! caption rides the video buffer again and A/V + caption alignment can be
+//! asserted on two appsinks:
+//!
+//! ```text
+//! nmossrc (video) ! queue ! comb.sink    ─ st2038combiner ! queue ! appsink (video+data)
+//! nmossrc (data)  ! queue ! comb.st2038 ─┘
+//! nmossrc (audio) ! queue                                         ! appsink (audio)
+//! ```
+//!
+//! Ported from `mxl/rust/gst-mxl-rs/tests/av_sync.rs`, substituting
+//! `nmossink`/`nmossrc` (+ an `nvnmosd` child process) for the bare
+//! `mxlsink`/`mxlsrc`, and adding the ancillary data flow and caption check.
+//!
+//! Each case self-gates: it runs when its transport's toolchain is present and
+//! otherwise prints a skip reason (so a checkout without MXL / DeepStream
+//! neither fails nor is silently `#[ignore]`d).
+//!
+//! MXL co-times both flows through one grain-index→PTS mapping, so ancillary
+//! pairs exactly (`anc_tolerance_frames() == 0`) and captions survive. The `udp`
+//! case runs but relaxes ancillary to +/-1 frame: the software RTP receive path
+//! (`udpsrc ! rtp*depay`, no rtpjitterbuffer) derives each flow's PTS from
+//! packet arrival time, so a video frame's whole ancillary group (the index and
+//! its co-timed caption CDP) shifts onto an adjacent frame (a "double" next to a
+//! "none") — every packet still arrives, within one frame of its home, and the
+//! caption always rides with its bar-centre index. Exact `udp` pairing needs an
+//! RFC 7273-sync jitterbuffer on a shared PTP clock (see [`skip_reason`]).
+//! Captions are still asserted best-effort because atomic index+caption delivery
+//! depends on the `rtpsmpte291depay` multi-ANC fix that is not yet in a released
+//! `gst-plugins-rs`; on a stock toolchain the second ANC packet is mis-read.
+//! `nvdsudp` needs the DeepStream + PTP runtime and self-skips without it.
+
+mod common;
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Once;
+
+use common::{init, nvnmosd_skip_reason, DaemonGuard};
+use gst::prelude::*;
+use gstreamer as gst;
+use gstreamer_app as gst_app;
+use test_skip::skip;
+
+// Cadence. 25 fps puts an exact frame on every 200 ms pip and — unlike 50 fps —
+// keeps each TICK/TOCK caption's CEA-708 DTVCC packet inside a single frame's
+// CDP, so a bar-centre frame carries its whole caption (at 50 fps the caption
+// spills into the next frame's cc_data). 25/1 is CDP-representable.
+const FR_NUM: i32 = 25;
+const FR_DEN: i32 = 1;
+const FRAME_PERIOD_NS: u64 = gst::ClockTime::SECOND.nseconds() * FR_DEN as u64 / FR_NUM as u64;
+const PIP_INTERVAL_NS: u64 = 200_000_000; // 200 ms
+const FRAMES_PER_INTERVAL: u64 = PIP_INTERVAL_NS / FRAME_PERIOD_NS; // 5
+// Small frames keep every push cheap; width is a multiple of 6 (v210 group) and
+// of 2 (UYVP pair), height > 1 so the bar is visible on more than one line.
+const WIDTH: i32 = 192;
+const HEIGHT: i32 = 4;
+const NUM_FRAMES: i32 = 75; // 3 s at 25 fps; < 256 so the byte-0 index is unambiguous
+const RATE: i32 = 48_000;
+const NUM_AUDIO_BUFFERS: i32 = 155; // covers the video run with margin
+/// Maximum inter-flow attach offset, in frames. Each Receiver's reader anchors
+/// at its flow's head as it appears; the video and data readers can anchor up to
+/// this many frames apart, so only that many head frames may arrive before the
+/// combiner can pair ancillary onto them. After attach there are no drops (in
+/// practice the offset is one or two frames). Applied once — not per reader.
+const ATTACH_SLACK: usize = 5;
+
+const NODE_SEED: &str = "nvnmos-avsync-test";
+const VIDEO_SENDER: &str = "video-sender";
+const DATA_SENDER: &str = "data-sender";
+const AUDIO_SENDER: &str = "audio-sender";
+const VIDEO_RECEIVER: &str = "video-receiver";
+const DATA_RECEIVER: &str = "data-receiver";
+const AUDIO_RECEIVER: &str = "audio-receiver";
+
+// Stable per-flow MXL identifiers (each run gets a fresh /dev/shm domain, so
+// these never collide across runs).
+const DOMAIN_ID: &str = "11111111-2222-3333-4444-555555555555";
+const VIDEO_FLOW_ID: &str = "00000000-0000-0000-0000-0000000000a0";
+const DATA_FLOW_ID: &str = "00000000-0000-0000-0000-0000000000d0";
+const AUDIO_FLOW_ID: &str = "00000000-0000-0000-0000-0000000000b0";
+
+// RTP/UDP multicast destinations (one group per flow).
+const VIDEO_MCAST: (&str, u32) = ("232.99.98.1", 5040);
+const DATA_MCAST: (&str, u32) = ("232.99.98.2", 5042);
+const AUDIO_MCAST: (&str, u32) = ("232.99.98.3", 5044);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Transport {
+    Mxl,
+    Udp,
+    NvdsUdp,
+}
+
+impl Transport {
+    fn nmos_name(self) -> &'static str {
+        match self {
+            Transport::Mxl => "mxl",
+            Transport::Udp => "udp",
+            Transport::NvdsUdp => "nvdsudp",
+        }
+    }
+
+    fn video_format(self) -> &'static str {
+        match self {
+            Transport::Mxl => "v210",
+            Transport::Udp | Transport::NvdsUdp => "UYVP",
+        }
+    }
+
+    fn audio_format(self) -> &'static str {
+        match self {
+            Transport::Mxl => "F32LE",
+            Transport::Udp | Transport::NvdsUdp => "S24BE",
+        }
+    }
+
+    /// `st2038combiner drop-late-st2038`. MXL (and PTP-timed nvdsudp) co-time the
+    /// video and ancillary flows exactly, so late ANC is a real error worth
+    /// dropping to keep pairing strict. The software RTP path times each flow from
+    /// packet arrival, so the ancillary lands a few ms off its frame; dropping it
+    /// would lose it, so we collect it onto the nearest frame instead.
+    fn combiner_drop_late(self) -> bool {
+        match self {
+            Transport::Mxl | Transport::NvdsUdp => true,
+            Transport::Udp => false,
+        }
+    }
+
+    /// How far, in frames, a recovered frame's ancillary index may sit from the
+    /// frame's own index. Zero for the co-timed transports (exact pairing); one for
+    /// the software RTP path, whose arrival-time PTS can shift ancillary to an
+    /// adjacent frame (see the module header).
+    fn anc_tolerance_frames(self) -> u8 {
+        match self {
+            Transport::Mxl | Transport::NvdsUdp => 0,
+            Transport::Udp => 1,
+        }
+    }
+
+    /// Extra element factories the transport's inner data path needs, so a
+    /// missing one skips (rather than fails) on a checkout without that stack.
+    fn transport_factories(self) -> &'static [&'static str] {
+        match self {
+            Transport::Mxl => &["mxlsink", "mxlsrc"],
+            Transport::Udp => &["udpsink", "udpsrc"],
+            Transport::NvdsUdp => &["nvdsudpsink", "nvdsudpsrc"],
+        }
+    }
+}
+
+/// Register the aligned A/V sources (they live in a library crate, not a plugin
+/// on `GST_PLUGIN_PATH`) once per process, after `common::init`'s `gst::init`.
+fn register_sources() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        gst::Element::register(
+            None,
+            "avsyncvideotestsrc",
+            gst::Rank::NONE,
+            gstavsynctest::videosrc::AvSyncVideoTestSrc::static_type(),
+        )
+        .unwrap();
+        gst::Element::register(
+            None,
+            "avsyncaudiotestsrc",
+            gst::Rank::NONE,
+            gstavsynctest::audiosrc::AvSyncAudioTestSrc::static_type(),
+        )
+        .unwrap();
+    });
+}
+
+/// Per-test MXL Domain under `/dev/shm`, removed on drop. Mirrors the gst-mxl-rs
+/// domain guard and adds a BCP-007-03 `domain_def.json` so the `mxl-domain-id`
+/// cross-check in `nmossink`/`nmossrc` passes.
+struct TestDomainGuard {
+    dir: PathBuf,
+}
+
+impl TestDomainGuard {
+    fn new(test: &str) -> Self {
+        let pid = std::process::id();
+        let now_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock pre-epoch")
+            .as_nanos();
+        let dir = PathBuf::from(format!("/dev/shm/nvnmos_avsync_{test}_{pid}_{now_nanos}"));
+        std::fs::create_dir_all(&dir)
+            .unwrap_or_else(|e| panic!("create test domain `{}`: {e}", dir.display()));
+        let domain_def = serde_json::json!({
+            "id": DOMAIN_ID,
+            "label": format!("nvnmos avsync test {test}"),
+        });
+        std::fs::write(
+            dir.join("domain_def.json"),
+            serde_json::to_string_pretty(&domain_def).expect("serialise domain_def"),
+        )
+        .unwrap_or_else(|e| panic!("write domain_def.json: {e}"));
+        Self { dir }
+    }
+
+    fn path(&self) -> &str {
+        self.dir.to_str().expect("ASCII domain path")
+    }
+}
+
+impl Drop for TestDomainGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Local egress NIC IPv4 for the RTP transports (skips loopback). Mirrors the
+/// example scripts' `_default_nic_ip`.
+fn nic_ip() -> String {
+    if let Ok(ip) = std::env::var("NVNMOS_TEST_NIC_IP") {
+        return ip;
+    }
+    let out = std::process::Command::new("ip")
+        .args(["-4", "-o", "addr", "show"])
+        .output();
+    if let Ok(out) = out {
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            let f: Vec<&str> = line.split_whitespace().collect();
+            if f.len() >= 4 && f[1] != "lo" {
+                if let Some(ip) = f[3].split('/').next() {
+                    return ip.to_owned();
+                }
+            }
+        }
+    }
+    "127.0.0.1".to_owned()
+}
+
+/// Essence caps for each flow (also drives the synthesised NMOS flow_def).
+fn video_caps(t: Transport) -> String {
+    format!(
+        "video/x-raw,format={},width={WIDTH},height={HEIGHT},framerate={FR_NUM}/{FR_DEN}",
+        t.video_format()
+    )
+}
+
+fn data_caps() -> String {
+    format!("meta/x-st-2038,framerate={FR_NUM}/{FR_DEN}")
+}
+
+fn audio_caps(t: Transport) -> String {
+    format!(
+        "audio/x-raw,format={},rate={RATE},channels=1,layout=interleaved",
+        t.audio_format()
+    )
+}
+
+/// The transport-specific `nmossink`/`nmossrc` properties for one flow. `domain`
+/// is the MXL Domain path (unused for the RTP transports).
+fn transport_props(
+    t: Transport,
+    is_sender: bool,
+    flow_id: &str,
+    mcast: (&str, u32),
+    nic: &str,
+    domain: &str,
+) -> String {
+    match t {
+        Transport::Mxl => {
+            format!("mxl-domain-id={DOMAIN_ID} mxl-domain-path={domain} mxl-flow-id={flow_id}")
+        }
+        Transport::Udp | Transport::NvdsUdp => {
+            let (ip, port) = mcast;
+            if is_sender {
+                format!("destination-ip={ip} destination-port={port} source-ip={nic}")
+            } else {
+                format!(
+                    "multicast-ip={ip} destination-port={port} interface-ip={nic} source-ip={nic}"
+                )
+            }
+        }
+    }
+}
+
+fn build_producer(t: Transport, uri: &str, nic: &str, domain: &str) -> gst::Pipeline {
+    let vcaps = video_caps(t);
+    let dcaps = data_caps();
+    let acaps = audio_caps(t);
+    let tp = t.nmos_name();
+    let video_tp = transport_props(t, true, VIDEO_FLOW_ID, VIDEO_MCAST, nic, domain);
+    let data_tp = transport_props(t, true, DATA_FLOW_ID, DATA_MCAST, nic, domain);
+    let audio_tp = transport_props(t, true, AUDIO_FLOW_ID, AUDIO_MCAST, nic, domain);
+
+    let desc = format!(
+        "avsyncvideotestsrc is-live=true num-buffers={NUM_FRAMES} \
+             pip-interval={PIP_INTERVAL_NS} width={WIDTH} height={HEIGHT} \
+             framerate={FR_NUM}/{FR_DEN} \
+           ! {vcaps} \
+           ! st2038extractor name=ext remove-ancillary-meta=true \
+         ext.src \
+           ! queue \
+           ! nmossink daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+                 sender-name={VIDEO_SENDER} auto-activate=true caps=\"{vcaps}\" {video_tp} \
+         ext.st2038 \
+           ! queue \
+           ! nmossink daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+                 sender-name={DATA_SENDER} auto-activate=true caps=\"{dcaps}\" {data_tp} \
+         avsyncaudiotestsrc is-live=true num-buffers={NUM_AUDIO_BUFFERS} \
+             pip-interval={PIP_INTERVAL_NS} \
+           ! {acaps} \
+           ! queue \
+           ! nmossink daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+                 sender-name={AUDIO_SENDER} auto-activate=true caps=\"{acaps}\" {audio_tp}"
+    );
+    gst::parse::launch(&desc)
+        .expect("parse producer")
+        .downcast::<gst::Pipeline>()
+        .expect("producer pipeline")
+}
+
+fn build_consumer(t: Transport, uri: &str, nic: &str, domain: &str) -> gst::Pipeline {
+    let vcaps = video_caps(t);
+    let dcaps = data_caps();
+    let acaps = audio_caps(t);
+    let tp = t.nmos_name();
+    let video_tp = transport_props(t, false, VIDEO_FLOW_ID, VIDEO_MCAST, nic, domain);
+    let data_tp = transport_props(t, false, DATA_FLOW_ID, DATA_MCAST, nic, domain);
+    let audio_tp = transport_props(t, false, AUDIO_FLOW_ID, AUDIO_MCAST, nic, domain);
+
+    // Diagnostic: tap the raw ST-2038 flow into its own appsink (bypassing the
+    // combiner's running-time matching) to attribute data loss to transport vs
+    // combiner.
+    let data_tap = std::env::var("NVNMOS_TEST_DATA_TAP").is_ok();
+    let data_branch = if data_tap {
+        format!(
+            "nmossrc daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+                 receiver-name={DATA_RECEIVER} auto-activate=true caps=\"{dcaps}\" {data_tp} \
+               ! tee name=dt \
+             dt. ! queue ! comb.st2038 \
+             dt. ! queue ! appsink name=data_sink sync=false caps=meta/x-st-2038"
+        )
+    } else {
+        format!(
+            "nmossrc daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+                 receiver-name={DATA_RECEIVER} auto-activate=true caps=\"{dcaps}\" {data_tp} \
+               ! queue \
+               ! comb.st2038"
+        )
+    };
+    let desc = format!(
+        "nmossrc daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+             receiver-name={VIDEO_RECEIVER} auto-activate=true caps=\"{vcaps}\" {video_tp} \
+           ! queue \
+           ! comb.sink \
+         {data_branch} \
+         st2038combiner name=comb drop-late-st2038={drop_late} \
+           ! queue \
+           ! appsink name=video_sink sync=true caps=video/x-raw,format={vfmt} \
+         nmossrc daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \
+             receiver-name={AUDIO_RECEIVER} auto-activate=true caps=\"{acaps}\" {audio_tp} \
+           ! queue \
+           ! audioconvert \
+            ! appsink name=audio_sink sync=false caps=audio/x-raw,format=F32LE",
+        vfmt = t.video_format(),
+        drop_late = t.combiner_drop_late(),
+    );
+    gst::parse::launch(&desc)
+        .expect("parse consumer")
+        .downcast::<gst::Pipeline>()
+        .expect("consumer pipeline")
+}
+
+/// First ST-2038 ANC packet's first user-data byte (the frame index stamped by
+/// avsyncvideotestsrc). Manual bit unpack (SMPTE ST 2038, big-endian, MSB-first);
+/// first user data word starts at bit 60. Diagnostic only.
+fn st2038_first_index(data: &[u8]) -> Option<u8> {
+    fn read_bits(data: &[u8], bit_offset: usize, width: usize) -> Option<u32> {
+        let mut out = 0u32;
+        for i in 0..width {
+            let bit = bit_offset + i;
+            let byte = *data.get(bit / 8)?;
+            let shift = 7 - (bit % 8);
+            out = (out << 1) | (((byte >> shift) & 1) as u32);
+        }
+        Some(out)
+    }
+    read_bits(data, 60, 10).map(|w| (w & 0xff) as u8)
+}
+
+fn appsink(pipeline: &gst::Pipeline, name: &str) -> gst_app::AppSink {
+    pipeline
+        .by_name(name)
+        .unwrap_or_else(|| panic!("appsink {name}"))
+        .downcast::<gst_app::AppSink>()
+        .expect("AppSink downcast")
+}
+
+fn running_time(sample: &gst::SampleRef) -> Option<gst::ClockTime> {
+    let pts = sample.buffer()?.pts()?;
+    sample
+        .segment()?
+        .downcast_ref::<gst::ClockTime>()?
+        .to_running_time(pts)
+}
+
+/// A recovered video frame: its byte-0 frame index, running time, and *every*
+/// ancillary packet the combiner attached to it — the frame indices recombined
+/// from the data flow (usually one; a lossy live round-trip can land two on one
+/// frame and none on a neighbour) and the non-null captions carried alongside.
+struct VideoFrame {
+    idx: u8,
+    rt: u64,
+    anc: Vec<u8>,
+    captions: Vec<String>,
+}
+
+/// Pull recovered video frames (with recombined ancillary + captions) until the
+/// last frame arrives or the deadline passes.
+fn pull_video(sink: &gst_app::AppSink) -> Vec<VideoFrame> {
+    let last = (NUM_FRAMES - 1) as u8;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let timeout = gst::ClockTime::from_seconds(2);
+    let mut parser = cdp_types::CDPParser::new();
+    let mut out = Vec::new();
+    let mut seen_last = false;
+    while !seen_last && std::time::Instant::now() < deadline {
+        let Some(sample) = sink.try_pull_sample(timeout) else {
+            if sink.is_eos() {
+                break;
+            }
+            continue;
+        };
+        let Some(rt) = running_time(&sample) else {
+            continue;
+        };
+        let buffer = sample.buffer().expect("video buffer");
+        let idx = buffer.map_readable().expect("video readable").as_slice()[0];
+        let anc = gstavsynctest::analyze::ancillary_indices(buffer, gstavsynctest::signal::ANC_DID);
+        let captions = gstavsynctest::analyze::caption_cdps(buffer)
+            .iter()
+            .filter_map(|cdp| gstavsynctest::analyze::decode_caption(&mut parser, cdp))
+            .collect();
+        seen_last = idx == last;
+        out.push(VideoFrame {
+            idx,
+            rt: rt.nseconds(),
+            anc,
+            captions,
+        });
+    }
+    out
+}
+
+/// Drain `(running_time_ns, amplitude)` for every audio sample until `done` or
+/// EOS/deadline (see gst-mxl-rs av_sync for why we drain continuously).
+fn drain_audio(sink: &gst_app::AppSink, done: &AtomicBool) -> Vec<(u64, f32)> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let timeout = gst::ClockTime::from_mseconds(200);
+    let mut out = Vec::new();
+    while std::time::Instant::now() < deadline {
+        let Some(sample) = sink.try_pull_sample(timeout) else {
+            if sink.is_eos() || done.load(Ordering::Relaxed) {
+                break;
+            }
+            continue;
+        };
+        let Some(rt) = running_time(&sample) else {
+            continue;
+        };
+        let base = rt.nseconds();
+        let buffer = sample.buffer().expect("audio buffer");
+        let map = buffer.map_readable().expect("audio readable");
+        let body = gstavsynctest::analyze::f32le_samples(map.as_slice());
+        for (i, &v) in body.iter().enumerate() {
+            let t = base + i as u64 * gst::ClockTime::SECOND.nseconds() / RATE as u64;
+            out.push((t, v));
+        }
+    }
+    out
+}
+
+/// Expected TICK/TOCK for the bar-centre frame at index `idx` (`idx == k *
+/// FRAMES_PER_INTERVAL`, `k >= 1`): odd pip -> TICK, even -> TOCK.
+fn expected_caption(idx: u8) -> &'static str {
+    let k = idx as u64 / FRAMES_PER_INTERVAL;
+    if k % 2 == 1 {
+        gstavsynctest::captions::CC_TICK
+    } else {
+        gstavsynctest::captions::CC_TOCK
+    }
+}
+
+/// The recovered streams stay in lockstep. `anc_tol` frames is how far an
+/// ancillary packet may sit from its home video frame: zero for the co-timed
+/// transports (MXL), one for the software RTP path, whose arrival-time PTS shifts
+/// ancillary onto an adjacent frame — which shows up as a frame that collected
+/// two packets ("double") next to one that collected none ("none").
+///
+/// 1. The video Receiver attaches within `ATTACH_SLACK` of the head and then
+///    reads contiguously through to the last frame — no gaps, no duplicates.
+/// 2. `st2038combiner` conserves the data flow's ancillary: no frame carries more
+///    than `anc_tol + 1` packets, every received frame-index packet lands on
+///    exactly one video frame within `anc_tol` of its own index, and the received
+///    indices are gap-free from the attach point through the last frame (so no
+///    packet is lost or duplicated — a "double" is always matched by a "none").
+/// 3. Captions ride that same ancillary: a frame's non-null captions are exactly
+///    the phase-locked TICK/TOCK expected for the bar-centre packet indices it
+///    carries (so a "double" straddling a bar-centre carries that caption too).
+/// 4. Every bar-centre frame the audio spans has a coincident pip to within one
+///    frame period (see gst-mxl-rs's av_sync for the A/V rationale).
+fn assert_synchronised(video: &[VideoFrame], pips: &[u64], anc_tol: usize) {
+    assert!(!pips.is_empty(), "no audio pips detected");
+    let (first_pip, last_pip) = (*pips.first().unwrap(), *pips.last().unwrap());
+
+    if std::env::var("NVNMOS_TEST_DUMP").is_ok() {
+        eprintln!("--- video frames (idx, rt_ms, anc, captions) ---");
+        for f in video {
+            let mark = match f.anc.len() {
+                0 => "  none",
+                1 => "",
+                _ => "DOUBLE",
+            };
+            eprintln!(
+                "  idx={:3} rt={:6}ms anc={:?} {:?} {mark}",
+                f.idx,
+                f.rt / 1_000_000,
+                f.anc,
+                f.captions,
+            );
+        }
+        eprintln!(
+            "--- pips (ms) --- {:?}",
+            pips.iter().map(|p| p / 1_000_000).collect::<Vec<_>>()
+        );
+    }
+
+    // 1. Contiguous video capture.
+    let frames: std::collections::BTreeSet<u8> = video.iter().map(|f| f.idx).collect();
+    assert_eq!(
+        frames.len(),
+        video.len(),
+        "duplicate video frames in capture"
+    );
+    let first = *frames.iter().next().expect("no video frames") as usize;
+    let last = *frames.iter().next_back().unwrap() as usize;
+    assert_eq!(
+        last,
+        NUM_FRAMES as usize - 1,
+        "video did not read through the last frame {}, got {last}",
+        NUM_FRAMES - 1
+    );
+    assert!(
+        first <= ATTACH_SLACK,
+        "video missed too many frames at attach: first read frame_idx {first}"
+    );
+    assert_eq!(
+        frames.len(),
+        last - first + 1,
+        "video capture has gaps: {} frames over range {first}..={last}",
+        frames.len()
+    );
+
+    // 2. Ancillary conserved: every received packet lands on exactly one frame
+    //    within `anc_tol`, no frame over `anc_tol + 1` packets, no interior gaps.
+    let max_per_frame = anc_tol + 1;
+    let overloaded: Vec<(u8, &Vec<u8>)> = video
+        .iter()
+        .filter(|f| f.anc.len() > max_per_frame)
+        .map(|f| (f.idx, &f.anc))
+        .collect();
+    assert!(
+        overloaded.is_empty(),
+        "frames carried more than {max_per_frame} ancillary packets (frame, anc): {overloaded:?}"
+    );
+    let mut placement: std::collections::BTreeMap<u8, Vec<u8>> = std::collections::BTreeMap::new();
+    for f in video {
+        for &a in &f.anc {
+            placement.entry(a).or_default().push(f.idx);
+        }
+    }
+    let misregistered: Vec<(u8, &Vec<u8>)> = placement
+        .iter()
+        .filter(|(a, on)| {
+            on.len() != 1 || (on[0] as i64 - **a as i64).unsigned_abs() as usize > anc_tol
+        })
+        .map(|(a, on)| (*a, on))
+        .collect();
+    assert!(
+        misregistered.is_empty(),
+        "ancillary mis-registered beyond +/-{anc_tol} frame (anc -> frames): {misregistered:?}"
+    );
+    let recv_first = *placement.keys().next().expect("no ancillary received") as usize;
+    let recv_last = *placement.keys().next_back().unwrap() as usize;
+    assert!(
+        recv_first <= ATTACH_SLACK,
+        "ancillary attach missed too many at head: first received index {recv_first}"
+    );
+    assert!(
+        recv_last >= last - anc_tol,
+        "ancillary lost at the tail: last received index {recv_last}, video read to {last}"
+    );
+    assert_eq!(
+        placement.len(),
+        recv_last - recv_first + 1,
+        "ancillary packets missing in range {recv_first}..={recv_last}: received {:?}",
+        placement.keys().collect::<Vec<_>>()
+    );
+
+    // 3. Captions ride the recombined ancillary, so hold them to the same
+    //    conservation contract as the index packets (§2): each bar-centre's
+    //    TICK/TOCK is received exactly once, on a frame within `anc_tol` of that
+    //    bar-centre. A caption CDP is just another ST-2038 packet, so UDP jitter
+    //    slides it the same way — and by the same amount — as the frame-index
+    //    packet it was emitted with. Attribute every received caption to the
+    //    bar-centre whose expected text it matches within that window; one that
+    //    matches none is a genuinely wrong or misplaced caption.
+    let mut cap_placement: std::collections::BTreeMap<u8, Vec<u8>> =
+        std::collections::BTreeMap::new();
+    for f in video {
+        for c in &f.captions {
+            let target = ((f.idx as i64 - anc_tol as i64).max(0)
+                ..=(f.idx as i64 + anc_tol as i64))
+                .find_map(|i| {
+                    let i = i as u8;
+                    (i != 0
+                        && (i as i32) < NUM_FRAMES
+                        && (i as u64) % FRAMES_PER_INTERVAL == 0
+                        && expected_caption(i) == c.as_str())
+                    .then_some(i)
+                });
+            match target {
+                Some(t) => cap_placement.entry(t).or_default().push(f.idx),
+                None => panic!(
+                    "frame {} carried caption {c:?} with no correct bar-centre \
+                     within +/-{anc_tol} (anc {:?})",
+                    f.idx, f.anc,
+                ),
+            }
+        }
+    }
+    let cap_misregistered: Vec<(u8, &Vec<u8>)> = cap_placement
+        .iter()
+        .filter(|(b, on)| {
+            on.len() != 1 || (on[0] as i64 - **b as i64).unsigned_abs() as usize > anc_tol
+        })
+        .map(|(b, on)| (*b, on))
+        .collect();
+    assert!(
+        cap_misregistered.is_empty(),
+        "captions mis-registered beyond +/-{anc_tol} frame (bar-centre -> frames): {cap_misregistered:?}"
+    );
+    let cap_first = *cap_placement.keys().next().expect("no captions received") as usize;
+    let cap_last = *cap_placement.keys().next_back().unwrap() as usize;
+    let fpi = FRAMES_PER_INTERVAL as usize;
+    assert!(
+        cap_first <= fpi + ATTACH_SLACK,
+        "captions missed too many bar-centres at head: first received {cap_first}"
+    );
+    let last_bc = (last / fpi) * fpi;
+    if last_bc + anc_tol <= last {
+        assert!(
+            cap_last >= last_bc,
+            "captions lost at the tail: last received bar-centre {cap_last}, \
+             video read to {last} (last bar-centre {last_bc})"
+        );
+    }
+    assert_eq!(
+        cap_placement.len(),
+        (cap_last - cap_first) / fpi + 1,
+        "bar-centre captions missing in {cap_first}..={cap_last}: received {:?}",
+        cap_placement.keys().collect::<Vec<_>>()
+    );
+
+    // 4. A/V: every bar-centre frame the audio spans has a coincident pip.
+    let mut in_span = 0;
+    for frame in video
+        .iter()
+        .filter(|f| (f.idx as u64) != 0 && (f.idx as u64) % FRAMES_PER_INTERVAL == 0)
+    {
+        if frame.rt + FRAME_PERIOD_NS < first_pip || frame.rt > last_pip + FRAME_PERIOD_NS {
+            continue;
+        }
+        in_span += 1;
+        let nearest = pips
+            .iter()
+            .copied()
+            .min_by_key(|p| p.abs_diff(frame.rt))
+            .expect("pip present");
+        let d = nearest.abs_diff(frame.rt);
+        assert!(
+            d <= FRAME_PERIOD_NS,
+            "bar-centre frame {} (rt {}): nearest pip {nearest} is {d} ns away ({}) — pips: {pips:?}",
+            frame.idx,
+            frame.rt,
+            if d < PIP_INTERVAL_NS / 2 {
+                "over one frame period: A/V sync error"
+            } else {
+                "no pip near this frame: audio round-trip dropped samples"
+            },
+        );
+    }
+
+    let expected = (NUM_FRAMES as u64 / FRAMES_PER_INTERVAL) as usize;
+    assert!(
+        in_span >= expected - 2,
+        "audio spanned only {in_span} of ~{expected} bar-centre frames (pips: {pips:?})",
+    );
+}
+
+fn skip_reason(t: Transport) -> Option<String> {
+    match t {
+        // The software RTP receive path is `udpsrc ! rtp<essence>depay` with no
+        // rtpjitterbuffer (see gst-nmos-rs `inner.rs`), so each flow's PTS comes
+        // from packet arrival time, not its RTP timestamp; the video and data
+        // flows land a few ms apart, which shifts a frame's ancillary group by up
+        // to one frame (a frame that collects two packets next to one that
+        // collects none). The test tolerates that (`anc_tolerance_frames`) —
+        // every packet is still received within +/-1 frame, caption riding with
+        // its index. Exact pairing needs an RFC 7273-sync jitterbuffer on a
+        // shared PTP clock; MXL gets it for free (one grain-index→PTS map).
+        Transport::Udp => {}
+        Transport::NvdsUdp => {
+            return Some(
+                "nvdsudp needs the DeepStream/Rivermax + PTP runtime (hardware \
+                 timestamping) to co-time the flows; not available here"
+                    .into(),
+            )
+        }
+        Transport::Mxl => {
+            if !cfg!(target_os = "linux") {
+                return Some("MXL domains use /dev/shm (Linux only)".into());
+            }
+            if !std::path::Path::new("/dev/shm").is_dir() {
+                return Some("/dev/shm is not available".into());
+            }
+        }
+    }
+    if let Some(why) = nvnmosd_skip_reason() {
+        return Some(why);
+    }
+    let mut needed: Vec<&str> = vec![
+        "appsink",
+        "audioconvert",
+        "queue",
+        "st2038extractor",
+        "st2038combiner",
+        "nmossink",
+        "nmossrc",
+        "avsyncvideotestsrc",
+        "avsyncaudiotestsrc",
+    ];
+    needed.extend_from_slice(t.transport_factories());
+    let missing: Vec<&str> = needed
+        .into_iter()
+        .filter(|n| gst::ElementFactory::find(n).is_none())
+        .collect();
+    if !missing.is_empty() {
+        return Some(format!("missing element factories: {missing:?}"));
+    }
+    None
+}
+
+fn run_case(t: Transport) {
+    init();
+    register_sources();
+    if let Some(why) = skip_reason(t) {
+        skip!(why);
+    }
+
+    let domain_guard = (t == Transport::Mxl).then(|| TestDomainGuard::new(t.nmos_name()));
+    let domain = domain_guard.as_ref().map(|d| d.path()).unwrap_or("");
+    let nic = nic_ip();
+
+    let pid = std::process::id();
+    let now_nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let socket = PathBuf::from(format!("/tmp/nvnmos_avsync_{pid}_{now_nanos}.sock"));
+    let _daemon = DaemonGuard::new(socket.clone());
+    let uri = _daemon.uri();
+
+    let producer = build_producer(t, &uri, &nic, domain);
+    let consumer = build_consumer(t, &uri, &nic, domain);
+    struct Teardown(gst::Pipeline, gst::Pipeline);
+    impl Drop for Teardown {
+        fn drop(&mut self) {
+            let _ = self.0.set_state(gst::State::Null);
+            let _ = self.1.set_state(gst::State::Null);
+        }
+    }
+    let _teardown = Teardown(producer.clone(), consumer.clone());
+
+    // Producer first so all three flows exist before the consumer attaches.
+    producer.set_state(gst::State::Playing).expect("producer Playing");
+    consumer.set_state(gst::State::Playing).expect("consumer Playing");
+    let (res, _, _) = consumer.state(gst::ClockTime::from_seconds(10));
+    res.expect("consumer reached Playing");
+
+    let video_sink = appsink(&consumer, "video_sink");
+    let audio_sink = appsink(&consumer, "audio_sink");
+    let data_tap = std::env::var("NVNMOS_TEST_DATA_TAP")
+        .ok()
+        .map(|_| appsink(&consumer, "data_sink"));
+    let done = AtomicBool::new(false);
+    let (video, audio) = std::thread::scope(|s| {
+        let audio = s.spawn(|| drain_audio(&audio_sink, &done));
+        let data = data_tap.as_ref().map(|sink| {
+            s.spawn(|| {
+                let mut idx = Vec::new();
+                while !done.load(Ordering::Relaxed) {
+                    let Some(sample) = sink.try_pull_sample(gst::ClockTime::from_mseconds(200))
+                    else {
+                        if sink.is_eos() {
+                            break;
+                        }
+                        continue;
+                    };
+                    let rt = running_time(&sample).map(|t| t.nseconds()).unwrap_or(0);
+                    let buffer = sample.buffer().expect("data buffer");
+                    let map = buffer.map_readable().expect("data readable");
+                    idx.push((st2038_first_index(map.as_slice()), rt));
+                }
+                idx
+            })
+        });
+        let video = pull_video(&video_sink);
+        done.store(true, Ordering::Relaxed);
+        let data = data.map(|d| d.join().expect("data drain thread"));
+        if let Some(data) = data {
+            eprintln!("--- raw ST-2038 (idx, rt_ms) ({} buffers) ---", data.len());
+            for (i, rt) in &data {
+                eprintln!("  data idx={:?} rt={}ms", i, rt / 1_000_000);
+            }
+        }
+        (video, audio.join().expect("audio drain thread"))
+    });
+
+    let pips = gstavsynctest::analyze::detect_pips(&audio);
+    assert_synchronised(&video, &pips, t.anc_tolerance_frames() as usize);
+}
+
+#[test]
+fn av_sync_via_mxl() {
+    run_case(Transport::Mxl);
+}
+
+#[test]
+fn av_sync_via_udp() {
+    run_case(Transport::Udp);
+}
+
+#[test]
+fn av_sync_via_nvdsudp() {
+    run_case(Transport::NvdsUdp);
+}

--- a/rust/gst-nmos-rs/tests/av_sync.rs
+++ b/rust/gst-nmos-rs/tests/av_sync.rs
@@ -83,6 +83,19 @@ const NUM_AUDIO_BUFFERS: i32 = 155; // covers the video run with margin
 /// combiner can pair ancillary onto them. After attach there are no drops (in
 /// practice the offset is one or two frames). Applied once — not per reader.
 const ATTACH_SLACK: usize = 5;
+/// Extra grace (`GstAggregator:latency`) for the `st2038combiner` to wait for a
+/// late ancillary grain before finishing a video frame. The combiner's own
+/// latency is one frame, so by default the ancillary grain's journey (producer
+/// commit → MXL → data `mxlsrc` → queue → combiner) has only ~one frame plus the
+/// reported upstream latency to arrive. This test co-locates producer and
+/// consumer in a single process, so scheduling jitter of the consumer's data
+/// reader thread (amplified under CPU load) can occasionally push the grain past
+/// that deadline; the aggregator would then emit the video frame bare and
+/// `drop-late` would discard the now-late grain (the data itself is never lost —
+/// see the module header). One extra frame absorbs that jitter (proven: 0 vs. the
+/// default window's intermittent drops under load). Folded straight into the
+/// aggregator's wait deadline and reported downstream, so sync stays consistent.
+const COMBINER_LATENCY_NS: u64 = FRAME_PERIOD_NS; // 40 ms at 25 fps
 
 const NODE_SEED: &str = "nvnmos-avsync-test";
 const VIDEO_SENDER: &str = "video-sender";
@@ -369,7 +382,7 @@ fn build_consumer(t: Transport, uri: &str, nic: &str, domain: &str) -> gst::Pipe
            ! queue \
            ! comb.sink \
          {data_branch} \
-         st2038combiner name=comb drop-late-st2038={drop_late} \
+         st2038combiner name=comb drop-late-st2038={drop_late} latency={COMBINER_LATENCY_NS} \
            ! queue \
            ! appsink name=video_sink sync=true caps=video/x-raw,format={vfmt} \
          nmossrc daemon-uri=\"{uri}\" transport={tp} node-seed={NODE_SEED} \


### PR DESCRIPTION
## Summary

Adds a transport-parameterised end-to-end synchronisation test for NMOS Senders/Receivers, plus the reusable test sources it needs, and fixes two transport-layer sync bugs the test uncovered.

The test runs `avsyncvideotestsrc`/`avsyncaudiotestsrc` through real NMOS Senders and Receivers and asserts that **video, audio-pip, and CEA-708 caption alignment survive the round-trip** over all three transports (`mxl`, `udp`,
`nvdsudp`).

## Commits

1. **`gst-avsynctest-rs`: add aligned A/V test sources for sync testing**
   New first-class crate with phase-locked test sources and recovery-side analysis helpers:
   - `avsyncvideotestsrc` — white bar centred on each pip instant plus a phase-locked CEA-708 TICK/TOCK caption carried in ancillary data.
   - `avsyncaudiotestsrc` — matching tone pip.
   - public `analyze` module — locates the bar, the pips, and the caption on recovered samples so tests (and a demo) can check alignment survived a round-trip.

2. **`gst-nmos-rs`: default RTP payloader `timestamp-offset` to 0**
   Pins the RTP timestamp base to 0 so the timestamp is a pure function of running time (`rtp_ts = running_time · clock_rate`). Every flow of one Sender shares the pipeline `base_time`, so equal PTS now yields equal RTP timestamps across flows (e.g. video and its extracted ancillary) — the stock random per-stream offset broke this. Also makes the advertised `a=mediaclk:direct=0` truthful. Applied before `pay-properties`, so a caller can still restore the GStreamer default with `timestamp-offset=-1` (although they **shouldn't** and we won't change the `mediaclk` attribute value).

3. **`gst-nmos-rs`: stop pinning ST-2038 `alignment` in transport parsing**
   `alignment` on `meta/x-st-2038` caps is a GStreamer buffer-grouping detail (packet/line/frame), not a transport property, so the transport-file parsers shouldn't invent it. The SDP parser no longer emits `alignment=frame`; the
   source element (`rtpsmpte291depay`, `mxlsrc`, …) is authoritative for the grouping it produces, and the receiver capssetter no longer relabels it. Only the nvdsudp boundary re-adds the field (its `ANY` pads can't carry the
   per-frame grouping DeepStream's Mode-3 ANC path assumes): `build_nvdsudpsink` wraps a `capsfilter` pinning `meta/x-st-2038,alignment=frame` and `build_nvdsudpsrc` stamps it onto the output caps.

4. **`gst-nmos-rs`: add end-to-end A/V and caption sync test**
   Transport-parameterised integration test. `st2038extractor` splits the video's ancillary data (frame index + phase-locked TICK/TOCK caption) into its own Sender; `st2038combiner` re-attaches it on the Receiver side before two appsinks (video+data, audio). Formats negotiate per transport (MXL: v210/F32LE, RTP/UDP: UYVP/S24BE). Recovery side reads back every ANC index and caption per frame and checks them against the emitted phase.

## Dependencies

- The `udp`/`udp2` transport also relies on two `rtpsmpte291depay` fixes (word-alignment skip and last-only marker bit) submitted separately to gst-plugins-rs; without them the second ANC packet per RTP packet (the caption CDP) is corrupted or slips a frame. (See https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/3159.)
