### PR TITLE
gst-avsynctest-rs: report internal failures instead of panicking

### DIFF
--- a/rust/gst-avsynctest-rs/src/analyze.rs
+++ b/rust/gst-avsynctest-rs/src/analyze.rs
@@ -58,12 +58,13 @@ pub fn f32le_samples(bytes: &[u8]) -> &[f32] {
 /// energy-weighted centroid is skewed by how the burst's samples fall across the
 /// bin edges.
 pub fn detect_pips(audio: &[(u64, f32)]) -> Vec<u64> {
-    if audio.is_empty() {
+    let Some(&(t0, _)) = audio.first() else {
         return Vec::new();
-    }
+    };
+    let Some(&(tn, _)) = audio.last() else {
+        return Vec::new();
+    };
     const BIN_NS: u64 = 5_000_000;
-    let t0 = audio.first().unwrap().0;
-    let tn = audio.last().unwrap().0;
     let nbins = ((tn - t0) / BIN_NS + 1) as usize;
     let mut energy = vec![0.0f64; nbins];
     for &(t, a) in audio {
@@ -129,15 +130,21 @@ pub fn caption_cdp_bytes(buffer: &gst::BufferRef) -> Option<Vec<u8>> {
 }
 
 /// The caption text carried by one frame's CDP (service
-/// [`CC_SERVICE_NO`](captions::CC_SERVICE_NO)), or `None` for a null CDP.
-pub fn decode_caption(parser: &mut CDPParser, cdp: &[u8]) -> Option<String> {
-    parser.parse(cdp).expect("valid CDP");
-    let packet = parser.pop_packet()?;
+/// [`CC_SERVICE_NO`](captions::CC_SERVICE_NO)), or `Ok(None)` for a null CDP
+/// (a valid CDP that carries no caption). `Err` if the CDP fails to parse.
+pub fn decode_caption(
+    parser: &mut CDPParser,
+    cdp: &[u8],
+) -> Result<Option<String>, cdp_types::ParserError> {
+    parser.parse(cdp)?;
+    let Some(packet) = parser.pop_packet() else {
+        return Ok(None);
+    };
     let mut text = String::new();
     for service in packet.services() {
         if service.number() == captions::CC_SERVICE_NO {
             text.extend(service.codes().iter().filter_map(|code| code.char()));
         }
     }
-    (!text.is_empty()).then_some(text)
+    Ok((!text.is_empty()).then_some(text))
 }

--- a/rust/gst-avsynctest-rs/src/audiosrc/imp.rs
+++ b/rust/gst-avsynctest-rs/src/audiosrc/imp.rs
@@ -24,6 +24,13 @@ use gstreamer_audio as gst_audio;
 use gstreamer_base as gst_base;
 
 use crate::signal;
+use crate::{
+    imp_error::{
+        self, BUFFER_NOT_WRITABLE, CALC_LATENCY, CAPS_NO_STRUCTURE, GET_TIME_SEGMENT,
+        LOCK_CLOCK_WAIT, LOCK_SETTINGS, LOCK_STATE,
+    },
+    imp_failed,
+};
 
 static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
     gst::DebugCategory::new(
@@ -198,24 +205,70 @@ impl ObjectImpl for AvSyncAudioTestSrc {
     }
 
     fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
-        let mut settings = self.settings.lock().unwrap();
+        let Ok(mut settings) = self.settings.lock() else {
+            imp_failed!(self, LOCK_SETTINGS);
+            return;
+        };
+
         match pspec.name() {
             "pip-interval" => {
-                settings.pip_interval = gst::ClockTime::from_nseconds(value.get().unwrap());
+                if let Ok(ns) = value.get::<u64>() {
+                    settings.pip_interval = gst::ClockTime::from_nseconds(ns);
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for pip-interval property");
+                }
             }
             "pip-duration" => {
-                settings.pip_duration = gst::ClockTime::from_nseconds(value.get().unwrap());
+                if let Ok(ns) = value.get::<u64>() {
+                    settings.pip_duration = gst::ClockTime::from_nseconds(ns);
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for pip-duration property");
+                }
             }
-            "pip-freq" => settings.pip_freq = value.get().unwrap(),
-            "pip-volume" => settings.pip_volume = value.get().unwrap(),
-            "samples-per-buffer" => settings.samples_per_buffer = value.get().unwrap(),
-            "is-live" => settings.is_live = value.get().unwrap(),
-            _ => unimplemented!(),
+            "pip-freq" => {
+                if let Ok(freq) = value.get::<f64>() {
+                    settings.pip_freq = freq;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for pip-freq property");
+                }
+            }
+            "pip-volume" => {
+                if let Ok(volume) = value.get::<f64>() {
+                    settings.pip_volume = volume;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for pip-volume property");
+                }
+            }
+            "samples-per-buffer" => {
+                if let Ok(n) = value.get::<u32>() {
+                    settings.samples_per_buffer = n;
+                } else {
+                    gst::error!(
+                        CAT,
+                        imp = self,
+                        "Invalid type for samples-per-buffer property"
+                    );
+                }
+            }
+            "is-live" => {
+                if let Ok(is_live) = value.get::<bool>() {
+                    settings.is_live = is_live;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for is-live property");
+                }
+            }
+            other => {
+                gst::error!(CAT, imp = self, "Unknown property '{}'", other);
+            }
         }
     }
 
     fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
-        let settings = self.settings.lock().unwrap();
+        let Ok(settings) = self.settings.lock() else {
+            imp_failed!(self, LOCK_SETTINGS);
+            return glib::Value::from(&"");
+        };
+
         match pspec.name() {
             "pip-interval" => settings.pip_interval.nseconds().to_value(),
             "pip-duration" => settings.pip_duration.nseconds().to_value(),
@@ -223,7 +276,10 @@ impl ObjectImpl for AvSyncAudioTestSrc {
             "pip-volume" => settings.pip_volume.to_value(),
             "samples-per-buffer" => settings.samples_per_buffer.to_value(),
             "is-live" => settings.is_live.to_value(),
-            _ => unimplemented!(),
+            _ => {
+                gst::error!(CAT, imp = self, "Unknown property {}", pspec.name());
+                glib::Value::from(&"")
+            }
         }
     }
 }
@@ -245,26 +301,32 @@ impl ElementImpl for AvSyncAudioTestSrc {
     }
 
     fn pad_templates() -> &'static [gst::PadTemplate] {
-        static PAD_TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
-            let caps = gst_audio::AudioCapsBuilder::new_interleaved()
-                .format_list([
-                    gst_audio::AudioFormat::F32le,
-                    gst_audio::AudioFormat::S24be,
-                    gst_audio::AudioFormat::S16be,
-                ])
-                .build();
-            let src_pad_template = gst::PadTemplate::new(
-                "src",
-                gst::PadDirection::Src,
-                gst::PadPresence::Always,
-                &caps,
-            )
-            .unwrap();
+        static PAD_TEMPLATES: LazyLock<Result<Vec<gst::PadTemplate>, glib::BoolError>> =
+            LazyLock::new(|| {
+                let caps = gst_audio::AudioCapsBuilder::new_interleaved()
+                    .format_list([
+                        gst_audio::AudioFormat::F32le,
+                        gst_audio::AudioFormat::S24be,
+                        gst_audio::AudioFormat::S16be,
+                    ])
+                    .build();
+                let src_pad_template = gst::PadTemplate::new(
+                    "src",
+                    gst::PadDirection::Src,
+                    gst::PadPresence::Always,
+                    &caps,
+                )?;
 
-            vec![src_pad_template]
-        });
+                Ok(vec![src_pad_template])
+            });
 
-        PAD_TEMPLATES.as_ref()
+        match PAD_TEMPLATES.as_ref() {
+            Ok(templates) => templates,
+            Err(err) => {
+                gst::trace!(CAT, "Failed to create src pad template: {:?}", err);
+                &[]
+            }
+        }
     }
 
     fn change_state(
@@ -272,7 +334,11 @@ impl ElementImpl for AvSyncAudioTestSrc {
         transition: gst::StateChange,
     ) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
         if let gst::StateChange::ReadyToPaused = transition {
-            self.obj().set_live(self.settings.lock().unwrap().is_live);
+            let settings = self.settings.lock().map_err(|_| {
+                imp_failed!(self, LOCK_SETTINGS);
+                gst::StateChangeError
+            })?;
+            self.obj().set_live(settings.is_live);
         }
         self.parent_change_state(transition)
     }
@@ -284,10 +350,18 @@ impl BaseSrcImpl for AvSyncAudioTestSrc {
             gst::loggable_error!(CAT, "Failed to build `AudioInfo` from caps {}", caps)
         })?;
 
+        let settings = self
+            .settings
+            .lock()
+            .map_err(|_| gst::loggable_error!(CAT, "{}", LOCK_SETTINGS))?;
         self.obj()
-            .set_blocksize(info.bpf() * self.settings.lock().unwrap().samples_per_buffer);
+            .set_blocksize(info.bpf() * settings.samples_per_buffer);
+        drop(settings);
 
-        self.state.lock().unwrap().info = Some(info);
+        self.state
+            .lock()
+            .map_err(|_| gst::loggable_error!(CAT, "{}", LOCK_STATE))?
+            .info = Some(info);
 
         let _ = self
             .obj()
@@ -297,25 +371,40 @@ impl BaseSrcImpl for AvSyncAudioTestSrc {
     }
 
     fn start(&self) -> Result<(), gst::ErrorMessage> {
-        *self.state.lock().unwrap() = Default::default();
+        *self
+            .state
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_STATE))? = Default::default();
         self.unlock_stop()?;
         Ok(())
     }
 
     fn stop(&self) -> Result<(), gst::ErrorMessage> {
-        *self.state.lock().unwrap() = Default::default();
+        *self
+            .state
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_STATE))? = Default::default();
         self.unlock()?;
         Ok(())
     }
 
     fn query(&self, query: &mut gst::QueryRef) -> bool {
         if let gst::QueryViewMut::Latency(q) = query.view_mut() {
-            let settings = *self.settings.lock().unwrap();
-            let state = self.state.lock().unwrap();
+            let Ok(settings) = self.settings.lock() else {
+                imp_failed!(self, LOCK_SETTINGS);
+                return false;
+            };
+            let Ok(state) = self.state.lock() else {
+                imp_failed!(self, LOCK_STATE);
+                return false;
+            };
             if let Some(ref info) = state.info {
-                let latency = gst::ClockTime::SECOND
+                let Some(latency) = gst::ClockTime::SECOND
                     .mul_div_floor(settings.samples_per_buffer as u64, info.rate() as u64)
-                    .unwrap();
+                else {
+                    imp_failed!(self, CALC_LATENCY);
+                    return false;
+                };
                 q.set(settings.is_live, latency, gst::ClockTime::NONE);
                 return true;
             }
@@ -328,9 +417,12 @@ impl BaseSrcImpl for AvSyncAudioTestSrc {
         caps.truncate();
         {
             let caps = caps.make_mut();
-            let s = caps.structure_mut(0).unwrap();
-            s.fixate_field_nearest_int("rate", signal::DEFAULT_RATE);
-            s.fixate_field_nearest_int("channels", signal::DEFAULT_CHANNELS);
+            if let Some(s) = caps.structure_mut(0) {
+                s.fixate_field_nearest_int("rate", signal::DEFAULT_RATE);
+                s.fixate_field_nearest_int("channels", signal::DEFAULT_CHANNELS);
+            } else {
+                imp_failed!(self, CAPS_NO_STRUCTURE);
+            }
         }
         self.parent_fixate(caps)
     }
@@ -340,7 +432,10 @@ impl BaseSrcImpl for AvSyncAudioTestSrc {
     }
 
     fn unlock(&self) -> Result<(), gst::ErrorMessage> {
-        let mut clock_wait = self.clock_wait.lock().unwrap();
+        let mut clock_wait = self
+            .clock_wait
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_CLOCK_WAIT))?;
         if let Some(clock_id) = clock_wait.clock_id.take() {
             clock_id.unschedule();
         }
@@ -349,7 +444,10 @@ impl BaseSrcImpl for AvSyncAudioTestSrc {
     }
 
     fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
-        self.clock_wait.lock().unwrap().flushing = false;
+        self.clock_wait
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_CLOCK_WAIT))?
+            .flushing = false;
         Ok(())
     }
 }
@@ -359,9 +457,19 @@ impl PushSrcImpl for AvSyncAudioTestSrc {
         &self,
         _buffer: Option<&mut gst::BufferRef>,
     ) -> Result<CreateSuccess, gst::FlowError> {
-        let settings = *self.settings.lock().unwrap();
+        let settings = self
+            .settings
+            .lock()
+            .map_err(|_| {
+                imp_failed!(self, LOCK_SETTINGS);
+                gst::FlowError::Error
+            })
+            .map(|s| *s)?;
 
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock().map_err(|_| {
+            imp_failed!(self, LOCK_STATE);
+            gst::FlowError::Error
+        })?;
         let info = match state.info {
             None => {
                 gst::element_imp_error!(self, gst::CoreError::Negotiation, ["Have no caps yet"]);
@@ -371,22 +479,38 @@ impl PushSrcImpl for AvSyncAudioTestSrc {
         };
 
         let n_samples = settings.samples_per_buffer as u64;
-        let mut buffer = gst::Buffer::with_size(n_samples as usize * info.bpf() as usize).unwrap();
+        let mut buffer =
+            gst::Buffer::with_size(n_samples as usize * info.bpf() as usize).map_err(|_| {
+                imp_failed!(self, "Failed to allocate audio buffer");
+                gst::FlowError::Error
+            })?;
         {
-            let buffer = buffer.get_mut().unwrap();
+            let buffer = buffer.get_mut().ok_or_else(|| {
+                imp_failed!(self, BUFFER_NOT_WRITABLE);
+                gst::FlowError::Error
+            })?;
             let pts = state
                 .sample_offset
                 .mul_div_floor(gst::ClockTime::SECOND.nseconds(), info.rate() as u64)
                 .map(gst::ClockTime::from_nseconds)
-                .unwrap();
+                .ok_or_else(|| {
+                    imp_failed!(self, "Failed to calculate audio PTS");
+                    gst::FlowError::Error
+                })?;
             let next_pts = (state.sample_offset + n_samples)
                 .mul_div_floor(gst::ClockTime::SECOND.nseconds(), info.rate() as u64)
                 .map(gst::ClockTime::from_nseconds)
-                .unwrap();
+                .ok_or_else(|| {
+                    imp_failed!(self, "Failed to calculate next audio PTS");
+                    gst::FlowError::Error
+                })?;
             buffer.set_pts(pts);
             buffer.set_duration(next_pts - pts);
 
-            let mut map = buffer.map_writable().unwrap();
+            let mut map = buffer.map_writable().map_err(|_| {
+                imp_failed!(self, "Failed to map audio buffer writable");
+                gst::FlowError::Error
+            })?;
             Self::fill(map.as_mut_slice(), &info, state.sample_offset, &settings);
         }
         state.sample_offset += n_samples;
@@ -413,13 +537,19 @@ impl AvSyncAudioTestSrc {
             .obj()
             .segment()
             .downcast::<gst::format::Time>()
-            .unwrap();
+            .map_err(|_| {
+                imp_failed!(self, GET_TIME_SEGMENT);
+                gst::FlowError::Error
+            })?;
         let running_time = segment.to_running_time(buffer.pts().opt_add(buffer.duration()));
         let Some(wait_until) = running_time.opt_add(base_time) else {
             return Ok(());
         };
 
-        let mut clock_wait = self.clock_wait.lock().unwrap();
+        let mut clock_wait = self.clock_wait.lock().map_err(|_| {
+            imp_failed!(self, LOCK_CLOCK_WAIT);
+            gst::FlowError::Error
+        })?;
         if clock_wait.flushing {
             return Err(gst::FlowError::Flushing);
         }
@@ -428,7 +558,14 @@ impl AvSyncAudioTestSrc {
         drop(clock_wait);
 
         let (res, _) = id.wait();
-        self.clock_wait.lock().unwrap().clock_id.take();
+        self.clock_wait
+            .lock()
+            .map_err(|_| {
+                imp_failed!(self, LOCK_CLOCK_WAIT);
+                gst::FlowError::Error
+            })?
+            .clock_id
+            .take();
         if res == Err(gst::ClockError::Unscheduled) {
             return Err(gst::FlowError::Flushing);
         }

--- a/rust/gst-avsynctest-rs/src/imp_error.rs
+++ b/rust/gst-avsynctest-rs/src/imp_error.rs
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared error helpers for the avsynctest source element implementations.
+
+use gstreamer as gst;
+
+// Constants are only for messages shared verbatim by both source elements.
+pub const LOCK_SETTINGS: &str = "Failed to lock settings";
+pub const LOCK_STATE: &str = "Failed to lock state";
+pub const LOCK_CLOCK_WAIT: &str = "Failed to lock clock wait";
+pub const CALC_LATENCY: &str = "Failed to calculate latency";
+pub const CAPS_NO_STRUCTURE: &str = "Caps had no structure to fixate";
+pub const GET_TIME_SEGMENT: &str = "Failed to get time segment";
+pub const BUFFER_NOT_WRITABLE: &str = "Newly allocated buffer was not writable";
+
+pub fn failed_msg(msg: &str) -> gst::ErrorMessage {
+    gst::error_msg!(gst::CoreError::Failed, ["{}", msg])
+}
+
+/// Thin wrapper around [`gst::element_imp_error!`] for internal failures
+/// ([`CoreError::Failed`](gst::CoreError::Failed)).
+#[macro_export]
+macro_rules! imp_failed {
+    ($imp:expr, $msg:expr) => {
+        gst::element_imp_error!($imp, gst::CoreError::Failed, ["{}", $msg])
+    };
+}

--- a/rust/gst-avsynctest-rs/src/lib.rs
+++ b/rust/gst-avsynctest-rs/src/lib.rs
@@ -31,6 +31,7 @@ use gstreamer as gst;
 pub mod analyze;
 pub mod audiosrc;
 pub mod captions;
+pub(crate) mod imp_error;
 pub mod signal;
 pub mod videosrc;
 

--- a/rust/gst-avsynctest-rs/src/videosrc/imp.rs
+++ b/rust/gst-avsynctest-rs/src/videosrc/imp.rs
@@ -24,7 +24,14 @@ use gstreamer as gst;
 use gstreamer_base as gst_base;
 use gstreamer_video as gst_video;
 
-use crate::{captions, signal};
+use crate::{
+    captions,
+    imp_error::{
+        self, BUFFER_NOT_WRITABLE, CALC_LATENCY, CAPS_NO_STRUCTURE, GET_TIME_SEGMENT,
+        LOCK_CLOCK_WAIT, LOCK_SETTINGS, LOCK_STATE,
+    },
+    imp_failed, signal,
+};
 
 static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
     gst::DebugCategory::new(
@@ -253,28 +260,69 @@ impl ObjectImpl for AvSyncVideoTestSrc {
     }
 
     fn set_property(&self, _id: usize, value: &glib::Value, pspec: &glib::ParamSpec) {
-        let mut settings = self.settings.lock().unwrap();
+        let Ok(mut settings) = self.settings.lock() else {
+            imp_failed!(self, LOCK_SETTINGS);
+            return;
+        };
+
         match pspec.name() {
             "pip-interval" => {
-                settings.pip_interval = gst::ClockTime::from_nseconds(value.get().unwrap());
+                if let Ok(ns) = value.get::<u64>() {
+                    settings.pip_interval = gst::ClockTime::from_nseconds(ns);
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for pip-interval property");
+                }
             }
-            "width" => settings.width = value.get().unwrap(),
-            "height" => settings.height = value.get().unwrap(),
-            "framerate" => settings.framerate = value.get().unwrap(),
-            "is-live" => settings.is_live = value.get().unwrap(),
-            _ => unimplemented!(),
+            "width" => {
+                if let Ok(width) = value.get::<i32>() {
+                    settings.width = width;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for width property");
+                }
+            }
+            "height" => {
+                if let Ok(height) = value.get::<i32>() {
+                    settings.height = height;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for height property");
+                }
+            }
+            "framerate" => {
+                if let Ok(framerate) = value.get::<gst::Fraction>() {
+                    settings.framerate = framerate;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for framerate property");
+                }
+            }
+            "is-live" => {
+                if let Ok(is_live) = value.get::<bool>() {
+                    settings.is_live = is_live;
+                } else {
+                    gst::error!(CAT, imp = self, "Invalid type for is-live property");
+                }
+            }
+            other => {
+                gst::error!(CAT, imp = self, "Unknown property '{}'", other);
+            }
         }
     }
 
     fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
-        let settings = self.settings.lock().unwrap();
+        let Ok(settings) = self.settings.lock() else {
+            imp_failed!(self, LOCK_SETTINGS);
+            return glib::Value::from(&"");
+        };
+
         match pspec.name() {
             "pip-interval" => settings.pip_interval.nseconds().to_value(),
             "width" => settings.width.to_value(),
             "height" => settings.height.to_value(),
             "framerate" => settings.framerate.to_value(),
             "is-live" => settings.is_live.to_value(),
-            _ => unimplemented!(),
+            _ => {
+                gst::error!(CAT, imp = self, "Unknown property {}", pspec.name());
+                glib::Value::from(&"")
+            }
         }
     }
 }
@@ -296,35 +344,41 @@ impl ElementImpl for AvSyncVideoTestSrc {
     }
 
     fn pad_templates() -> &'static [gst::PadTemplate] {
-        static PAD_TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
-            // Only CDP-representable frame rates: every frame carries a CEA-708
-            // CDP whose header encodes one of these eight broadcast rates.
-            let framerates = [
-                gst::Fraction::new(24000, 1001),
-                gst::Fraction::new(24, 1),
-                gst::Fraction::new(25, 1),
-                gst::Fraction::new(30000, 1001),
-                gst::Fraction::new(30, 1),
-                gst::Fraction::new(50, 1),
-                gst::Fraction::new(60000, 1001),
-                gst::Fraction::new(60, 1),
-            ];
-            let caps = gst_video::VideoCapsBuilder::new()
-                .format_list([gst_video::VideoFormat::V210, gst_video::VideoFormat::Uyvp])
-                .framerate_list(framerates)
-                .build();
-            let src_pad_template = gst::PadTemplate::new(
-                "src",
-                gst::PadDirection::Src,
-                gst::PadPresence::Always,
-                &caps,
-            )
-            .unwrap();
+        static PAD_TEMPLATES: LazyLock<Result<Vec<gst::PadTemplate>, glib::BoolError>> =
+            LazyLock::new(|| {
+                // Only CDP-representable frame rates: every frame carries a CEA-708
+                // CDP whose header encodes one of these eight broadcast rates.
+                let framerates = [
+                    gst::Fraction::new(24000, 1001),
+                    gst::Fraction::new(24, 1),
+                    gst::Fraction::new(25, 1),
+                    gst::Fraction::new(30000, 1001),
+                    gst::Fraction::new(30, 1),
+                    gst::Fraction::new(50, 1),
+                    gst::Fraction::new(60000, 1001),
+                    gst::Fraction::new(60, 1),
+                ];
+                let caps = gst_video::VideoCapsBuilder::new()
+                    .format_list([gst_video::VideoFormat::V210, gst_video::VideoFormat::Uyvp])
+                    .framerate_list(framerates)
+                    .build();
+                let src_pad_template = gst::PadTemplate::new(
+                    "src",
+                    gst::PadDirection::Src,
+                    gst::PadPresence::Always,
+                    &caps,
+                )?;
 
-            vec![src_pad_template]
-        });
+                Ok(vec![src_pad_template])
+            });
 
-        PAD_TEMPLATES.as_ref()
+        match PAD_TEMPLATES.as_ref() {
+            Ok(templates) => templates,
+            Err(err) => {
+                gst::trace!(CAT, "Failed to create src pad template: {:?}", err);
+                &[]
+            }
+        }
     }
 
     fn change_state(
@@ -332,7 +386,11 @@ impl ElementImpl for AvSyncVideoTestSrc {
         transition: gst::StateChange,
     ) -> Result<gst::StateChangeSuccess, gst::StateChangeError> {
         if let gst::StateChange::ReadyToPaused = transition {
-            self.obj().set_live(self.settings.lock().unwrap().is_live);
+            let settings = self.settings.lock().map_err(|_| {
+                imp_failed!(self, LOCK_SETTINGS);
+                gst::StateChangeError
+            })?;
+            self.obj().set_live(settings.is_live);
         }
         self.parent_change_state(transition)
     }
@@ -354,7 +412,11 @@ impl BaseSrcImpl for AvSyncVideoTestSrc {
             ));
         }
 
-        let pip_interval = self.settings.lock().unwrap().pip_interval;
+        let pip_interval = self
+            .settings
+            .lock()
+            .map_err(|_| gst::loggable_error!(CAT, "{}", LOCK_SETTINGS))?
+            .pip_interval;
         // Bar width is one frame's horizontal step, so the sweep tiles gap-free
         // and the bar thins as the frame rate rises.
         let fps = info.fps().numer() as f64 / info.fps().denom() as f64;
@@ -362,7 +424,10 @@ impl BaseSrcImpl for AvSyncVideoTestSrc {
             (pip_interval.nseconds() as f64 / gst::ClockTime::SECOND.nseconds() as f64) * fps;
         let bar_width = (info.width() as f64 / frames_per_interval).round().max(1.0) as u32;
 
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| gst::loggable_error!(CAT, "{}", LOCK_STATE))?;
         state.bar_width = bar_width;
         state.cdp_framerate = captions::cdp_framerate(info.fps());
         state.info = Some(info);
@@ -376,26 +441,41 @@ impl BaseSrcImpl for AvSyncVideoTestSrc {
     }
 
     fn start(&self) -> Result<(), gst::ErrorMessage> {
-        *self.state.lock().unwrap() = Default::default();
+        *self
+            .state
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_STATE))? = Default::default();
         self.unlock_stop()?;
         Ok(())
     }
 
     fn stop(&self) -> Result<(), gst::ErrorMessage> {
-        *self.state.lock().unwrap() = Default::default();
+        *self
+            .state
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_STATE))? = Default::default();
         self.unlock()?;
         Ok(())
     }
 
     fn query(&self, query: &mut gst::QueryRef) -> bool {
         if let gst::QueryViewMut::Latency(q) = query.view_mut() {
-            let is_live = self.settings.lock().unwrap().is_live;
-            let state = self.state.lock().unwrap();
+            let Ok(settings) = self.settings.lock() else {
+                imp_failed!(self, LOCK_SETTINGS);
+                return false;
+            };
+            let Ok(state) = self.state.lock() else {
+                imp_failed!(self, LOCK_STATE);
+                return false;
+            };
             if let Some(ref info) = state.info {
-                let latency = gst::ClockTime::SECOND
+                let Some(latency) = gst::ClockTime::SECOND
                     .mul_div_floor(info.fps().denom() as u64, info.fps().numer() as u64)
-                    .unwrap();
-                q.set(is_live, latency, gst::ClockTime::NONE);
+                else {
+                    imp_failed!(self, CALC_LATENCY);
+                    return false;
+                };
+                q.set(settings.is_live, latency, gst::ClockTime::NONE);
                 return true;
             }
             return false;
@@ -404,14 +484,23 @@ impl BaseSrcImpl for AvSyncVideoTestSrc {
     }
 
     fn fixate(&self, mut caps: gst::Caps) -> gst::Caps {
-        let settings = *self.settings.lock().unwrap();
+        let settings = match self.settings.lock() {
+            Ok(settings) => *settings,
+            Err(_) => {
+                imp_failed!(self, LOCK_SETTINGS);
+                Settings::default()
+            }
+        };
         caps.truncate();
         {
             let caps = caps.make_mut();
-            let s = caps.structure_mut(0).unwrap();
-            s.fixate_field_nearest_int("width", settings.width);
-            s.fixate_field_nearest_int("height", settings.height);
-            s.fixate_field_nearest_fraction("framerate", settings.framerate);
+            if let Some(s) = caps.structure_mut(0) {
+                s.fixate_field_nearest_int("width", settings.width);
+                s.fixate_field_nearest_int("height", settings.height);
+                s.fixate_field_nearest_fraction("framerate", settings.framerate);
+            } else {
+                imp_failed!(self, CAPS_NO_STRUCTURE);
+            }
         }
         self.parent_fixate(caps)
     }
@@ -421,7 +510,10 @@ impl BaseSrcImpl for AvSyncVideoTestSrc {
     }
 
     fn unlock(&self) -> Result<(), gst::ErrorMessage> {
-        let mut clock_wait = self.clock_wait.lock().unwrap();
+        let mut clock_wait = self
+            .clock_wait
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_CLOCK_WAIT))?;
         if let Some(clock_id) = clock_wait.clock_id.take() {
             clock_id.unschedule();
         }
@@ -430,7 +522,10 @@ impl BaseSrcImpl for AvSyncVideoTestSrc {
     }
 
     fn unlock_stop(&self) -> Result<(), gst::ErrorMessage> {
-        self.clock_wait.lock().unwrap().flushing = false;
+        self.clock_wait
+            .lock()
+            .map_err(|_| imp_error::failed_msg(LOCK_CLOCK_WAIT))?
+            .flushing = false;
         Ok(())
     }
 }
@@ -440,9 +535,19 @@ impl PushSrcImpl for AvSyncVideoTestSrc {
         &self,
         _buffer: Option<&mut gst::BufferRef>,
     ) -> Result<CreateSuccess, gst::FlowError> {
-        let settings = *self.settings.lock().unwrap();
+        let settings = self
+            .settings
+            .lock()
+            .map_err(|_| {
+                imp_failed!(self, LOCK_SETTINGS);
+                gst::FlowError::Error
+            })
+            .map(|s| *s)?;
 
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock().map_err(|_| {
+            imp_failed!(self, LOCK_STATE);
+            gst::FlowError::Error
+        })?;
         let info = match state.info {
             None => {
                 gst::element_imp_error!(self, gst::CoreError::Negotiation, ["Have no caps yet"]);
@@ -455,10 +560,18 @@ impl PushSrcImpl for AvSyncVideoTestSrc {
 
         let num = info.fps().numer() as u64;
         let den = info.fps().denom() as u64;
-        let pts = gst::ClockTime::SECOND.mul_div_floor(n * den, num).unwrap();
+        let pts = gst::ClockTime::SECOND
+            .mul_div_floor(n * den, num)
+            .ok_or_else(|| {
+                imp_failed!(self, "Failed to calculate video PTS");
+                gst::FlowError::Error
+            })?;
         let next_pts = gst::ClockTime::SECOND
             .mul_div_floor((n + 1) * den, num)
-            .unwrap();
+            .ok_or_else(|| {
+                imp_failed!(self, "Failed to calculate next video PTS");
+                gst::FlowError::Error
+            })?;
         let bar_centre =
             signal::bar_centre_column(signal::phase(pts, settings.pip_interval), info.width());
         let frame_idx = n as u8;
@@ -470,18 +583,30 @@ impl PushSrcImpl for AvSyncVideoTestSrc {
             state.caption_writer.next_cdp(framerate, n as u16, text)
         });
 
-        let mut buffer = gst::Buffer::with_size(info.size()).unwrap();
+        let mut buffer = gst::Buffer::with_size(info.size()).map_err(|_| {
+            imp_failed!(self, "Failed to allocate video buffer");
+            gst::FlowError::Error
+        })?;
         {
-            let buffer = buffer.get_mut().unwrap();
+            let buffer = buffer.get_mut().ok_or_else(|| {
+                imp_failed!(self, BUFFER_NOT_WRITABLE);
+                gst::FlowError::Error
+            })?;
             buffer.set_pts(pts);
             buffer.set_duration(next_pts - pts);
             {
-                let mut map = buffer.map_writable().unwrap();
+                let mut map = buffer.map_writable().map_err(|_| {
+                    imp_failed!(self, "Failed to map video buffer writable");
+                    gst::FlowError::Error
+                })?;
                 let data = map.as_mut_slice();
                 match info.format() {
                     gst_video::VideoFormat::V210 => fill_v210(data, &info, bar_centre, bar_width),
                     gst_video::VideoFormat::Uyvp => fill_uyvp(data, &info, bar_centre, bar_width),
-                    _ => unreachable!("format validated in set_caps"),
+                    _ => {
+                        imp_failed!(self, "Unsupported video format after caps validation");
+                        return Err(gst::FlowError::Error);
+                    }
                 }
                 data[0] = frame_idx;
             }
@@ -526,13 +651,19 @@ impl AvSyncVideoTestSrc {
             .obj()
             .segment()
             .downcast::<gst::format::Time>()
-            .unwrap();
+            .map_err(|_| {
+                imp_failed!(self, GET_TIME_SEGMENT);
+                gst::FlowError::Error
+            })?;
         let running_time = segment.to_running_time(buffer.pts().opt_add(buffer.duration()));
         let Some(wait_until) = running_time.opt_add(base_time) else {
             return Ok(());
         };
 
-        let mut clock_wait = self.clock_wait.lock().unwrap();
+        let mut clock_wait = self.clock_wait.lock().map_err(|_| {
+            imp_failed!(self, LOCK_CLOCK_WAIT);
+            gst::FlowError::Error
+        })?;
         if clock_wait.flushing {
             return Err(gst::FlowError::Flushing);
         }
@@ -541,7 +672,14 @@ impl AvSyncVideoTestSrc {
         drop(clock_wait);
 
         let (res, _) = id.wait();
-        self.clock_wait.lock().unwrap().clock_id.take();
+        self.clock_wait
+            .lock()
+            .map_err(|_| {
+                imp_failed!(self, LOCK_CLOCK_WAIT);
+                gst::FlowError::Error
+            })?
+            .clock_id
+            .take();
         if res == Err(gst::ClockError::Unscheduled) {
             return Err(gst::FlowError::Flushing);
         }

--- a/rust/gst-avsynctest-rs/tests/generator.rs
+++ b/rust/gst-avsynctest-rs/tests/generator.rs
@@ -212,7 +212,7 @@ fn captions_tick_tock_on_pip_frames() {
         let n = pts / frame_period;
         let cdp =
             gstavsynctest::analyze::caption_cdp_bytes(buffer).expect("caption ancillary present");
-        let text = gstavsynctest::analyze::decode_caption(&mut parser, &cdp);
+        let text = gstavsynctest::analyze::decode_caption(&mut parser, &cdp).expect("valid CDP");
         let on_pip = pts != 0 && pts.is_multiple_of(PIP_INTERVAL_NS);
         match text {
             Some(t) if on_pip => {

--- a/rust/gst-nmos-rs/tests/av_sync.rs
+++ b/rust/gst-nmos-rs/tests/av_sync.rs
@@ -467,7 +467,9 @@ fn pull_video(sink: &gst_app::AppSink) -> Vec<VideoFrame> {
         let anc = gstavsynctest::analyze::ancillary_indices(buffer, gstavsynctest::signal::ANC_DID);
         let captions = gstavsynctest::analyze::caption_cdps(buffer)
             .iter()
-            .filter_map(|cdp| gstavsynctest::analyze::decode_caption(&mut parser, cdp))
+            .filter_map(|cdp| {
+                gstavsynctest::analyze::decode_caption(&mut parser, cdp).expect("valid CDP")
+            })
             .collect();
         seen_last = idx == last;
         out.push(VideoFrame {


### PR DESCRIPTION
Production code paths used unwrap()/expect() for conditions that, while "shouldn't happen", are still recoverable failures the pipeline should be told about rather than aborting the process. Replace them with error propagation wired through to GStreamer:

- audiosrc/videosrc: replace silent "if let Ok(lock)" degradation and unwrap() with element error reporting; post CoreError::Failed on the bus (imp_failed!) or return an ErrorMessage/LoggableError/FlowError.
- analyze: detect_pips uses let-else instead of unwrap; decode_caption returns Result so a parse error is distinct from a null CDP (Ok(None)).
- add imp_error module: message constants shared verbatim by both source elements, a failed_msg() ErrorMessage constructor, and the imp_failed! macro wrapping element_imp_error!(.., CoreError::Failed, ..).

Test code keeps unwrap/expect.