### PR TITLE
gst-nmos-rs: add ST 2110-22 JPEG XS (video/jxsv) support

### DIFF
--- a/rust/gst-nmos-rs/README.md
+++ b/rust/gst-nmos-rs/README.md
@@ -31,11 +31,27 @@ Both elements:
 | `label`          | string  | optional  | NMOS label for this Sender/Receiver (not the Node). Overrides the transport file when both are supplied (MXL `flow_def` top-level `label`; SDP `s=` line). |
 | `description`    | string  | optional  | NMOS description for this Sender/Receiver. Overrides the transport file when both are supplied (MXL `flow_def` top-level `description`; SDP `i=` line). |
 | `group-hint`     | string  | optional  | NMOS group hint (`urn:x-nmos:tag:grouphint/v1.0`), e.g. `"SDI 1:Video"`, used by controllers to group a device's Senders/Receivers (the related video, audio and ANC flows). Becomes the session-level `a=x-nvnmos-group-hint:` SDP attribute on RTP/UDP, or the grouphint tag in an MXL `flow_def`. Overrides the transport file when both are supplied. Omitted from synthesised files when unset. |
-| `caps`           | GstCaps | required when `transport-file*` is unset | Essence caps. Supported shapes: `video/x-raw,format=…,width=…,height=…,framerate=…[,interlace-mode=…]` (MXL: `v210`; RTP/UDP: RFC 4175 8-bit `UYVY` and 10-bit `UYVP`); `audio/x-raw,format=…,rate=…,channels=…` (MXL: `F32LE`; RTP/UDP: ST 2110-30 `S24BE` (L24) and `S16BE` (L16)); `meta/x-st-2038,framerate=…` (the framerate must be present — set it upstream with a `capsfilter caps="meta/x-st-2038,framerate=30/1"` if needed). On both elements, drives `transport-file` synthesis when `transport-file*` is unset: on `transport=mxl` a MXL `flow_def` JSON document (requires `mxl-flow-id`); on `transport=udp` / `udp2` an SDP description (requires the relevant IS-05 endpoint properties — `destination-ip` etc.). On `nmossrc` the synthesised configuring file describes the essence shape: narrow receivers advertise BCP-004-01 Receiver Caps on IS-04; wide receivers advertise none (`receiver-caps-mode` controls the marker — `urn:x-nvnmos:tag:caps` on MXL, `a=x-nvnmos-caps:` on RTP/UDP). On `nmossrc` with `transport=mxl`, the media-type structure name (`video/x-raw` / `audio/x-raw` / `meta/x-st-2038`) also picks the `mxlsrc.{video,audio,data}-flow-id=` slot. Cross-checked against the transport file's `format` (MXL) / `m=` line (SDP) when both are supplied. |
+| `caps`           | GstCaps | required when `transport-file*` is unset | Essence caps describing the media format. Drives transport file synthesis when `transport-file*` is unset; cross-checked against a supplied transport file when both are set. See [supported essence shapes](#caps-essence-shapes) below. |
 | `transport-caps` | GstCaps | optional  | RTP-only transport-layer overrides applied to the synthesised or supplied SDP, expressed as an `application/x-rtp` caps structure. Recognised fields: `payload` (dynamic RTP payload type, 96–127), `clock-rate` (audio only — video / ANC are pinned to 90000), `ptime` / `maxptime` (audio packetisation interval in ms, packed into SDP `a=ptime:` / `a=maxptime:`). Ignored on `transport=mxl`. |
 | `transport-properties` | GstStructure | optional | Overrides applied to the inner source or sink (`udpsrc` / `udpsink` / `nvdsudpsrc` / `nvdsudpsink` / `mxlsrc` / `mxlsink`) every time the data-path chain is built. Pass a `GstStructure` whose fields are GObject property names on that inner element — for example `properties,buffer-size=26214400` or `properties,gpu-id=0,sync=false`. The structure name is not interpreted. Takes effect on the next chain build, not immediately on the one currently in the chain. Unknown fields log a warning and are skipped. |
 | `mxl-domain-path` | string | required for MXL | Local filesystem path identifying the MXL Domain on this host; fed into the inner `mxlsink` / `mxlsrc` `domain=` property. If a `domain_def.json` is present in the directory its `id` is used to populate or cross-check `mxl-domain-id` (mismatch is an error — this is host-level identity). |
 | `auto-activate`  | boolean | optional, default `false` | When `false` the element adds the Sender or Receiver to the daemon so it appears on IS-04 and IS-05 but leaves the inner data path on the fake chain until an IS-05 PATCH activates it (`master_enable: true` on `/single/{senders,receivers}/{id}/active`). When `true` the element brings the inner transport src/sink up immediately once the configuring transport file has been resolved at NULL→READY (or, for a deferred-mode sender, at READY→PAUSED) *and* calls `SyncResourceState` to push the daemon's IS-04/IS-05 view to active — i.e. it's a no-controller shortcut for development pipelines and for setups where flow identity comes entirely from properties / `transport-file*`. Orthogonal to how the transport file itself becomes available: property override of `mxl-flow-id`, supplied `transport-file*`, and caps-driven synthesis (MXL `flow_def` or SDP) all feed the same gate. |
+
+#### `caps` essence shapes {#caps-essence-shapes}
+
+When `transport-file*` is unset, `caps` drives synthesis of the configuring transport file:
+
+- `transport=mxl` → MXL `flow_def` JSON (also requires `mxl-flow-id`).
+- `transport=udp` / `udp2` / `nvdsudp` → SDP (also requires the relevant IS-05 endpoint properties — `destination-ip` etc.).
+
+On `nmossrc`, the synthesised configuring file describes the essence shape: narrow receivers advertise BCP-004-01 Receiver Caps on IS-04; wide receivers advertise none (`receiver-caps-mode` controls the marker — `urn:x-nvnmos:tag:caps` on MXL, `a=x-nvnmos-caps:` on RTP/UDP). On `nmossrc` with `transport=mxl`, the `caps` media-type structure name also picks the `mxlsrc.{video,audio,data}-flow-id=` slot.
+
+| Media | Caps shape | Transports | Notes |
+| ----- | ---------- | ---------- | ----- |
+| Video (raw) | `video/x-raw,format=…,width=…,height=…,framerate=…[,interlace-mode=…]` | all | MXL: `v210`. RTP/UDP: RFC 4175 8-bit `UYVY` and 10-bit `UYVP`. |
+| Video (JPEG XS) | `image/x-jxsc,…` or `video/x-jxsv,…` | `udp` / `udp2` only | AMWA BCP-006-01 / RFC 9134 / ST 2110-22. `width` / `height` / `framerate` required; `sampling` / `depth` / `profile` / `level` / `sublevel` optional. Both essence caps map to the `video/jxsv` SDP and `rtpjxsvpay` / `rtpjxsvdepay`. Bit rates are element properties (`format-bit-rate` / `transport-bit-rate`), not caps fields — see property tables below. Not supported on `nvdsudp`. |
+| Audio | `audio/x-raw,format=…,rate=…,channels=…` | all | MXL: `F32LE`. RTP/UDP: ST 2110-30 `S24BE` (L24) and `S16BE` (L16). |
+| Data (ANC) | `meta/x-st-2038,framerate=…` | all | `framerate` must be present — set it upstream with a `capsfilter caps="meta/x-st-2038,framerate=30/1"` if needed. |
 
 `nmossink`-only:
 
@@ -48,6 +64,8 @@ Both elements:
 | `source-port` | uint (0–65535) | optional, RTP transports only | IS-05 sender `transport_params.source_port`. Local egress port. Drives `udpsink.bind-port` and the SDP `a=x-nvnmos-src-port:` attribute. `0` (the default) = unset; the OS picks an ephemeral port. RTP-only. |
 | `destination-ip` | string | optional, RTP transports only | IS-05 sender `transport_params.destination_ip`. Remote destination (unicast peer or multicast group). Becomes the configuring SDP `c=` line address and `udpsink.host`. Empty = unset (use the transport file's `c=` line if present; else daemon `auto`). RTP-only. |
 | `destination-port` | uint (0–65535) | optional, RTP transports only | IS-05 sender `transport_params.destination_port`. Remote destination port. Becomes the SDP `m=` port slot and `udpsink.port`. `0` (the default) = unset; falls back to the transport file's `m=` port, else to the canonical RTP default 5004 (`nmos-cpp::auto_rtp_port`). RTP-only. |
+| `format-bit-rate` | uint64 | optional, JPEG XS RTP only | Coded essence (Flow) bit rate in **kilobits per second** (1000 bits/s). Synthesises SDP fmtp `x-nvnmos-format-bit-rate` and sets `rtpjxsvpay max-codestream-bitrate` (×1000 → bit/s) unless `pay-properties` already supplies it. `0` = unset. See [property interaction](#property-interaction-with-transport-file). |
+| `transport-bit-rate` | uint64 | optional, JPEG XS RTP only | Transport (Sender) bit rate in **kilobits per second**, including RTP/UDP/IP overhead. Synthesises SDP `b=AS:` and fmtp `x-nvnmos-transport-bit-rate`. `0` = unset. Derives the other side via the `nvnmosd` 1.05 overhead factor when only one rate is set (transport derived from format is rounded to the nearest Mbit/s). |
 | `pay-properties` | GstStructure | optional | Overrides applied to the inner RTP payloader every time the UDP sender chain is built. Same `GstStructure` syntax as `transport-properties`; ignored on `mxl` and `nvdsudp` (a warning is logged if non-empty). Takes effect on the next chain build. |
 
 `nmossrc`-only:
@@ -62,6 +80,8 @@ Both elements:
 | `interface-ip`    | string | optional, RTP transports only | IS-05 receiver `transport_params.interface_ip`. Local NIC IP used for the IGMP join; resolved to an interface name and fed into `udpsrc.multicast-iface`. Also emitted in the configuring SDP as `a=x-nvnmos-iface-ip:`. Empty = unset (let the kernel pick). RTP-only. |
 | `multicast-ip`    | string | optional, RTP transports only | IS-05 receiver `transport_params.multicast_ip`. Multicast group to join. Becomes `udpsrc.address` and the SDP `c=` line address. Empty = unset (unicast reception). RTP-only. |
 | `destination-port` | uint (0–65535) | optional, RTP transports only | IS-05 receiver `transport_params.destination_port`. **Different semantics from the sender-side property of the same name**: local listen port. Becomes `udpsrc.port` and the SDP `m=` port slot. `0` (the default) = unset; falls back to the transport file's `m=` port, else to 5004. RTP-only. |
+| `format-bit-rate` | uint64 | optional, JPEG XS RTP only | Coded essence (Flow) bit rate in **kilobits per second** for cross-check / splice against a supplied `transport-file*` SDP. `0` = unset. See [property interaction](#property-interaction-with-transport-file). |
+| `transport-bit-rate` | uint64 | optional, JPEG XS RTP only | Transport (Sender) bit rate in **kilobits per second** for cross-check / splice against a supplied `transport-file*` SDP. `0` = unset. |
 | `depay-properties` | GstStructure | optional | Overrides applied to the inner RTP depayloader every time the UDP receiver chain is built. Same `GstStructure` syntax as `transport-properties`; ignored on non-UDP transports (a warning is logged if non-empty). Takes effect on the next chain build. |
 
 ### Property Interaction With `transport-file`
@@ -74,6 +94,7 @@ built with these rules:
 | ------------- | ---------- | ------------------ |
 | Identity / cosmetic | `sender-name` / `receiver-name`, `mxl-flow-id`, `mxl-domain-id`, `label`, `description`, `group-hint`, `receiver-caps-mode` | **Property overrides file.** The element rewrites the file's matching field/tag to the property value before the daemon sees it. |
 | Essence shape | `caps`, `transport-caps` | **Cross-check.** Property must agree with the file's shape (today: `caps` first structure name vs `format`). Mismatch is a hard error at NULL→READY. |
+| Bit rates | `format-bit-rate`, `transport-bit-rate` | **Cross-check when both declare a rate; splice when only the property is set.** Values are kilobits per second (matching NMOS `bit_rate`, SDP `b=AS:`, and fmtp `x-nvnmos-*-bit-rate` per AMWA BCP-006-01 / RFC 9134 / ST 2110-22). When the supplied SDP omits bit rates, non-zero properties are written into the configuring SDP before the daemon sees it. |
 | Activation gate | `auto-activate` | Doesn't appear in the transport file; it gates whether the data path goes live eagerly at NULL→READY (and tells the daemon to flip `/active` to `master_enable: true` via `SyncResourceState`) or waits for an IS-05 PATCH. Orthogonal to where the flow_def came from. |
 | No interaction | `daemon-uri`, `node-seed`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url`, `transport`, `mxl-domain-path`, `transport-properties`, `pay-properties`, `depay-properties` | These don't appear in the transport file at all. Node-identity properties (`host-name`, `domain`, `registration-url`, `system-url`, `http-port`) are forwarded to `OpenSession` as `node_config` and honoured only when that session creates the Node (first opener for a given `node-seed`). `transport-properties` / `pay-properties` / `depay-properties` tune the inner GStreamer elements at chain-build time instead. |
 
@@ -239,7 +260,8 @@ at activation; `nvdsudpsrc` uses comma-separated `st2022-7-streams`,
 `udp` / `udp2` are rejected. Caps-only synthesis still emits one `m=`.
 See [`doc/designs/gst-nmos-rs-st2022-7-dual-leg-plan.md`](../../doc/designs/gst-nmos-rs-st2022-7-dual-leg-plan.md).
 
-**Not yet supported:** `video/x-jxsv`.
+**Not yet supported on `nvdsudp`:** JPEG XS (`image/x-jxsc` / `video/x-jxsv`) —
+available on `udp` / `udp2` only.
 
 Design notes: [`doc/designs/gst-nmos-rs-nvdsudp-plan.md`](../../doc/designs/gst-nmos-rs-nvdsudp-plan.md).
 

--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -47,6 +47,11 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MXL_REPO/build/Linux-Clang-Debug/lib
 `transport={udp,udp2}` needs only the nvnmos build above plus system
 GStreamer plugins (gst-plugins-good; gst-plugins-rs for `udp2`).
 
+JPEG XS examples (`*-udp-jxsv.sh`) also need gst-plugins-rs `rsrtp`
+(`rtpjxsvpay` / `rtpjxsvdepay`) and a JPEG XS codec
+(`svtjpegxsenc` / `svtjpegxsdec` from gst-plugins-bad). JPEG XS
+is not supported on `transport=nvdsudp`.
+
 **Daemon** (terminal 1 — or use the demo script, which starts its own):
 
 ```sh
@@ -117,6 +122,7 @@ prefix. Example scripts and the interactive demo both source this file.
 | `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_LABEL` | Primary essence name for NMOS `label=` (keep in sync with `*_CAPS`) |
 | `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_CAPS_ALT` | Alternate essence (demo Node 4) |
 | `DEMO_{MXL,UDP}_{VIDEO,AUDIO}_LABEL_ALT` | Alternate essence name for NMOS `label=` (keep in sync with `*_CAPS_ALT`) |
+| `DEMO_UDP_VIDEO_JXSV_{CAPS,RAW_CAPS,BIT_RATE,LABEL}` | JPEG XS essence caps (`image/x-jxsc`), encoder input (`video/x-raw`), format bit rate (kbit/s), and NMOS `label=` |
 | `DEMO_UDP_AUDIO_TRANSPORT_CAPS_ALT` | Alt UDP audio `transport-caps` (`a-ptime=0.125` ms; demo Node 4) |
 | `DEMO_UDP_VIDEO_BUFFER_SIZE` | `udpsrc`/`udpsink` socket buffer (`udp`/`udp2` only) |
 | `DEMO_VIDEO_QUEUE_MAX_BUFFERS` | Queue after video `nmossrc` on receiver / flipper paths |
@@ -136,6 +142,7 @@ By default, essence formats are aligned across transports at
 | Flow | MXL caps | UDP caps |
 |------|----------|----------|
 | Video | `DEMO_MXL_VIDEO_CAPS` — 1080p25 `v210` | `DEMO_UDP_VIDEO_CAPS` — 1080p25 `UYVP` |
+| Video (JPEG XS) | — | `DEMO_UDP_VIDEO_JXSV_CAPS` — 1080p25 `image/x-jxsc` |
 | Audio | `DEMO_MXL_AUDIO_CAPS` — 2 ch `F32LE` | `DEMO_UDP_AUDIO_CAPS` — 2 ch `S24BE` |
 | Video (alt) | `DEMO_MXL_VIDEO_CAPS_ALT` — 1080p29.97 `v210` | `DEMO_UDP_VIDEO_CAPS_ALT` — 1080p29.97 `UYVP` |
 | Audio (alt) | `DEMO_MXL_AUDIO_CAPS_ALT` — 8 ch `F32LE` | `DEMO_UDP_AUDIO_CAPS_ALT` — 8 ch `S24BE`; `DEMO_UDP_AUDIO_TRANSPORT_CAPS_ALT` — `ptime=0.125` ms |
@@ -148,8 +155,8 @@ Alternate caps are used by demo **Node 4** for wide-receiver reroute tests
 
 | Scenario | MXL script | UDP script (`udp` / `udp2` / `nvdsudp`) | Demo script node |
 |----------|------------|-------------------------------------------|------------------|
-| 1080p25 sender | [`1080p25-sender-mxl.sh`](scripts/example-pipelines/1080p25-sender-mxl.sh) | [`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh) | Node 1 video |
-| 1080p25 receiver | [`1080p25-receiver-mxl.sh`](scripts/example-pipelines/1080p25-receiver-mxl.sh) | [`1080p25-receiver-udp.sh`](scripts/example-pipelines/1080p25-receiver-udp.sh) | Node 2 video |
+| 1080p25 sender | [`1080p25-sender-mxl.sh`](scripts/example-pipelines/1080p25-sender-mxl.sh) | [`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh) · [`1080p25-sender-udp-jxsv.sh`](scripts/example-pipelines/1080p25-sender-udp-jxsv.sh) | Node 1 video |
+| 1080p25 receiver | [`1080p25-receiver-mxl.sh`](scripts/example-pipelines/1080p25-receiver-mxl.sh) | [`1080p25-receiver-udp.sh`](scripts/example-pipelines/1080p25-receiver-udp.sh) · [`1080p25-receiver-udp-jxsv.sh`](scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh) | Node 2 video |
 | Flip / process | [`1080p25-flipper-mxl.sh`](scripts/example-pipelines/1080p25-flipper-mxl.sh) | [`1080p25-flipper-udp.sh`](scripts/example-pipelines/1080p25-flipper-udp.sh) | Node 3 video |
 | Deferred sender | [`1080p25-deferred-sender-mxl.sh`](scripts/example-pipelines/1080p25-deferred-sender-mxl.sh) | [`1080p25-deferred-sender-udp.sh`](scripts/example-pipelines/1080p25-deferred-sender-udp.sh) | — |
 | Multi-flow sender | [`multi-flow-sender-mxl.sh`](scripts/example-pipelines/multi-flow-sender-mxl.sh) | [`multi-flow-sender-udp.sh`](scripts/example-pipelines/multi-flow-sender-udp.sh) | Node 1 (video + audio) |
@@ -157,12 +164,17 @@ Alternate caps are used by demo **Node 4** for wide-receiver reroute tests
 | Minimal receiver (properties) | [`minimal-prop-receiver-mxl.sh`](scripts/example-pipelines/minimal-prop-receiver-mxl.sh) | [`minimal-prop-receiver-udp.sh`](scripts/example-pipelines/minimal-prop-receiver-udp.sh) | — |
 | Minimal sender (transport file) | [`minimal-file-sender-mxl.sh`](scripts/example-pipelines/minimal-file-sender-mxl.sh) | [`minimal-file-sender-udp.sh`](scripts/example-pipelines/minimal-file-sender-udp.sh) | — |
 | Minimal receiver (transport file) | [`minimal-file-receiver-mxl.sh`](scripts/example-pipelines/minimal-file-receiver-mxl.sh) | [`minimal-file-receiver-udp.sh`](scripts/example-pipelines/minimal-file-receiver-udp.sh) | — |
+| Minimal sender (properties, JPEG XS) | — | [`minimal-prop-sender-udp-jxsv.sh`](scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh) | — |
+| Minimal receiver (properties, JPEG XS) | — | [`minimal-prop-receiver-udp-jxsv.sh`](scripts/example-pipelines/minimal-prop-receiver-udp-jxsv.sh) | — |
+| Minimal sender (transport file, JPEG XS) | — | [`minimal-file-sender-udp-jxsv.sh`](scripts/example-pipelines/minimal-file-sender-udp-jxsv.sh) | — |
+| Minimal receiver (transport file, JPEG XS) | — | [`minimal-file-receiver-udp-jxsv.sh`](scripts/example-pipelines/minimal-file-receiver-udp-jxsv.sh) | — |
 | Full lab + IS-05 | — | — | [`gst-nmos-rs-demo.sh`](scripts/gst-nmos-rs-demo.sh) |
 
 ### 1080p25 Sender
 
 [`1080p25-sender-mxl.sh`](scripts/example-pipelines/1080p25-sender-mxl.sh) ·
-[`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh)
+[`1080p25-sender-udp.sh`](scripts/example-pipelines/1080p25-sender-udp.sh) ·
+[`1080p25-sender-udp-jxsv.sh`](scripts/example-pipelines/1080p25-sender-udp-jxsv.sh)
 
 **MXL** — caps + `mxl-flow-id` synthesis, eager activation:
 
@@ -190,6 +202,8 @@ gst-launch-1.0 -e \
 ```sh
 export DEMO_NIC_IP=203.0.113.1   # your high-bandwidth network interface
 ./scripts/example-pipelines/1080p25-sender-udp.sh
+# or
+./scripts/example-pipelines/1080p25-sender-udp-jxsv.sh
 ```
 
 Equivalent one-liner (`transport=udp2` also works):
@@ -209,7 +223,8 @@ gst-launch-1.0 -e \
 ### 1080p25 Receiver
 
 [`1080p25-receiver-mxl.sh`](scripts/example-pipelines/1080p25-receiver-mxl.sh) ·
-[`1080p25-receiver-udp.sh`](scripts/example-pipelines/1080p25-receiver-udp.sh)
+[`1080p25-receiver-udp.sh`](scripts/example-pipelines/1080p25-receiver-udp.sh) ·
+[`1080p25-receiver-udp-jxsv.sh`](scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh)
 
 Start a matching sender first (same flow identity / multicast group).
 
@@ -223,6 +238,8 @@ Start a matching sender first (same flow identity / multicast group).
 
 ```sh
 ./scripts/example-pipelines/1080p25-receiver-udp.sh
+# or
+./scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh
 ```
 
 Use `DEMO_VIDEO_SINK=fakesink` on headless hosts (element name only;
@@ -294,6 +311,11 @@ JSON; UDP synthesises configuring SDP).
 [`minimal-file-receiver-mxl.sh`](scripts/example-pipelines/minimal-file-receiver-mxl.sh) ·
 [`minimal-file-receiver-udp.sh`](scripts/example-pipelines/minimal-file-receiver-udp.sh)
 
+[`minimal-prop-sender-udp-jxsv.sh`](scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh) ·
+[`minimal-prop-receiver-udp-jxsv.sh`](scripts/example-pipelines/minimal-prop-receiver-udp-jxsv.sh) ·
+[`minimal-file-sender-udp-jxsv.sh`](scripts/example-pipelines/minimal-file-sender-udp-jxsv.sh) ·
+[`minimal-file-receiver-udp-jxsv.sh`](scripts/example-pipelines/minimal-file-receiver-udp-jxsv.sh)
+
 Smallest NULL→READY AddSender / AddReceiver paths with
 `auto-activate=false`. Resources register on IS-04 at READY; the controller
 PATCHes `/single/{senders,receivers}/{id}/staged` to bring the data path
@@ -315,10 +337,14 @@ plus `caps` (and `source-ip` / `interface-ip` for RTP/UDP, or
 ```sh
 ./scripts/example-pipelines/minimal-prop-sender-udp.sh
 ./scripts/example-pipelines/minimal-prop-receiver-udp.sh
+# or
+./scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh
+./scripts/example-pipelines/minimal-prop-receiver-udp-jxsv.sh
 ```
 
 **Transport-file-driven (`minimal-file-*`)** — configuring SDP / flow_def
-from [`fixtures/minimal-video.sdp.in`](scripts/example-pipelines/fixtures/minimal-video.sdp.in)
+from [`fixtures/minimal-video.sdp.in`](scripts/example-pipelines/fixtures/minimal-video.sdp.in),
+[`fixtures/minimal-video-jxsv.sdp.in`](scripts/example-pipelines/fixtures/minimal-video-jxsv.sdp.in),
 and
 [`fixtures/minimal-video.mxl.json.in`](scripts/example-pipelines/fixtures/minimal-video.mxl.json.in)
 via `transport-file-path`. Resource name comes from the file
@@ -342,6 +368,9 @@ addresses via IS-05 PATCH.
 ```sh
 ./scripts/example-pipelines/minimal-file-sender-udp.sh
 ./scripts/example-pipelines/minimal-file-receiver-udp.sh
+# or
+./scripts/example-pipelines/minimal-file-sender-udp-jxsv.sh
+./scripts/example-pipelines/minimal-file-receiver-udp-jxsv.sh
 ```
 
 ### Multi-Flow (Video + Audio on One Node)

--- a/rust/gst-nmos-rs/scripts/env.sh
+++ b/rust/gst-nmos-rs/scripts/env.sh
@@ -43,11 +43,16 @@ export DEMO_UDP_TRANSPORT=${DEMO_UDP_TRANSPORT:-udp}
 # Primary essence: 1080p25 10-bit 4:2:2 video + 2 ch @ 48 kHz audio.
 export DEMO_MXL_VIDEO_CAPS='video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
 export DEMO_UDP_VIDEO_CAPS='video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
+export DEMO_UDP_VIDEO_JXSV_RAW_CAPS='video/x-raw,format=I422_10LE,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
+export DEMO_UDP_VIDEO_JXSV_CAPS='image/x-jxsc,width=1920,height=1080,framerate=25/1,interlace-mode=progressive,sampling=YCbCr-4:2:2,depth=10,profile=High444.12,level=2k-1,sublevel=Sublev3bpp'
+# JPEG XS format bit rate (kbit/s); drives SDP b=AS:/fmtp and rtpjxsvpay ceiling.
+export DEMO_UDP_VIDEO_JXSV_BIT_RATE=110000
 export DEMO_MXL_AUDIO_CAPS='audio/x-raw,format=F32LE,rate=48000,channels=2,layout=interleaved'
 export DEMO_UDP_AUDIO_CAPS='audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved'
 # Truncated human-readable essence name for NMOS `label=` — keep in sync with *_CAPS.
 export DEMO_MXL_VIDEO_LABEL=${DEMO_MXL_VIDEO_LABEL:-1080p25 v210}
 export DEMO_UDP_VIDEO_LABEL=${DEMO_UDP_VIDEO_LABEL:-1080p25 UYVP}
+export DEMO_UDP_VIDEO_JXSV_LABEL=${DEMO_UDP_VIDEO_JXSV_LABEL:-1080p25 JPEG XS}
 export DEMO_MXL_AUDIO_LABEL=${DEMO_MXL_AUDIO_LABEL:-48 kHz F32LE 2ch}
 export DEMO_UDP_AUDIO_LABEL=${DEMO_UDP_AUDIO_LABEL:-48 kHz S24BE 2ch}
 

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# 1080p25 JPEG XS RTP/UDP receiver — eager activation, matched to
+# `1080p25-receiver-udp.sh` (multicast group 1, `auto-activate=true`).
+#
+# Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvdepay) and `svtjpegxsdec`.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-consumer \
+        http-port=18102 \
+        receiver-name=video2 \
+        multicast-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        interface-ip="$DEMO_NIC_IP" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_JXSV_CAPS" \
+        label="${DEMO_UDP_VIDEO_JXSV_LABEL} receiver" \
+        auto-activate=true ! \
+    $(demo_video_queue) ! \
+    svtjpegxsdec ! videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp-jxsv.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# 1080p25 JPEG XS RTP/UDP sender — eager activation, matched to
+# `1080p25-sender-udp.sh` (multicast group 1, `auto-activate=true`).
+#
+# Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvpay) and `svtjpegxsenc`.
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_JXSV_RAW_CAPS" ! \
+    svtjpegxsenc ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-producer \
+        http-port=18101 \
+        sender-name=video1 \
+        destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
+        destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_JXSV_CAPS" \
+        format-bit-rate="$DEMO_UDP_VIDEO_JXSV_BIT_RATE" \
+        label="${DEMO_UDP_VIDEO_JXSV_LABEL} sender" \
+        auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video-jxsv.sdp.in
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video-jxsv.sdp.in
@@ -1,0 +1,12 @@
+v=0
+o=- 1 0 IN IP4 @NIC_IP@
+s=@LABEL@
+t=0 0
+a=x-nvnmos-name:video1
+m=video 5004 RTP/AVP 96
+c=IN IP4 0.0.0.0
+b=AS:116000
+a=rtpmap:96 jxsv/90000
+a=fmtp:96 x-nvnmos-format-bit-rate=110000; packetmode=0; profile=High444.12; level=2k-1; sublevel=Sublev3bpp; sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25; depth=10; colorimetry=BT709; SSN=ST2110-22:2022
+a=x-nvnmos-iface-ip:@NIC_IP@
+a=mediaclk:direct=0

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video-jxsv.sdp.in.license
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-video-jxsv.sdp.in.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-udp-jxsv.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal transport-file JPEG XS RTP/UDP receiver for controller-driven IS-05
+# activation.
+#
+# AddReceiver at NULL→READY with configuring SDP from `transport-file-path`.
+# The resource name comes from `a=x-nvnmos-name` in the file (no `receiver-name`).
+# The NMOS label comes from SDP `s=` in the file (no `label` property).
+# Subscription identity (e.g., `multicast-ip`, `destination-port`)
+# and the data path arrive via IS-05 PATCH on
+# /single/receivers/{id}/staged.
+#
+# Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvdepay) and a JPEG XS decoder
+# (`svtjpegxsdec`).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../env.sh"
+require_nvnmosd
+
+transport_path="$(mktemp "${TMPDIR:-/tmp}/nvnmos-minimal-jxsv.XXXXXX.sdp")"
+trap 'rm -f "$transport_path"' EXIT
+transport_label="minimal ${DEMO_UDP_VIDEO_JXSV_LABEL} receiver (file)"
+render_transport_fixture \
+    "$SCRIPT_DIR/fixtures/minimal-video-jxsv.sdp.in" \
+    "$transport_path" \
+    "$transport_label"
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-jxsv-consumer \
+        $(udp_video_buffer_props) \
+        transport-file-path="$transport_path" \
+        auto-activate=false ! \
+    $(demo_video_queue) ! \
+    svtjpegxsdec ! videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-udp-jxsv.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal transport-file JPEG XS RTP/UDP sender for controller-driven IS-05
+# activation.
+#
+# AddSender at NULL→READY with configuring SDP from `transport-file-path`.
+# The resource name comes from `a=x-nvnmos-name` in the file (no `sender-name`).
+# The NMOS label comes from SDP `s=` in the file (no `label` property).
+#
+# Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvpay) and a JPEG XS encoder
+# (`svtjpegxsenc`).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../env.sh"
+require_nvnmosd
+
+transport_path="$(mktemp "${TMPDIR:-/tmp}/nvnmos-minimal-jxsv.XXXXXX.sdp")"
+trap 'rm -f "$transport_path"' EXIT
+transport_label="minimal ${DEMO_UDP_VIDEO_JXSV_LABEL} sender (file)"
+render_transport_fixture \
+    "$SCRIPT_DIR/fixtures/minimal-video-jxsv.sdp.in" \
+    "$transport_path" \
+    "$transport_label"
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_JXSV_RAW_CAPS" ! \
+    svtjpegxsenc ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-jxsv-producer \
+        $(udp_video_buffer_props) \
+        transport-file-path="$transport_path" \
+        auto-activate=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-receiver-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-receiver-udp-jxsv.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal properties-driven JPEG XS RTP/UDP receiver for controller-driven IS-05
+# activation.
+#
+# AddReceiver at NULL→READY with configuring SDP synthesised from `caps`,
+# `interface-ip`, and `receiver-name`.
+# Subscription identity (e.g., `multicast-ip`, `destination-port`)
+# and the data path arrive via IS-05 PATCH on
+# /single/receivers/{id}/staged.
+#
+# Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvdepay) and a JPEG XS decoder
+# (`svtjpegxsdec`).
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    nmossrc \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-jxsv-consumer \
+        receiver-name=video1 \
+        interface-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_JXSV_CAPS" \
+        label="minimal ${DEMO_UDP_VIDEO_JXSV_LABEL} receiver" \
+        auto-activate=false ! \
+    $(demo_video_queue) ! \
+    svtjpegxsdec ! videoconvert ! "$DEMO_VIDEO_SINK" sync=false

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal properties-driven JPEG XS RTP/UDP sender for controller-driven IS-05
+# activation.
+#
+# AddSender at NULL→READY with configuring SDP synthesised from `caps`,
+# `source-ip`, `sender-name`, and `format-bit-rate`.
+#
+# For JPEG XS the bit rate is format-defining: `format-bit-rate` (kbit/s) drives
+# the SDP `b=AS:` / fmtp advertisement and the `rtpjxsvpay max-codestream-bitrate`
+# ceiling. Omit it and the sender advertises no rate.
+#
+# Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvpay) and a JPEG XS encoder
+# (`svtjpegxsenc`).
+set -euo pipefail
+source "$(dirname "${BASH_SOURCE[0]}")/../env.sh"
+require_nvnmosd
+
+exec gst-launch-1.0 -e \
+    videotestsrc pattern=smpte is-live=true ! \
+    "$DEMO_UDP_VIDEO_JXSV_RAW_CAPS" ! \
+    svtjpegxsenc ! \
+    nmossink \
+        daemon-uri="$DEMO_DAEMON_URI" \
+        transport="$DEMO_UDP_TRANSPORT" \
+        node-seed=example-minimal-jxsv-producer \
+        sender-name=video1 \
+        source-ip="$DEMO_NIC_IP" \
+        $(udp_video_buffer_props) \
+        caps="$DEMO_UDP_VIDEO_JXSV_CAPS" \
+        format-bit-rate="$DEMO_UDP_VIDEO_JXSV_BIT_RATE" \
+        label="minimal ${DEMO_UDP_VIDEO_JXSV_LABEL} sender" \
+        auto-activate=false

--- a/rust/gst-nmos-rs/src/essence_caps.rs
+++ b/rust/gst-nmos-rs/src/essence_caps.rs
@@ -10,21 +10,21 @@ use gstreamer as gst;
 /// fields are filled in where absent (audio `channel-mask` and
 /// `channel-order`; video and ANC pass through unchanged).
 ///
-/// `raw_caps` is the minimal essence shape (from [`crate::flow_def::caps_from`]
+/// `caps` is the minimal essence shape (from [`crate::flow_def::caps_from`]
 /// or SDP parse). When `rtp_caps` is supplied, audio `channel-order`
 /// is taken from the fmtp slot on the companion `application/x-rtp`
 /// caps; otherwise audio defaults use channel count (`M` / `ST` / `Uxx`).
-pub(crate) fn caps_from(raw_caps: &gst::Caps, rtp_caps: Option<&gst::Caps>) -> gst::Caps {
-    if raw_caps
+pub(crate) fn caps_from(caps: &gst::Caps, rtp_caps: Option<&gst::Caps>) -> gst::Caps {
+    if caps
         .structure(0)
         .is_some_and(|s| s.name() == "audio/x-raw")
     {
         let channel_order = rtp_caps
             .and_then(|rtp| rtp.structure(0))
             .and_then(channel_order_from_rtp_structure);
-        audio_caps_from(raw_caps, channel_order.as_deref())
+        audio_caps_from(caps, channel_order.as_deref())
     } else {
-        raw_caps.clone()
+        caps.clone()
     }
 }
 

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -984,8 +984,9 @@ pub(crate) fn build_udpsink(
 /// [`UdpVariant::V2`] is requested.
 ///
 /// `suffix` is `"pay"` for senders or `"depay"` for receivers;
-/// `stem` is one of `"rtpvraw"` / `"rtpL24"` / `"rtpL16"` /
-/// `"rtpsmpte291"`, chosen from `(FlowFormat, encoding-name)`.
+/// `stem` is one of `"rtpvraw"` / `"rtpjxsv"` / `"rtpL24"` /
+/// `"rtpL16"` / `"rtpsmpte291"`, chosen from
+/// `(FlowFormat, encoding-name)`.
 ///
 /// `encoding_name` is matched ASCII-case-insensitively. The SDP
 /// parser already upper-cases `encoding-name` (GStreamer's
@@ -1014,14 +1015,16 @@ fn select_rtp_factory(
     let encoding_name_upper = encoding_name.to_ascii_uppercase();
     let stem = match (format, encoding_name_upper.as_str()) {
         (FlowFormat::Video, "RAW") => "rtpvraw",
+        (FlowFormat::Video, "JXSV") => "rtpjxsv",
         (FlowFormat::Audio, "L24") => "rtpL24",
         (FlowFormat::Audio, "L16") => "rtpL16",
         (FlowFormat::Data, "SMPTE291") => "rtpsmpte291",
         _ => bail!(
             "unsupported essence for RTP/UDP `{suffix}`: format={format:?}, \
              encoding-name=`{encoding_name}` (today RFC 4175 `RAW` video, \
-             ST 2110-30 `L24` / `L16` audio, and RFC 8331 / ST 2110-40 \
-             `SMPTE291` ANC are supported)"
+             RFC 9134 / ST 2110-22 `JXSV` JPEG XS video, ST 2110-30 `L24` / \
+             `L16` audio, and RFC 8331 / ST 2110-40 `SMPTE291` ANC are \
+             supported)"
         ),
     };
     let v1 = format!("{stem}{suffix}");
@@ -1054,8 +1057,34 @@ fn select_rtp_factory(
 /// `gst-plugins-good`.
 fn package_hint_for_stem(stem: &str) -> &'static str {
     match stem {
-        "rtpsmpte291" => "gst-plugins-rs (`rsrtp` plugin)",
+        "rtpsmpte291" | "rtpjxsv" => "gst-plugins-rs (`rsrtp` plugin)",
         _ => "gst-plugins-good",
+    }
+}
+
+/// Decide whether an `nmossrc` UDP receiver should append a `capssetter`
+/// after the depayloader when the caller has narrow Receiver Caps to
+/// advertise.
+///
+/// Raw RFC 4175 video keeps the capssetter because V1 `rtpvrawdepay`
+/// hardcodes some output fields (`framerate=0/1`, colour defaults) that
+/// need overriding from the SDP-derived essence caps. Audio and ANC keep
+/// the existing no-op/consistent advertisement behaviour.
+///
+/// JPEG XS is different: `rtpjxsvdepay` derives complete caps from RTP
+/// fmtp and negotiates `image/x-jxsc` vs `video/x-jxsv` with downstream.
+/// A fixed capssetter would clamp that structure choice, so leave the
+/// depayloader's src pad as the exposed pad.
+fn select_udp_src_capssetter_caps<'a>(
+    format: FlowFormat,
+    encoding_name: &str,
+    advertise_caps: Option<&'a gst::Caps>,
+) -> Option<&'a gst::Caps> {
+    let caps = advertise_caps?;
+    let encoding_name_upper = encoding_name.to_ascii_uppercase();
+    match (format, encoding_name_upper.as_str()) {
+        (FlowFormat::Video, "JXSV") => None,
+        _ => Some(caps),
     }
 }
 
@@ -1215,6 +1244,8 @@ pub(crate) fn build_udpsrc(
         .map_err(|e| anyhow!("UdpMedia.rtp_caps missing `encoding-name`: {e}"))?;
 
     let depayloader_factory = select_rtp_factory("depay", media.format, encoding_name, variant)?;
+    let capssetter_caps =
+        select_udp_src_capssetter_caps(media.format, encoding_name, advertise_caps);
     let depayloader = gst::ElementFactory::make(&depayloader_factory)
         .name("nmossrc-depayloader")
         .build()
@@ -1273,15 +1304,15 @@ pub(crate) fn build_udpsrc(
         .link(&depayloader)
         .with_context(|| "linking udpsrc to depayloader")?;
 
-    let tail_src_pad = match advertise_caps {
+    let tail_src_pad = match capssetter_caps {
         None => depayloader
             .static_pad("src")
             .ok_or_else(|| anyhow!("depayloader `{depayloader_factory}` missing src pad"))?,
         Some(caps) => {
             // For consistent "minimal essence advertisement" across
-            // transports, always use `capssetter` here. It merges the
-            // advertised essence caps over whatever the depayloader
-            // actually emits without failing negotiation.
+            // transports that need or tolerate it, use `capssetter`
+            // here. It merges the advertised essence caps over whatever
+            // the depayloader actually emits without failing negotiation.
             //
             // This also fixes the long-standing V1 `rtpvrawdepay`
             // mismatch where framerate/colorimetry defaults disagree
@@ -1768,6 +1799,37 @@ pub(crate) fn apply_udp_sink_inner_properties(
     apply_properties_to_element(cat, element, &chain.pay, pay_properties);
 }
 
+/// Set `rtpjxsvpay max-codestream-bitrate` from the resolved format
+/// bit rate (kbit/s) unless `pay-properties` already supplies it.
+pub(crate) fn apply_format_bit_rate_to_jxsv_payloader(
+    media: &UdpMedia,
+    payloader: &gst::Element,
+    format_bit_rate_kbps: u64,
+    pay_properties: Option<&gst::Structure>,
+) {
+    if format_bit_rate_kbps == 0 {
+        return;
+    }
+    let Some(s) = media.rtp_caps.structure(0) else {
+        return;
+    };
+    let Ok(encoding) = s.get::<&str>("encoding-name") else {
+        return;
+    };
+    if !encoding.eq_ignore_ascii_case("jxsv") {
+        return;
+    }
+    if pay_properties.is_some_and(|p| p.has_field("max-codestream-bitrate")) {
+        return;
+    }
+    if payloader.has_property("max-codestream-bitrate") {
+        payloader.set_property(
+            "max-codestream-bitrate",
+            format_bit_rate_kbps.saturating_mul(1000),
+        );
+    }
+}
+
 pub(crate) fn apply_udp_src_inner_properties(
     cat: &gst::DebugCategory,
     element: &str,
@@ -1897,6 +1959,7 @@ mod tests {
                 "video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
+            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -1927,6 +1990,7 @@ mod tests {
                 "meta/x-st-2038,framerate=60/1",
             )
             .expect("static raw caps parse"),
+            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -1940,6 +2004,46 @@ mod tests {
         init_gst();
         gst::ElementFactory::find("rtpsmpte291pay").is_some()
             && gst::ElementFactory::find("rtpsmpte291depay").is_some()
+    }
+
+    /// RFC 9134 / ST 2110-22 JPEG XS video, mirroring what
+    /// `sdp::parse_sdp` produces from a `video/jxsv` SDP: `media=video`
+    /// with `encoding-name=JXSV` on the RTP caps, and the essence caps
+    /// carrying the bare-codestream `image/x-jxsc` structure.
+    fn jxsv_media() -> UdpMedia {
+        init_gst();
+        UdpMedia {
+            format: FlowFormat::Video,
+            primary: UdpLeg {
+                destination_ip: "239.1.1.20".to_owned(),
+                destination_port: 5004,
+                interface_ip: None,
+                source_ip: None,
+                source_port: None,
+            },
+            secondary: None,
+            rtp_caps: gst::Caps::from_str(
+                "application/x-rtp,media=video,clock-rate=90000,\
+                 encoding-name=JXSV,payload=96",
+            )
+            .expect("static rtp caps parse"),
+            raw_caps: gst::Caps::from_str(
+                "image/x-jxsc,width=1920,height=1080,framerate=50/1",
+            )
+            .expect("static raw caps parse"),
+            bit_rates: crate::sdp::BitRates::UNSET,
+        }
+    }
+
+    /// `true` iff `gst-plugins-rs`' `rtpjxsv*` element pair is
+    /// installed. Like the ANC pair, JPEG XS pay/depay live only in
+    /// `gst-plugins-rs`' `rsrtp` plugin, so chain-construction tests
+    /// soft-skip when it's absent; the SDP-level coverage in
+    /// `sdp::tests::*jxsv*` does not depend on it.
+    fn rtpjxsv_available() -> bool {
+        init_gst();
+        gst::ElementFactory::find("rtpjxsvpay").is_some()
+            && gst::ElementFactory::find("rtpjxsvdepay").is_some()
     }
 
     /// L24 stereo 48 kHz with `a-ptime=0.125` already hoisted onto
@@ -1967,6 +2071,7 @@ mod tests {
                 "audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved",
             )
             .expect("static raw caps parse"),
+            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -2145,8 +2250,9 @@ mod tests {
             "application/x-rtp,media=video,clock-rate=90000,encoding-name=H264,payload=96",
         )
         .expect("static rtp caps parse");
-        let err = build_udpsink(&media, UdpVariant::V1)
-            .expect_err("H264 must be rejected (today only RAW/L24/L16/SMPTE291 are supported)");
+        let err = build_udpsink(&media, UdpVariant::V1).expect_err(
+            "H264 must be rejected (today only RAW/JXSV/L24/L16/SMPTE291 are supported)",
+        );
         let msg = format!("{err:#}");
         assert!(
             msg.contains("unsupported essence")
@@ -2162,6 +2268,11 @@ mod tests {
         // user hunting in the wrong package.
         assert_eq!(
             package_hint_for_stem("rtpsmpte291"),
+            "gst-plugins-rs (`rsrtp` plugin)",
+        );
+        // JPEG XS `rtpjxsv*` also lives only in `gst-plugins-rs`.
+        assert_eq!(
+            package_hint_for_stem("rtpjxsv"),
             "gst-plugins-rs (`rsrtp` plugin)",
         );
         // Everything else `select_rtp_factory` knows about today
@@ -2191,6 +2302,75 @@ mod tests {
              there is no `gst-plugins-good` equivalent",
         );
         assert_eq!(pay.property::<u32>("pt"), 100);
+    }
+
+    #[test]
+    fn build_udpsink_jxsv_uses_rtpjxsvpay() {
+        if !rtpjxsv_available() {
+            // `gst-plugins-rs` `rsrtp` plugin isn't installed on this
+            // host; the SDP-level JPEG XS coverage in
+            // `sdp::tests::*jxsv*` is independent. Soft-skip the chain
+            // construction rather than failing the suite.
+            return;
+        }
+        let chain = build_udpsink(&jxsv_media(), UdpVariant::V1)
+            .expect("JPEG XS sender chain must construct when rtpjxsvpay is available");
+        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let pay = child(&bin, "nmossink-payloader");
+        assert_eq!(
+            pay.factory().expect("payloader has a factory").name(),
+            "rtpjxsvpay",
+            "JPEG XS sender chain must use `gst-plugins-rs`' rtpjxsvpay",
+        );
+        assert_eq!(pay.property::<u32>("pt"), 96);
+    }
+
+    #[test]
+    fn apply_format_bit_rate_sets_jxsv_payloader_max_codestream_bitrate() {
+        if !rtpjxsv_available() {
+            return;
+        }
+        let chain = build_udpsink(&jxsv_media(), UdpVariant::V1)
+            .expect("JPEG XS sender chain must construct when rtpjxsvpay is available");
+        if !chain.pay.has_property("max-codestream-bitrate") {
+            return;
+        }
+        apply_format_bit_rate_to_jxsv_payloader(
+            &jxsv_media(),
+            &chain.pay,
+            110_000,
+            None,
+        );
+        assert_eq!(
+            chain.pay.property::<u64>("max-codestream-bitrate"),
+            110_000_000,
+        );
+    }
+
+    #[test]
+    fn apply_format_bit_rate_skipped_when_pay_properties_set_max_codestream_bitrate() {
+        if !rtpjxsv_available() {
+            return;
+        }
+        let chain = build_udpsink(&jxsv_media(), UdpVariant::V1)
+            .expect("JPEG XS sender chain must construct when rtpjxsvpay is available");
+        if !chain.pay.has_property("max-codestream-bitrate") {
+            return;
+        }
+        let props = gst::Structure::builder("properties")
+            .field("max-codestream-bitrate", 42_000_000u64)
+            .build();
+        apply_format_bit_rate_to_jxsv_payloader(
+            &jxsv_media(),
+            &chain.pay,
+            110_000_000,
+            Some(&props),
+        );
+        apply_properties_to_element(test_log_cat(), "nmossink", &chain.pay, Some(&props));
+        assert_eq!(
+            chain.pay.property::<u64>("max-codestream-bitrate"),
+            42_000_000,
+        );
     }
 
     #[test]
@@ -2514,8 +2694,9 @@ mod tests {
             "application/x-rtp,media=video,clock-rate=90000,encoding-name=H264,payload=96",
         )
         .expect("static rtp caps parse");
-        let err = build_udpsrc(&media, UdpVariant::V1, None)
-            .expect_err("H264 must be rejected (today only RAW/L24/L16/SMPTE291 are supported)");
+        let err = build_udpsrc(&media, UdpVariant::V1, None).expect_err(
+            "H264 must be rejected (today only RAW/JXSV/L24/L16/SMPTE291 are supported)"
+        );
         let msg = format!("{err:#}");
         assert!(
             msg.contains("unsupported essence")
@@ -2536,6 +2717,30 @@ mod tests {
         assert_eq!(
             depay.factory().expect("depayloader has a factory").name(),
             "rtpsmpte291depay",
+        );
+    }
+
+    #[test]
+    fn build_udpsrc_jxsv_uses_rtpjxsvdepay_without_capssetter() {
+        if !rtpjxsv_available() {
+            return;
+        }
+        let media = jxsv_media();
+        // Even when a narrow receiver supplies advertise_caps,
+        // `rtpjxsvdepay` negotiates `image/x-jxsc` vs `video/x-jxsv`
+        // with the downstream itself; no `capssetter` tail is inserted.
+        let chain = build_udpsrc(&media, UdpVariant::V1, Some(&media.raw_caps))
+            .expect("JPEG XS receiver chain must construct when rtpjxsvdepay is available");
+        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let depay = child(&bin, "nmossrc-depayloader");
+        assert_eq!(
+            depay.factory().expect("depayloader has a factory").name(),
+            "rtpjxsvdepay",
+            "JPEG XS receiver chain must use `gst-plugins-rs`' rtpjxsvdepay",
+        );
+        assert!(
+            bin.by_name("nmossrc-caps").is_none(),
+            "JPEG XS receiver chain must omit the capssetter tail",
         );
     }
 

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -1444,7 +1444,7 @@ pub(crate) fn build_nvdsudpsink(
     sdp_text: &str,
 ) -> Result<NvDsUdpSinkChain, anyhow::Error> {
     require_nvdsudp_factory("nvdsudpsink")?;
-    let pkt = packetization::from_media(media.format, &media.raw_caps, &media.rtp_caps)?;
+    let pkt = packetization::from_media(media.format, &media.caps, &media.rtp_caps)?;
 
     let sdp_for_sink = if media.secondary.is_none()
         && crate::sdp::sdp_media_block_count(sdp_text).is_ok_and(|n| n > 1)
@@ -1605,8 +1605,8 @@ pub(crate) fn build_nvdsudpsrc(
     // onto the output caps so a downstream `st2038combiner` (which requires the
     // field) sees it — the src-side mirror of the `capsfilter` `build_nvdsudpsink`
     // inserts. Add only when absent; an explicit non-`frame` is left for
-    // `from_media`/`anc_from_raw_caps` to reject rather than silently relabel.
-    let mut caps = media.raw_caps.clone();
+    // `from_media`/`anc_from_caps` to reject rather than silently relabel.
+    let mut caps = media.caps.clone();
     if media.format == FlowFormat::Data
         && let Some(s) = caps.make_mut().structure_mut(0)
         && s.name() == "meta/x-st-2038"
@@ -1891,7 +1891,7 @@ pub(crate) fn apply_nvdsudp_sink_inner_properties(
     if media.format == crate::types::FlowFormat::Video {
         if let Err(e) = crate::nvdsudp::packetization::reconcile_sink_video_packetization(
             &chain.transport,
-            &media.raw_caps,
+            &media.caps,
             cat,
             element,
         ) {
@@ -1955,7 +1955,7 @@ mod tests {
                 "application/x-rtp,media=video,clock-rate=90000,encoding-name=RAW,payload=96",
             )
             .expect("static rtp caps parse"),
-            raw_caps: gst::Caps::from_str(
+            caps: gst::Caps::from_str(
                 "video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
@@ -1986,7 +1986,7 @@ mod tests {
                  encoding-name=SMPTE291,payload=100",
             )
             .expect("static rtp caps parse"),
-            raw_caps: gst::Caps::from_str(
+            caps: gst::Caps::from_str(
                 "meta/x-st-2038,framerate=60/1",
             )
             .expect("static raw caps parse"),
@@ -2027,7 +2027,7 @@ mod tests {
                  encoding-name=JXSV,payload=96",
             )
             .expect("static rtp caps parse"),
-            raw_caps: gst::Caps::from_str(
+            caps: gst::Caps::from_str(
                 "image/x-jxsc,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
@@ -2067,7 +2067,7 @@ mod tests {
                  encoding-params=(string)2,payload=97,a-ptime=(string)0.125",
             )
             .expect("static rtp caps parse"),
-            raw_caps: gst::Caps::from_str(
+            caps: gst::Caps::from_str(
                 "audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved",
             )
             .expect("static raw caps parse"),
@@ -2729,7 +2729,7 @@ mod tests {
         // Even when a narrow receiver supplies advertise_caps,
         // `rtpjxsvdepay` negotiates `image/x-jxsc` vs `video/x-jxsv`
         // with the downstream itself; no `capssetter` tail is inserted.
-        let chain = build_udpsrc(&media, UdpVariant::V1, Some(&media.raw_caps))
+        let chain = build_udpsrc(&media, UdpVariant::V1, Some(&media.caps))
             .expect("JPEG XS receiver chain must construct when rtpjxsvdepay is available");
         let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
         let depay = child(&bin, "nmossrc-depayloader");
@@ -3093,7 +3093,7 @@ mod tests {
         if gst::ElementFactory::find("mxlsrc").is_none() {
             return;
         }
-        let advertise = minimal_udp_media().raw_caps;
+        let advertise = minimal_udp_media().caps;
         let Ok(chain) = build_mxlsrc(
             "/tmp/domain",
             "00000000-0000-0000-0000-000000000003",

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -1048,7 +1048,7 @@ fn intermediate_fake_sink_caps(
     match &plan.inner {
         InnerConfig::Real(TransportConfig::Udp { media, .. })
         | InnerConfig::Real(TransportConfig::NvDsUdp { media, .. }) => Ok(Some(
-            crate::essence_caps::caps_from(&media.raw_caps, Some(&media.rtp_caps)),
+            crate::essence_caps::caps_from(&media.caps, Some(&media.rtp_caps)),
         )),
         InnerConfig::Real(TransportConfig::Mxl { .. }) => fake_caps_from_settings(settings),
         _ => fake_caps_from_settings(settings),

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -85,6 +85,8 @@ struct Settings {
     /// file's `m=` port or
     /// [`crate::sdp::defaults::RTP_PORT`]).
     destination_port: u16,
+    format_bit_rate: u64,
+    transport_bit_rate: u64,
     auto_activate: bool,
     transport_properties: Option<gst::Structure>,
     pay_properties: Option<gst::Structure>,
@@ -116,6 +118,8 @@ impl Default for Settings {
             source_port: 0,
             destination_ip: String::new(),
             destination_port: 0,
+            format_bit_rate: 0,
+            transport_bit_rate: 0,
             auto_activate: false,
             transport_properties: None,
             pay_properties: None,
@@ -330,6 +334,18 @@ impl ObjectImpl for NmosSink {
                     .default_value(0)
                     .mutable_ready()
                     .build(),
+                glib::ParamSpecUInt64::builder("format-bit-rate")
+                    .nick("Format bit rate")
+                    .blurb(crate::session::FORMAT_BIT_RATE_BLURB)
+                    .default_value(0)
+                    .mutable_ready()
+                    .build(),
+                glib::ParamSpecUInt64::builder("transport-bit-rate")
+                    .nick("Transport bit rate")
+                    .blurb(crate::session::TRANSPORT_BIT_RATE_BLURB)
+                    .default_value(0)
+                    .mutable_ready()
+                    .build(),
             ]
         });
         PROPERTIES.as_ref()
@@ -423,6 +439,12 @@ impl ObjectImpl for NmosSink {
                 let v: u32 = value.get().expect("type checked upstream");
                 settings.destination_port = u16::try_from(v).expect("range checked by ParamSpec");
             }
+            "format-bit-rate" => {
+                settings.format_bit_rate = value.get().expect("type checked upstream");
+            }
+            "transport-bit-rate" => {
+                settings.transport_bit_rate = value.get().expect("type checked upstream");
+            }
             _ => unimplemented!("unknown property {}", pspec.name()),
         }
     }
@@ -456,6 +478,8 @@ impl ObjectImpl for NmosSink {
             "source-port" => u32::from(settings.source_port).to_value(),
             "destination-ip" => settings.destination_ip.to_value(),
             "destination-port" => u32::from(settings.destination_port).to_value(),
+            "format-bit-rate" => settings.format_bit_rate.to_value(),
+            "transport-bit-rate" => settings.transport_bit_rate.to_value(),
             _ => unimplemented!("unknown property {}", pspec.name()),
         }
     }
@@ -943,6 +967,15 @@ fn build_real_sink(
         }
         TransportConfig::Udp { variant, media, .. } => {
             let chain = inner::build_udpsink(media, *variant)?;
+            let property =
+                crate::sdp::bit_rates_from_properties(settings.format_bit_rate, settings.transport_bit_rate);
+            let bit_rates = crate::sdp::effective_bit_rates(property, media.bit_rates);
+            inner::apply_format_bit_rate_to_jxsv_payloader(
+                media,
+                &chain.pay,
+                bit_rates.format_bit_rate,
+                settings.pay_properties.as_ref(),
+            );
             inner::apply_udp_sink_inner_properties(
                 &CAT,
                 "nmossink",
@@ -1059,6 +1092,8 @@ impl From<Settings> for CommonSettings {
             source_port: s.source_port,
             destination_ip: s.destination_ip,
             destination_port: s.destination_port,
+            format_bit_rate: s.format_bit_rate,
+            transport_bit_rate: s.transport_bit_rate,
             // Receiver-only slots: empty/0 on the Sender side.
             // `nmossrc::From<Settings>` populates these instead.
             interface_ip: String::new(),

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -1038,7 +1038,7 @@ fn intermediate_fake_src_caps(
         }) => Ok(udp_capssetter_caps(transport_file.as_deref(), media)),
         InnerConfig::Real(TransportConfig::NvDsUdp { media, .. }) => {
             // No capssetter hop on nvdsudp — essence caps are set on nvdsudpsrc.
-            Ok(Some(media.raw_caps.clone()))
+            Ok(Some(media.caps.clone()))
         }
         _ => fake_caps_from_settings(snapshot),
     }
@@ -1099,7 +1099,7 @@ fn udp_capssetter_caps(
         );
         return None;
     }
-    Some(media.raw_caps.clone())
+    Some(media.caps.clone())
 }
 
 /// Best-available caps for the bin's fake chain, resolved from

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -89,6 +89,8 @@ struct Settings {
     /// slot). 0 = unset (falls back to the transport file's `m=`
     /// port or [`crate::sdp::defaults::RTP_PORT`]).
     destination_port: u16,
+    format_bit_rate: u64,
+    transport_bit_rate: u64,
     auto_activate: bool,
     transport_properties: Option<gst::Structure>,
     depay_properties: Option<gst::Structure>,
@@ -121,6 +123,8 @@ impl Default for Settings {
             interface_ip: String::new(),
             multicast_ip: String::new(),
             destination_port: 0,
+            format_bit_rate: 0,
+            transport_bit_rate: 0,
             auto_activate: false,
             transport_properties: None,
             depay_properties: None,
@@ -334,6 +338,16 @@ impl ObjectImpl for NmosSrc {
                     .maximum(65535)
                     .default_value(0)
                     .build(),
+                glib::ParamSpecUInt64::builder("format-bit-rate")
+                    .nick("Format bit rate")
+                    .blurb(crate::session::FORMAT_BIT_RATE_BLURB)
+                    .default_value(0)
+                    .build(),
+                glib::ParamSpecUInt64::builder("transport-bit-rate")
+                    .nick("Transport bit rate")
+                    .blurb(crate::session::TRANSPORT_BIT_RATE_BLURB)
+                    .default_value(0)
+                    .build(),
             ]
         });
         PROPERTIES.as_ref()
@@ -428,6 +442,12 @@ impl ObjectImpl for NmosSrc {
                 let v: u32 = value.get().expect("type checked upstream");
                 settings.destination_port = u16::try_from(v).expect("range checked by ParamSpec");
             }
+            "format-bit-rate" => {
+                settings.format_bit_rate = value.get().expect("type checked upstream");
+            }
+            "transport-bit-rate" => {
+                settings.transport_bit_rate = value.get().expect("type checked upstream");
+            }
             _ => unimplemented!("unknown property {}", pspec.name()),
         }
     }
@@ -462,6 +482,8 @@ impl ObjectImpl for NmosSrc {
             "interface-ip" => settings.interface_ip.to_value(),
             "multicast-ip" => settings.multicast_ip.to_value(),
             "destination-port" => u32::from(settings.destination_port).to_value(),
+            "format-bit-rate" => settings.format_bit_rate.to_value(),
+            "transport-bit-rate" => settings.transport_bit_rate.to_value(),
             _ => unimplemented!("unknown property {}", pspec.name()),
         }
     }
@@ -1142,6 +1164,8 @@ impl From<Settings> for CommonSettings {
             interface_ip: s.interface_ip,
             multicast_ip: s.multicast_ip,
             destination_port: s.destination_port,
+            format_bit_rate: s.format_bit_rate,
+            transport_bit_rate: s.transport_bit_rate,
             // Sender-only slots: empty/0 on the Receiver side.
             // `nmossink::From<Settings>` populates these instead.
             source_port: 0,

--- a/rust/gst-nmos-rs/src/nvdsudp/packetization.rs
+++ b/rust/gst-nmos-rs/src/nvdsudp/packetization.rs
@@ -115,20 +115,20 @@ fn video_pgroup(format: &str) -> Result<VideoPgroup, anyhow::Error> {
 /// audio) the hoisted `a-ptime` field on `application/x-rtp` caps.
 pub(crate) fn from_media(
     format: FlowFormat,
-    raw_caps: &gst::Caps,
+    caps: &gst::Caps,
     rtp_caps: &gst::Caps,
 ) -> Result<Packetization, anyhow::Error> {
     match format {
         FlowFormat::Video => {
-            let pkt = video_from_raw_caps(raw_caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD)?;
+            let pkt = video_from_caps(caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD)?;
             Ok(Packetization::Video(pkt))
         }
         FlowFormat::Audio => {
             let ptime_ns = ptime_ns_from_rtp_caps(rtp_caps)?;
-            let pkt = audio_from_raw_caps(raw_caps, ptime_ns)?;
+            let pkt = audio_from_caps(caps, ptime_ns)?;
             Ok(Packetization::Audio(pkt))
         }
-        FlowFormat::Data => anc_from_raw_caps(raw_caps),
+        FlowFormat::Data => anc_from_caps(caps),
         FlowFormat::Unspecified => {
             bail!("nvdsudp Mode 3 does not support unspecified essence format");
         }
@@ -144,8 +144,8 @@ pub(crate) fn from_media(
 /// chain is built. An absent alignment is fine —
 /// transport-file caps never carry the field (an explicit one can only appear
 /// when `caps` are applied directly rather than resynthesised).
-pub(crate) fn anc_from_raw_caps(raw_caps: &gst::Caps) -> Result<Packetization, anyhow::Error> {
-    let s = raw_caps
+pub(crate) fn anc_from_caps(caps: &gst::Caps) -> Result<Packetization, anyhow::Error> {
+    let s = caps
         .structure(0)
         .ok_or_else(|| anyhow::anyhow!("ANC raw caps empty"))?;
     if s.name() != "meta/x-st-2038" {
@@ -175,11 +175,11 @@ pub(crate) fn video_line_stride(width: u32, format: &str) -> Result<u32, anyhow:
 }
 
 /// Compute video packetization for a `video/x-raw` caps structure.
-pub(crate) fn video_from_raw_caps(
-    raw_caps: &gst::Caps,
+pub(crate) fn video_from_caps(
+    caps: &gst::Caps,
     max_rtp_payload: u32,
 ) -> Result<VideoPacketization, anyhow::Error> {
-    let s = raw_caps
+    let s = caps
         .structure(0)
         .ok_or_else(|| anyhow::anyhow!("raw video caps empty"))?;
     let format = s
@@ -276,14 +276,14 @@ fn audio_sample_bytes(format: &str) -> Result<u32, anyhow::Error> {
 }
 
 /// Compute audio packetization for an `audio/x-raw` caps structure.
-pub(crate) fn audio_from_raw_caps(
-    raw_caps: &gst::Caps,
+pub(crate) fn audio_from_caps(
+    caps: &gst::Caps,
     ptime_ns: u64,
 ) -> Result<AudioPacketization, anyhow::Error> {
     if ptime_ns == 0 {
         bail!("ptime_ns must be > 0");
     }
-    let s = raw_caps
+    let s = caps
         .structure(0)
         .ok_or_else(|| anyhow::anyhow!("raw audio caps empty"))?;
     let format = s
@@ -338,8 +338,8 @@ pub(crate) fn video_configured_stride(sink_payload_size: u32, packets_per_line: 
 }
 
 /// Target line stride from `video/x-raw` caps.
-pub(crate) fn video_target_stride(raw_caps: &gst::Caps) -> Result<u32, anyhow::Error> {
-    let s = raw_caps
+pub(crate) fn video_target_stride(caps: &gst::Caps) -> Result<u32, anyhow::Error> {
+    let s = caps
         .structure(0)
         .ok_or_else(|| anyhow::anyhow!("raw video caps empty"))?;
     let format = s
@@ -358,19 +358,19 @@ pub(crate) fn video_target_stride(raw_caps: &gst::Caps) -> Result<u32, anyhow::E
 /// (matches `nvds_nmos_bin::configure_nvdsudpsink_for_media_api`).
 pub(crate) fn reconcile_sink_video_packetization(
     sink: &gst::Element,
-    raw_caps: &gst::Caps,
+    caps: &gst::Caps,
     cat: &gst::DebugCategory,
     element: &str,
 ) -> Result<(), anyhow::Error> {
-    let calculated = video_from_raw_caps(raw_caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD)?;
-    let target_stride = video_target_stride(raw_caps)?;
+    let calculated = video_from_caps(caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD)?;
+    let target_stride = video_target_stride(caps)?;
     let user_payload: u32 = sink.property("payload-size");
     let user_ppl: u32 = sink.property("packets-per-line");
     let configured_stride = video_configured_stride(user_payload, user_ppl);
     if configured_stride == target_stride {
         return Ok(());
     }
-    let s = raw_caps.structure(0).ok_or_else(|| anyhow::anyhow!("raw caps empty"))?;
+    let s = caps.structure(0).ok_or_else(|| anyhow::anyhow!("raw caps empty"))?;
     let format = s.get::<&str>("format").unwrap_or("?");
     let width = s.get::<i32>("width").unwrap_or(0);
     gst::warning!(
@@ -401,7 +401,7 @@ mod tests {
             "video/x-raw,format=UYVP,width=1920,height=1080,framerate=60/1",
         )
         .unwrap();
-        let pkt = video_from_raw_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
+        let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 4);
         assert_eq!(pkt.src_payload_size, 1200);
         assert_eq!(pkt.sink_payload_size, 1220);
@@ -414,7 +414,7 @@ mod tests {
             "video/x-raw,format=UYVP,width=1280,height=720,framerate=60/1",
         )
         .unwrap();
-        let pkt = video_from_raw_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
+        let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 4);
         assert_eq!(pkt.src_payload_size, 800);
         assert_eq!(pkt.sink_payload_size, 820);
@@ -428,7 +428,7 @@ mod tests {
         )
         .unwrap();
         let target = video_target_stride(&caps).unwrap();
-        let calculated = video_from_raw_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
+        let calculated = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(
             video_configured_stride(calculated.sink_payload_size, calculated.packets_per_line),
             target,
@@ -444,7 +444,7 @@ mod tests {
             "video/x-raw,format=UYVP,width=3840,height=2160,framerate=60/1",
         )
         .unwrap();
-        let pkt = video_from_raw_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
+        let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 8);
         assert_eq!(pkt.src_payload_size, 1200);
         assert_eq!(pkt.sink_payload_size, 1220);
@@ -457,7 +457,7 @@ mod tests {
             "video/x-raw,format=UYVY,width=1920,height=1080,framerate=60/1",
         )
         .unwrap();
-        let pkt = video_from_raw_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
+        let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 3);
         assert_eq!(pkt.sink_payload_size, 1300);
         assert_eq!(pkt.src_payload_size, 1280);
@@ -470,7 +470,7 @@ mod tests {
             "audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved",
         )
         .unwrap();
-        let pkt = audio_from_raw_caps(&caps, 1_000_000).unwrap();
+        let pkt = audio_from_caps(&caps, 1_000_000).unwrap();
         assert_eq!(pkt.src_payload_size, 288);
         assert_eq!(pkt.sink_payload_size, 300);
         assert_eq!(pkt.payload_multiple, 16);
@@ -483,7 +483,7 @@ mod tests {
             "audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved",
         )
         .unwrap();
-        let pkt = audio_from_raw_caps(&caps, 6_000_000).unwrap();
+        let pkt = audio_from_caps(&caps, 6_000_000).unwrap();
         assert_eq!(pkt.payload_multiple, 3, "round(16 ms / 6 ms) = 3");
     }
 
@@ -495,7 +495,7 @@ mod tests {
         )
         .unwrap();
         let ptime_ns = parse_ptime_ms_as_ns("0.125").unwrap();
-        let pkt = audio_from_raw_caps(&caps, ptime_ns).unwrap();
+        let pkt = audio_from_caps(&caps, ptime_ns).unwrap();
         assert_eq!(pkt.src_payload_size, 36);
         assert_eq!(pkt.sink_payload_size, 48);
     }
@@ -536,6 +536,6 @@ mod tests {
             "video/x-raw,format=v210,width=1920,height=1080,framerate=60/1",
         )
         .unwrap();
-        assert!(video_from_raw_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).is_err());
+        assert!(video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).is_err());
     }
 }

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -60,7 +60,7 @@
 //! `a=ptime:` / `a=maxptime:` are surfaced on the RTP caps as
 //! `a-ptime` / `a-maxptime` so that `set_media_from_caps`
 //! round-trips them as standalone `a=…:` lines on build — see
-//! [`raw_caps_from_rtp_audio`] for the reasoning.
+//! [`caps_from_rtp_audio`] for the reasoning.
 
 
 use std::collections::hash_map::DefaultHasher;
@@ -113,7 +113,7 @@ use crate::types::{CapsMode, FlowFormat};
 /// `destination_ip` → [`UNSPECIFIED_ADDRESS`](self::defaults::UNSPECIFIED_ADDRESS)
 /// on the `c=` line), [`UNSPECIFIED_ADDRESS`] by [`from_caps`]'s
 /// `o=` fallback, and the video / ANC constants by
-/// [`rtp_caps_from_raw_video`] / [`rtp_caps_from_raw_data`].
+/// [`rtp_caps_from_video`] / [`rtp_caps_from_data`].
 pub(crate) mod defaults {
     /// Default RTP payload type for `video/x-raw` (RFC 4175,
     /// ST 2110-20). Matches the nmos-cpp default.
@@ -196,7 +196,7 @@ pub(crate) mod defaults {
 
     // ST 2110-21 §8.1 `TP=` (video traffic profile) is intentionally omitted
     // from caps-only **video** synthesis for now — see
-    // [`rtp_caps_from_raw_video`]. Without `TP=2110TPW` or `TP=2110TPN`
+    // [`rtp_caps_from_video`]. Without `TP=2110TPW` or `TP=2110TPN`
     // the ST 2110-20 video fmtp is not strictly valid per ST 2110-21.
     // We might want to pick the value based on the transport family
     // (e.g. `2110TPW` for `udp` / `udp2`, `2110TPN` for `nvdsudp`) per the
@@ -379,7 +379,7 @@ pub(crate) struct SdpSession<'a> {
     /// format-derived capability constraints omitted, so any
     /// compatible Sender of the same media type can connect);
     /// `false` advertises *narrow* caps (capability constraints
-    /// derived from `media.raw_caps` / `media.rtp_caps`).
+    /// derived from `media.caps` / `media.rtp_caps`).
     ///
     /// Semantics match [`crate::flow_def::FlowDefMeta::caps`] on
     /// the MXL path. The SDP form is canonical per
@@ -623,7 +623,7 @@ pub(crate) fn indicates_wide_receiver_caps(text: &str) -> bool {
 struct ParsedMediaEssence {
     format: FlowFormat,
     rtp_caps: gst::Caps,
-    raw_caps: gst::Caps,
+    caps: gst::Caps,
     bit_rates: BitRates,
 }
 
@@ -720,25 +720,25 @@ fn parse_media_essence(msg: &SDPMessage, media: &SDPMediaRef) -> Result<ParsedMe
         }
     };
 
-    let raw_caps = match format {
+    let parsed_caps = match format {
         // RFC 9134 / ST 2110-22 JPEG XS rides `m=video` with
         // encoding-name `jxsv`; plain RFC 4175 video is `raw`.
         FlowFormat::Video if encoding_name.eq_ignore_ascii_case("jxsv") => {
-            raw_caps_from_rtp_video_jxsv(&rtp_caps)?
+            caps_from_rtp_video_jxsv(&rtp_caps)?
         }
-        FlowFormat::Video => raw_caps_from_rtp_video(&rtp_caps)?,
-        FlowFormat::Audio => raw_caps_from_rtp_audio(&rtp_caps)?,
-        FlowFormat::Data => raw_caps_from_rtp_data(&rtp_caps)?,
+        FlowFormat::Video => caps_from_rtp_video(&rtp_caps)?,
+        FlowFormat::Audio => caps_from_rtp_audio(&rtp_caps)?,
+        FlowFormat::Data => caps_from_rtp_data(&rtp_caps)?,
         FlowFormat::Unspecified => unreachable!(
             "format dispatch above never produces FlowFormat::Unspecified"
         ),
     };
-    let raw_caps = crate::essence_caps::caps_from(&raw_caps, Some(&rtp_caps));
+    let caps = crate::essence_caps::caps_from(&parsed_caps, Some(&rtp_caps));
 
     Ok(ParsedMediaEssence {
         format,
         rtp_caps,
-        raw_caps,
+        caps,
         bit_rates: bit_rates_from_media(media),
     })
 }
@@ -786,7 +786,7 @@ fn dual_leg_essence_equivalent(a: &ParsedMediaEssence, b: &ParsedMediaEssence) -
     if !rtp_match {
         return false;
     }
-    !a.raw_caps.intersect(&b.raw_caps).is_empty()
+    !a.caps.intersect(&b.caps).is_empty()
 }
 
 /// Map **active** legs (in SDP order) onto [`UdpMedia::primary`] /
@@ -813,7 +813,7 @@ fn active_legs_to_udp_media(
         primary,
         secondary,
         rtp_caps: essence.rtp_caps,
-        raw_caps: essence.raw_caps,
+        caps: essence.caps,
         bit_rates: essence.bit_rates,
     }
 }
@@ -844,7 +844,7 @@ pub(crate) fn parse_sdp(text: &str) -> Result<UdpMedia, SdpError> {
             primary: leg,
             secondary: None,
             rtp_caps: essence.rtp_caps,
-            raw_caps: essence.raw_caps,
+            caps: essence.caps,
             bit_rates: essence.bit_rates,
         });
     }
@@ -1449,7 +1449,7 @@ pub(crate) use crate::sdp_passthrough::{
 /// [`SdpError::TransportCapsMismatch`].
 ///
 /// Essence-caps cross-check intersects `caps` against
-/// `media.raw_caps`; an empty intersection is
+/// `media.caps`; an empty intersection is
 /// [`SdpError::EssenceShapeMismatch`]. Format-family mismatches
 /// (e.g. audio caps + video SDP) surface as
 /// [`SdpError::FormatMismatch`] before the shape intersect runs
@@ -1526,11 +1526,11 @@ fn cross_check_essence_caps(media: &UdpMedia, caps: &gst::Caps) -> Result<(), Sd
     // a shape mismatch. It is re-attached onto the inner-chain essence caps
     // separately (see `essence_caps::overlay_features`).
     let stripped = crate::essence_caps::without_features(caps);
-    let intersect = stripped.intersect(&media.raw_caps);
+    let intersect = stripped.intersect(&media.caps);
     if intersect.is_empty() {
         return Err(SdpError::EssenceShapeMismatch {
             caps: caps.to_string(),
-            sdp: media.raw_caps.to_string(),
+            sdp: media.caps.to_string(),
         });
     }
     Ok(())
@@ -1594,13 +1594,13 @@ pub(crate) struct SdpBuildInput<'a> {
     /// Essence caps (`video/x-raw,…` / `audio/x-raw,…` /
     /// `meta/x-st-2038,…`). Drives essence-shape fmtp fields and
     /// the `format` field of the returned [`UdpMedia`].
-    pub essence_caps: &'a gst::Caps,
+    pub caps: &'a gst::Caps,
     /// Optional `application/x-rtp,…` caps supplying the
     /// override-class fields (`payload`, audio `clock-rate`,
     /// `a-ptime`, `a-maxptime`). Cross-check-class fields the
     /// caps may also carry (`encoding-name`, video / ANC
     /// `clock-rate`) are ignored on the synthesis side — they're
-    /// derived from `essence_caps` instead.
+    /// derived from `caps` instead.
     pub transport_caps: Option<&'a gst::Caps>,
     /// Sender or Receiver — drives the per-side dispatch on
     /// `source_ip` / `interface_ip` into the produced
@@ -1666,8 +1666,8 @@ pub(crate) struct SdpBuildInput<'a> {
 ///
 /// Sequence:
 ///
-/// 1. Dispatch on `essence_caps`'s structure name to a
-///    [`FlowFormat`] and the matching `rtp_caps_from_raw_*`
+/// 1. Dispatch on `caps`'s structure name to a
+///    [`FlowFormat`] and the matching `rtp_caps_from_*`
 ///    primitive.
 /// 2. Resolve override-class RTP parameters from
 ///    `transport_caps` falling back to [`defaults`]: payload
@@ -1680,13 +1680,13 @@ pub(crate) struct SdpBuildInput<'a> {
 ///    `source_ip` → `o=` `<unicast-address>`).
 /// 4. Serialise via [`build_sdp`].
 ///
-/// Returns [`SdpError::UnsupportedEssence`] when `essence_caps`
+/// Returns [`SdpError::UnsupportedEssence`] when `caps`
 /// is not one of the recognised essence shapes, or
 /// [`SdpError::InvalidPayloadType`] when `transport_caps` carries
 /// a payload-type outside RFC 3551's dynamic range.
 pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
-    let format = essence_caps_format(input.essence_caps).ok_or_else(|| {
-        SdpError::UnsupportedEssence(format!("essence caps `{}`", input.essence_caps))
+    let format = essence_caps_format(input.caps).ok_or_else(|| {
+        SdpError::UnsupportedEssence(format!("essence caps `{}`", input.caps))
     })?;
 
     let payload_type = resolve_payload_type(format, input.transport_caps)?;
@@ -1696,18 +1696,18 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
             // JPEG XS essence (`image/x-jxsc` bare codestream or
             // `video/x-jxsv` picture segment) vs RFC 4175 raw video.
             let is_jxsv = input
-                .essence_caps
+                .caps
                 .structure(0)
                 .is_some_and(|s| matches!(s.name().as_str(), "image/x-jxsc" | "video/x-jxsv"));
             if is_jxsv {
-                rtp_caps_from_raw_video_jxsv(
-                    input.essence_caps,
+                rtp_caps_from_video_jxsv(
+                    input.caps,
                     payload_type,
                     input.narrow_traffic_profile,
                 )?
             } else {
-                rtp_caps_from_raw_video(
-                    input.essence_caps,
+                rtp_caps_from_video(
+                    input.caps,
                     payload_type,
                     input.narrow_traffic_profile,
                 )?
@@ -1715,12 +1715,12 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         }
         FlowFormat::Audio => {
             let (ptime_ns, maxptime_ns) = resolve_audio_ptime(input.transport_caps);
-            let resolved = resolved_audio_caps(input.essence_caps, input.transport_caps)?;
+            let resolved = resolved_audio_caps(input.caps, input.transport_caps)?;
             let channel_order = input
                 .transport_caps
                 .and_then(|c| c.structure(0))
                 .and_then(crate::essence_caps::channel_order_from_rtp_structure);
-            rtp_caps_from_raw_audio(
+            rtp_caps_from_audio(
                 &resolved,
                 payload_type,
                 ptime_ns,
@@ -1728,13 +1728,13 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
                 channel_order.as_deref(),
             )?
         }
-        FlowFormat::Data => rtp_caps_from_raw_data(input.essence_caps, payload_type)?,
+        FlowFormat::Data => rtp_caps_from_data(input.caps, payload_type)?,
         FlowFormat::Unspecified => {
             unreachable!("essence_caps_format never returns Unspecified")
         }
     };
 
-    let raw_caps = crate::essence_caps::caps_from(input.essence_caps, Some(&rtp_caps));
+    let caps = crate::essence_caps::caps_from(input.caps, Some(&rtp_caps));
     let bit_rates = bit_rates_from_properties(input.format_bit_rate, input.transport_bit_rate);
 
     let media = UdpMedia {
@@ -1742,7 +1742,7 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         primary: udp_leg_from_input(input),
         secondary: None,
         rtp_caps,
-        raw_caps,
+        caps,
         bit_rates,
     };
 
@@ -1894,7 +1894,7 @@ fn parse_ptime_ms_as_ns(value: &str) -> Option<u64> {
 /// cross-check) — the synthesised SDP advertises the overridden
 /// rate via `a=rtpmap:<pt> L24/<rate>/<n>` even when it differs
 /// from `essence_caps`'s `rate`. The rest of the synthesis chain
-/// (especially [`rtp_caps_from_raw_audio`]) sees the overridden
+/// (especially [`rtp_caps_from_audio`]) sees the overridden
 /// rate on `essence_caps` and emits matching `clock-rate=` /
 /// `rate=` on the produced caps.
 fn resolved_audio_caps(
@@ -2057,7 +2057,7 @@ fn extract_source_ip_from_filter(value: &str) -> Option<String> {
 /// Note that the returned preset always implies the standard
 /// narrow range (`16_235`) of its colorimetry tuple. ST 2110-21
 /// `RANGE=FULL` / `FULLPROTECT` is **not** propagated; see
-/// `raw_caps_from_rtp_video`'s docstring for the rationale (V2
+/// `caps_from_rtp_video`'s docstring for the rationale (V2
 /// doesn't read `RANGE` either, so plumbing it asymmetrically
 /// via the V1 capssetter would diverge V1/V2 output).
 fn caps_colorimetry_from_sdp(sdp: &str, depth: u32, tcs: Option<&str>) -> Option<&'static str> {
@@ -2159,7 +2159,7 @@ fn sdp_colorimetry_from_caps(caps_colorimetry: &str) -> Option<(&'static str, Op
 ///     standard preset's *narrow* range. Honouring `RANGE=FULL`
 ///     would require us to bake an explicit
 ///     `<range>:<matrix>:<transfer>:<primaries>` form (e.g.
-///     `1:3:5:1` for full-range BT.709) into raw_caps. That works
+///     `1:3:5:1` for full-range BT.709) into caps. That works
 ///     for the V1 capssetter (it would actively override the
 ///     depay's narrow preset) but breaks the V2 capsfilter
 ///     intersection, because V2 also emits the narrow preset and
@@ -2175,7 +2175,7 @@ fn sdp_colorimetry_from_caps(caps_colorimetry: &str) -> Option<(&'static str, Op
 ///     content where `videoconvert` will still produce
 ///     visually-correct output (just at the wrong dynamic range
 ///     mapping).
-fn raw_caps_from_rtp_video(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
+fn caps_from_rtp_video(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
     let s = rtp_caps
         .structure(0)
         .ok_or_else(|| SdpError::CapsFromMedia("rtp caps empty".to_owned()))?;
@@ -2266,7 +2266,7 @@ fn raw_caps_from_rtp_video(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> 
 /// `set_media_from_caps` round-trips them back out as standalone
 /// `a=ptime:` / `a=maxptime:` lines. We do not copy them onto
 /// `audio/x-raw` because the format has no native ptime field.
-fn raw_caps_from_rtp_audio(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
+fn caps_from_rtp_audio(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
     let s = rtp_caps
         .structure(0)
         .ok_or_else(|| SdpError::CapsFromMedia("rtp caps empty".to_owned()))?;
@@ -2317,7 +2317,7 @@ fn raw_caps_from_rtp_audio(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> 
 /// is clocked from the paired video flow at runtime and the caller
 /// (typically the element's `caps` property or the caps-merge on the
 /// `nmossrc` ghost src pad) supplies the framerate downstream.
-fn raw_caps_from_rtp_data(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
+fn caps_from_rtp_data(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
     let s = rtp_caps
         .structure(0)
         .ok_or_else(|| SdpError::CapsFromMedia("rtp caps empty".to_owned()))?;
@@ -2401,7 +2401,7 @@ fn format_ptime_ns_as_ms(ns: u64) -> String {
 
 /// Build an `application/x-rtp,...` caps describing an RFC 4175
 /// raw-video media that wraps the supplied `video/x-raw` caps.
-/// Inverse of [`raw_caps_from_rtp_video`]: the synthesised RTP
+/// Inverse of [`caps_from_rtp_video`]: the synthesised RTP
 /// caps round-trip back to an equivalent `video/x-raw` caps via
 /// the parse-direction helper (modulo preset-collapsing
 /// colorimetry — see [`sdp_colorimetry_from_caps`]).
@@ -2425,15 +2425,15 @@ fn format_ptime_ns_as_ms(ns: u64) -> String {
 /// preserved.
 ///
 /// Returns [`SdpError::UnsupportedEssence`] for `format=` values
-/// outside the {`UYVY`, `UYVP`} subset [`raw_caps_from_rtp_video`]
+/// outside the {`UYVY`, `UYVP`} subset [`caps_from_rtp_video`]
 /// understands today; widening the matrix here without widening
 /// the inverse first would break the round-trip contract.
-fn rtp_caps_from_raw_video(
-    raw_caps: &gst::Caps,
+fn rtp_caps_from_video(
+    caps: &gst::Caps,
     payload_type: u8,
     narrow_traffic_profile: bool,
 ) -> Result<gst::Caps, SdpError> {
-    let s = raw_caps
+    let s = caps
         .structure(0)
         .ok_or_else(|| SdpError::UnsupportedEssence("raw video caps empty".to_owned()))?;
     let format = s
@@ -2552,8 +2552,8 @@ fn jxsv_structure_caps(
 /// `application/x-rtp,encoding-name=jxsv` media. Emits both
 /// `image/x-jxsc` (bare codestream) and `video/x-jxsv` (picture
 /// segment) so the `rtpjxsvdepay` negotiates the concrete essence
-/// with its downstream. Inverse of [`rtp_caps_from_raw_video_jxsv`].
-fn raw_caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
+/// with its downstream. Inverse of [`rtp_caps_from_video_jxsv`].
+fn caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
     let s = rtp_caps
         .structure(0)
         .ok_or_else(|| SdpError::CapsFromMedia("rtp caps empty".to_owned()))?;
@@ -2606,7 +2606,7 @@ fn raw_caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpEr
 /// Build an `application/x-rtp,...` caps describing an RFC 9134 /
 /// ST 2110-22 JPEG XS media that wraps the supplied JPEG XS essence
 /// caps (`image/x-jxsc` or `video/x-jxsv`). Inverse of
-/// [`raw_caps_from_rtp_video_jxsv`].
+/// [`caps_from_rtp_video_jxsv`].
 ///
 /// `width` / `height` / `framerate` are required; `sampling` /
 /// `depth` / `profile` / `level` / `sublevel` are passed through
@@ -2614,12 +2614,12 @@ fn raw_caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpEr
 /// [`defaults::ST2110_22_SSN`]) is always emitted; `colorimetry=`
 /// and `tcs=` are emitted only when the essence caps carry a
 /// recognised GStreamer `colorimetry`.
-fn rtp_caps_from_raw_video_jxsv(
-    raw_caps: &gst::Caps,
+fn rtp_caps_from_video_jxsv(
+    caps: &gst::Caps,
     payload_type: u8,
     narrow_traffic_profile: bool,
 ) -> Result<gst::Caps, SdpError> {
-    let s = raw_caps
+    let s = caps
         .structure(0)
         .ok_or_else(|| SdpError::UnsupportedEssence("JPEG XS caps empty".to_owned()))?;
     let width = s
@@ -2683,7 +2683,7 @@ fn rtp_caps_from_raw_video_jxsv(
 
 /// Build an `application/x-rtp,...` caps describing an
 /// ST 2110-30 audio media that wraps the supplied `audio/x-raw`
-/// caps. Inverse of [`raw_caps_from_rtp_audio`].
+/// caps. Inverse of [`caps_from_rtp_audio`].
 ///
 /// | `audio/x-raw` field | `application/x-rtp` field |
 /// |---|---|
@@ -2702,14 +2702,14 @@ fn rtp_caps_from_raw_video_jxsv(
 /// Returns [`SdpError::UnsupportedEssence`] for `format=` values
 /// outside ST 2110-30's {`S16BE`, `S24BE`} restriction. RFC 3551
 /// L8, μ-law, A-law, etc. are out of scope.
-fn rtp_caps_from_raw_audio(
-    raw_caps: &gst::Caps,
+fn rtp_caps_from_audio(
+    caps: &gst::Caps,
     payload_type: u8,
     ptime_ns: u64,
     maxptime_ns: Option<u64>,
     channel_order: Option<&str>,
 ) -> Result<gst::Caps, SdpError> {
-    let s = raw_caps
+    let s = caps
         .structure(0)
         .ok_or_else(|| SdpError::UnsupportedEssence("raw audio caps empty".to_owned()))?;
     let format = s
@@ -2746,21 +2746,21 @@ fn rtp_caps_from_raw_audio(
         let maxptime = format_ptime_ns_as_ms(max);
         caps_text.push_str(&format!(",a-maxptime=(string){maxptime}"));
     }
-    let mut caps = gst::Caps::from_str(&caps_text)
+    let mut rtp_caps = gst::Caps::from_str(&caps_text)
         .map_err(|e| SdpError::UnsupportedEssence(format!("constructing rtp caps: {e}")))?;
     let order = channel_order
         .map(str::to_owned)
         .unwrap_or_else(|| crate::essence_caps::default_smpte2110_channel_order(channels));
-    let caps_mut = caps.make_mut();
+    let caps_mut = rtp_caps.make_mut();
     if let Some(s) = caps_mut.structure_mut(0) {
         s.set("channel-order", &order);
     }
-    Ok(caps)
+    Ok(rtp_caps)
 }
 
 /// Build an `application/x-rtp,...` caps describing an RFC 8331 /
 /// SMPTE ST 2110-40 ancillary-data media that wraps the supplied
-/// `meta/x-st-2038` caps. Inverse of [`raw_caps_from_rtp_data`].
+/// `meta/x-st-2038` caps. Inverse of [`caps_from_rtp_data`].
 ///
 /// | `meta/x-st-2038` field | `application/x-rtp` field |
 /// |---|---|
@@ -2776,8 +2776,8 @@ fn rtp_caps_from_raw_audio(
 /// wants ANC clocked to a specific video frame rate) and
 /// omitted otherwise — RFC 8331 / ST 2110-40 §6.4 makes the
 /// parameter optional and the depayloader does not require it.
-fn rtp_caps_from_raw_data(raw_caps: &gst::Caps, payload_type: u8) -> Result<gst::Caps, SdpError> {
-    let s = raw_caps
+fn rtp_caps_from_data(caps: &gst::Caps, payload_type: u8) -> Result<gst::Caps, SdpError> {
+    let s = caps
         .structure(0)
         .ok_or_else(|| SdpError::UnsupportedEssence("ANC caps empty".to_owned()))?;
     if s.name() != "meta/x-st-2038" {
@@ -2987,7 +2987,7 @@ mod tests {
         assert_eq!(rtp_s.get::<i32>("payload").unwrap(), 96);
         assert_eq!(rtp_s.get::<i32>("clock-rate").unwrap(), 90_000);
 
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(raw_s.name().as_str(), "video/x-raw");
         assert_eq!(raw_s.get::<&str>("format").unwrap(), "UYVP");
         assert_eq!(raw_s.get::<i32>("width").unwrap(), 1920);
@@ -3069,7 +3069,7 @@ mod tests {
         init_gst();
         let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("exactframerate=50;", "exactframerate=30000/1001;");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
             raw_s.get::<gst::Fraction>("framerate").unwrap(),
             gst::Fraction::new(30_000, 1_001)
@@ -3093,7 +3093,7 @@ mod tests {
         };
         let media = parse_sdp(&sdp).expect("parse");
         media
-            .raw_caps
+            .caps
             .structure(0)
             .and_then(|s| s.get::<&str>("colorimetry").ok().map(str::to_owned))
     }
@@ -3176,7 +3176,7 @@ mod tests {
         // must NOT smuggle a guess onto the caps; the V1 depay's
         // format-default takes over and the V2 depay also emits
         // nothing. depth=10 here is just to stay inside the
-        // `YCbCr-4:2:2` samplings `raw_caps_from_rtp_video` accepts
+        // `YCbCr-4:2:2` samplings `caps_from_rtp_video` accepts
         // today — the depth value doesn't otherwise affect the
         // `XYZ` / `UNSPECIFIED` arms.
         assert_eq!(colorimetry_via_parse("UNSPECIFIED", 10, Some("SDR")), None);
@@ -3404,7 +3404,7 @@ mod tests {
             "fmtp channel-order lands on rtp caps from parse",
         );
 
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(raw_s.name().as_str(), "audio/x-raw");
         assert_eq!(raw_s.get::<&str>("format").unwrap(), "S24BE");
         assert_eq!(raw_s.get::<i32>("rate").unwrap(), 48_000);
@@ -3444,7 +3444,7 @@ mod tests {
         init_gst();
         let sdp = AUDIO_L24_48K_STEREO_SDP.replace("L24/48000/2", "L16/48000/2");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(raw_s.get::<&str>("format").unwrap(), "S16BE");
         assert_eq!(raw_s.get::<i32>("channels").unwrap(), 2);
     }
@@ -3454,7 +3454,7 @@ mod tests {
         init_gst();
         let sdp = AUDIO_L24_48K_STEREO_SDP.replace("L24/48000/2", "L24/48000");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
             raw_s.get::<i32>("channels").unwrap(),
             1,
@@ -3488,7 +3488,7 @@ mod tests {
         let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
             .replace("exactframerate=50;", "exactframerate=25; interlace;");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
             raw_s.get::<&str>("interlace-mode").unwrap(),
             "interleaved",
@@ -3501,7 +3501,7 @@ mod tests {
         init_gst();
         let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("depth=10;", "depth=8;");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
             raw_s.get::<&str>("format").unwrap(),
             "UYVY",
@@ -3596,8 +3596,8 @@ mod tests {
         assert_eq!(round_tripped.primary.source_ip, original.primary.source_ip);
         assert_eq!(round_tripped.primary.source_port, original.primary.source_port);
 
-        let orig_raw = original.raw_caps.structure(0).unwrap();
-        let rt_raw = round_tripped.raw_caps.structure(0).unwrap();
+        let orig_raw = original.caps.structure(0).unwrap();
+        let rt_raw = round_tripped.caps.structure(0).unwrap();
         assert_eq!(rt_raw.get::<&str>("format"), orig_raw.get::<&str>("format"));
         assert_eq!(rt_raw.get::<i32>("width"), orig_raw.get::<i32>("width"));
         assert_eq!(rt_raw.get::<i32>("height"), orig_raw.get::<i32>("height"));
@@ -3631,8 +3631,8 @@ mod tests {
         assert_eq!(round_tripped.primary.source_ip, original.primary.source_ip);
         assert_eq!(round_tripped.primary.source_port, original.primary.source_port);
 
-        let orig_raw = original.raw_caps.structure(0).unwrap();
-        let rt_raw = round_tripped.raw_caps.structure(0).unwrap();
+        let orig_raw = original.caps.structure(0).unwrap();
+        let rt_raw = round_tripped.caps.structure(0).unwrap();
         assert_eq!(rt_raw.get::<&str>("format"), orig_raw.get::<&str>("format"));
         assert_eq!(rt_raw.get::<i32>("rate"), orig_raw.get::<i32>("rate"));
         assert_eq!(rt_raw.get::<i32>("channels"), orig_raw.get::<i32>("channels"));
@@ -4784,7 +4784,7 @@ mod tests {
         assert_eq!(rtp_s.get::<i32>("clock-rate").unwrap(), 90_000);
         assert_eq!(rtp_s.get::<i32>("payload").unwrap(), 100);
 
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
             raw_s.name().as_str(),
             "meta/x-st-2038",
@@ -4808,7 +4808,7 @@ mod tests {
         init_gst();
         let sdp = ANC_SMPTE291_1080P60_SDP.replace("exactframerate=60;", "exactframerate=30000/1001;");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
             raw_s.get::<gst::Fraction>("framerate").unwrap(),
             gst::Fraction::new(30_000, 1_001),
@@ -4825,10 +4825,10 @@ mod tests {
         let sdp = ANC_SMPTE291_1080P60_SDP
             .replace("a=fmtp:100 exactframerate=60; VPID_Code=132\r\n", "");
         let media = parse_sdp(&sdp).expect("parse");
-        let raw_s = media.raw_caps.structure(0).expect("raw caps");
+        let raw_s = media.caps.structure(0).expect("raw caps");
         assert!(
             raw_s.get::<gst::Fraction>("framerate").is_err(),
-            "framerate must be absent on raw_caps when SDP carries no \
+            "framerate must be absent on caps when SDP carries no \
              exactframerate; downstream caps-merge (element property / \
              paired-flow context) fills it in",
         );
@@ -4855,8 +4855,8 @@ mod tests {
             round_tripped.primary.destination_ip,
             original.primary.destination_ip,
         );
-        let orig_raw = original.raw_caps.structure(0).unwrap();
-        let rt_raw = round_tripped.raw_caps.structure(0).unwrap();
+        let orig_raw = original.caps.structure(0).unwrap();
+        let rt_raw = round_tripped.caps.structure(0).unwrap();
         assert_eq!(rt_raw.name(), orig_raw.name());
         assert!(
             orig_raw.get::<&str>("alignment").is_err()
@@ -4974,7 +4974,7 @@ mod tests {
         assert_eq!(sdp_colorimetry_from_caps("sRGB"), None);
     }
 
-    // -- rtp_caps_from_raw_video
+    // -- rtp_caps_from_video
 
     /// Build a synthetic `video/x-raw` caps with the supplied
     /// parameters; helper for the synthesis tests below.
@@ -5012,10 +5012,10 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_uyvy_maps_to_ycbcr422_depth8() {
+    fn rtp_caps_from_video_uyvy_maps_to_ycbcr422_depth8() {
         init_gst();
         let raw = raw_video_caps("UYVY", 1920, 1080, gst::Fraction::new(50, 1), None);
-        let rtp = rtp_caps_from_raw_video(&raw, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&raw, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.name().as_str(), "application/x-rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
@@ -5023,7 +5023,7 @@ mod tests {
         // Canonical SDP-form case: RFC 4175 lower-case
         // `raw`, ST 2110-20 upper-case `PM` / `SSN`. See
         // the comment on the caps-text builder in
-        // `rtp_caps_from_raw_video` for the libnvnmos /
+        // `rtp_caps_from_video` for the libnvnmos /
         // nmos-cpp compatibility rationale.
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "raw");
         assert_eq!(s.get::<i32>("payload").unwrap(), 96);
@@ -5037,17 +5037,17 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_uyvp_maps_to_ycbcr422_depth10() {
+    fn rtp_caps_from_video_uyvp_maps_to_ycbcr422_depth10() {
         init_gst();
         let raw = raw_video_caps("UYVP", 1920, 1080, gst::Fraction::new(50, 1), None);
-        let rtp = rtp_caps_from_raw_video(&raw, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&raw, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("sampling").unwrap(), "YCbCr-4:2:2");
         assert_eq!(s.get::<&str>("depth").unwrap(), "10");
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_emits_fractional_exactframerate() {
+    fn rtp_caps_from_video_emits_fractional_exactframerate() {
         init_gst();
         let raw = raw_video_caps(
             "UYVP",
@@ -5056,13 +5056,13 @@ mod tests {
             gst::Fraction::new(30_000, 1_001),
             None,
         );
-        let rtp = rtp_caps_from_raw_video(&raw, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&raw, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "30000/1001");
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_emits_interlace_only_when_interleaved() {
+    fn rtp_caps_from_video_emits_interlace_only_when_interleaved() {
         init_gst();
         let progressive = raw_video_caps(
             "UYVP",
@@ -5071,7 +5071,7 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("interlace-mode=progressive"),
         );
-        let rtp = rtp_caps_from_raw_video(&progressive, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&progressive, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert!(
             s.get::<&str>("interlace").is_err(),
@@ -5085,7 +5085,7 @@ mod tests {
             gst::Fraction::new(25, 1),
             Some("interlace-mode=interleaved"),
         );
-        let rtp = rtp_caps_from_raw_video(&interleaved, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&interleaved, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(
             s.get::<&str>("interlace").unwrap(),
@@ -5095,7 +5095,7 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_emits_colorimetry_for_recognised_preset() {
+    fn rtp_caps_from_video_emits_colorimetry_for_recognised_preset() {
         init_gst();
         let raw = raw_video_caps(
             "UYVP",
@@ -5104,7 +5104,7 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("colorimetry=bt709"),
         );
-        let rtp = rtp_caps_from_raw_video(&raw, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&raw, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("colorimetry").unwrap(), "BT709");
         assert!(
@@ -5114,7 +5114,7 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_emits_tcs_for_bt2100_presets() {
+    fn rtp_caps_from_video_emits_tcs_for_bt2100_presets() {
         init_gst();
         let pq = raw_video_caps(
             "UYVP",
@@ -5123,7 +5123,7 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("colorimetry=bt2100-pq"),
         );
-        let rtp = rtp_caps_from_raw_video(&pq, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&pq, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("colorimetry").unwrap(), "BT2100");
         assert_eq!(s.get::<&str>("tcs").unwrap(), "PQ");
@@ -5135,14 +5135,14 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("colorimetry=bt2100-hlg"),
         );
-        let rtp = rtp_caps_from_raw_video(&hlg, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&hlg, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("colorimetry").unwrap(), "BT2100");
         assert_eq!(s.get::<&str>("tcs").unwrap(), "HLG");
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_falls_back_to_default_on_unrecognised_colorimetry() {
+    fn rtp_caps_from_video_falls_back_to_default_on_unrecognised_colorimetry() {
         init_gst();
         let raw = raw_video_caps(
             "UYVP",
@@ -5151,7 +5151,7 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("colorimetry=1:3:5:1"),
         );
-        let rtp = rtp_caps_from_raw_video(&raw, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video(&raw, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         // `colorimetry=` is REQUIRED by nmos-cpp's
         // `get_video_raw_parameters`; an unrecognised value on
@@ -5169,15 +5169,15 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_rejects_unsupported_format() {
+    fn rtp_caps_from_video_rejects_unsupported_format() {
         init_gst();
         let raw = raw_video_caps("RGBA", 1920, 1080, gst::Fraction::new(50, 1), None);
-        let err = rtp_caps_from_raw_video(&raw, 96, false).expect_err("must reject");
+        let err = rtp_caps_from_video(&raw, 96, false).expect_err("must reject");
         assert!(matches!(err, SdpError::UnsupportedEssence(ref m) if m.contains("RGBA")));
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_round_trips_through_raw_caps_from_rtp_video() {
+    fn rtp_caps_from_video_round_trips_through_caps_from_rtp_video() {
         init_gst();
         let original = raw_video_caps(
             "UYVP",
@@ -5186,8 +5186,8 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("interlace-mode=progressive,colorimetry=bt2020-10"),
         );
-        let rtp = rtp_caps_from_raw_video(&original, 96, false).expect("synth");
-        let round_tripped = raw_caps_from_rtp_video(&rtp).expect("parse back");
+        let rtp = rtp_caps_from_video(&original, 96, false).expect("synth");
+        let round_tripped = caps_from_rtp_video(&rtp).expect("parse back");
         let rt = round_tripped.structure(0).expect("rt raw");
         let orig = original.structure(0).expect("orig raw");
         assert_eq!(rt.name(), orig.name());
@@ -5208,7 +5208,7 @@ mod tests {
         );
     }
 
-    // -- rtp_caps_from_raw_audio
+    // -- rtp_caps_from_audio
 
     fn raw_audio_caps(format: &str, rate: i32, channels: i32) -> gst::Caps {
         gst::Caps::from_str(&format!(
@@ -5219,11 +5219,11 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_s24be_maps_to_l24() {
+    fn rtp_caps_from_audio_s24be_maps_to_l24() {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
+            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "audio");
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "L24");
@@ -5238,20 +5238,20 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_s16be_maps_to_l16() {
+    fn rtp_caps_from_audio_s16be_maps_to_l16() {
         init_gst();
         let raw = raw_audio_caps("S16BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
+            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "L16");
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_emits_decimal_ptime_for_sub_millisecond() {
+    fn rtp_caps_from_audio_emits_decimal_ptime_for_sub_millisecond() {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
-        let rtp = rtp_caps_from_raw_audio(&raw, 97, 125_000, None, None).expect("synth");
+        let rtp = rtp_caps_from_audio(&raw, 97, 125_000, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(
             s.get::<&str>("a-ptime").unwrap(),
@@ -5261,34 +5261,34 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_emits_a_maxptime_when_supplied() {
+    fn rtp_caps_from_audio_emits_a_maxptime_when_supplied() {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, Some(4_000_000), None)
+            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, Some(4_000_000), None)
                 .expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("a-maxptime").unwrap(), "4");
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_rejects_unsupported_format() {
+    fn rtp_caps_from_audio_rejects_unsupported_format() {
         init_gst();
         let raw = raw_audio_caps("S32LE", 48_000, 2);
         let err =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect_err("reject");
+            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect_err("reject");
         assert!(matches!(err, SdpError::UnsupportedEssence(ref m) if m.contains("S32LE")));
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_round_trips_through_raw_caps_from_rtp_audio() {
+    fn rtp_caps_from_audio_round_trips_through_caps_from_rtp_audio() {
         init_gst();
         let original = raw_audio_caps("S24BE", 48_000, 2);
         let rtp =
-            rtp_caps_from_raw_audio(&original, 97, defaults::AUDIO_PTIME_NS, None, None)
+            rtp_caps_from_audio(&original, 97, defaults::AUDIO_PTIME_NS, None, None)
                 .expect("synth");
         let round_tripped = crate::essence_caps::caps_from(
-            &raw_caps_from_rtp_audio(&rtp).expect("parse back"),
+            &caps_from_rtp_audio(&rtp).expect("parse back"),
             Some(&rtp),
         );
         let rt = round_tripped.structure(0).expect("rt raw");
@@ -5304,11 +5304,11 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_audio_emits_default_channel_order_for_six_channels() {
+    fn rtp_caps_from_audio_emits_default_channel_order_for_six_channels() {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 6);
         let rtp =
-            rtp_caps_from_raw_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
+            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(
             s.get::<&str>("channel-order").unwrap(),
@@ -5316,13 +5316,13 @@ mod tests {
         );
     }
 
-    // -- rtp_caps_from_raw_data
+    // -- rtp_caps_from_data
 
     #[test]
-    fn rtp_caps_from_raw_data_minimal_meta_x_st_2038() {
+    fn rtp_caps_from_data_minimal_meta_x_st_2038() {
         init_gst();
         let raw = gst::Caps::from_str("meta/x-st-2038").expect("data caps");
-        let rtp = rtp_caps_from_raw_data(&raw, 100).expect("synth");
+        let rtp = rtp_caps_from_data(&raw, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "SMPTE291");
@@ -5335,11 +5335,11 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_data_propagates_framerate() {
+    fn rtp_caps_from_data_propagates_framerate() {
         init_gst();
         let raw = gst::Caps::from_str("meta/x-st-2038,framerate=25/1")
             .expect("data caps");
-        let rtp = rtp_caps_from_raw_data(&raw, 100).expect("synth");
+        let rtp = rtp_caps_from_data(&raw, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "25");
 
@@ -5347,28 +5347,28 @@ mod tests {
             "meta/x-st-2038,framerate=30000/1001",
         )
         .expect("data caps");
-        let rtp = rtp_caps_from_raw_data(&fractional, 100).expect("synth");
+        let rtp = rtp_caps_from_data(&fractional, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "30000/1001");
     }
 
     #[test]
-    fn rtp_caps_from_raw_data_rejects_non_anc_essence() {
+    fn rtp_caps_from_data_rejects_non_anc_essence() {
         init_gst();
         let raw = gst::Caps::from_str("video/x-raw,format=UYVY").expect("not ANC");
-        let err = rtp_caps_from_raw_data(&raw, 100).expect_err("must reject");
+        let err = rtp_caps_from_data(&raw, 100).expect_err("must reject");
         assert!(matches!(err, SdpError::UnsupportedEssence(ref m) if m.contains("video/x-raw")));
     }
 
     #[test]
-    fn rtp_caps_from_raw_data_round_trips_through_raw_caps_from_rtp_data() {
+    fn rtp_caps_from_data_round_trips_through_caps_from_rtp_data() {
         init_gst();
         let original = gst::Caps::from_str(
             "meta/x-st-2038,framerate=25/1",
         )
         .expect("data caps");
-        let rtp = rtp_caps_from_raw_data(&original, 100).expect("synth");
-        let round_tripped = raw_caps_from_rtp_data(&rtp).expect("parse back");
+        let rtp = rtp_caps_from_data(&original, 100).expect("synth");
+        let round_tripped = caps_from_rtp_data(&rtp).expect("parse back");
         let rt = round_tripped.structure(0).expect("rt raw");
         let orig = original.structure(0).expect("orig");
         assert_eq!(rt.name(), orig.name());
@@ -5412,12 +5412,12 @@ mod tests {
     //    resolved_audio_caps, udp_leg_from_input)
 
     fn build_input<'a>(
-        essence_caps: &'a gst::Caps,
+        caps: &'a gst::Caps,
         side: Side,
         transport_caps: Option<&'a gst::Caps>,
     ) -> SdpBuildInput<'a> {
         SdpBuildInput {
-            essence_caps,
+            caps,
             transport_caps,
             side,
             name: "test-name",
@@ -5653,7 +5653,7 @@ mod tests {
         // = U("PM")`, `smpte_standard_number = U("SSN")`)
         // matches them case-sensitively, so the canonical SDP
         // case has to be set in our caps-text builder. See the
-        // comment on `rtp_caps_from_raw_video` for the full
+        // comment on `rtp_caps_from_video` for the full
         // compat story (lower-case `raw` + upper-case `PM` /
         // `SSN` is what libnvnmos accepts).
         assert!(text.contains("PM=2110GPM"), "ST 2110-20 PM:\n{text}");
@@ -5684,7 +5684,7 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_jxsv_maps_core_fmtp_fields() {
+    fn rtp_caps_from_video_jxsv_maps_core_fmtp_fields() {
         init_gst();
         let essence = jxsv_caps(
             "image/x-jxsc",
@@ -5696,7 +5696,7 @@ mod tests {
                  sublevel=Sublev3bpp",
             ),
         );
-        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video_jxsv(&essence, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.name().as_str(), "application/x-rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
@@ -5716,10 +5716,10 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_jxsv_omits_optional_fields() {
+    fn rtp_caps_from_video_jxsv_omits_optional_fields() {
         init_gst();
         let essence = jxsv_caps("video/x-jxsv", 1280, 720, gst::Fraction::new(25, 1), None);
-        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video_jxsv(&essence, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert!(
             s.get::<&str>("colorimetry").is_err(),
@@ -5732,7 +5732,7 @@ mod tests {
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_jxsv_emits_explicit_colorimetry() {
+    fn rtp_caps_from_video_jxsv_emits_explicit_colorimetry() {
         init_gst();
         let essence = jxsv_caps(
             "image/x-jxsc",
@@ -5741,32 +5741,32 @@ mod tests {
             gst::Fraction::new(50, 1),
             Some("colorimetry=bt2100-pq"),
         );
-        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, false).expect("synth");
+        let rtp = rtp_caps_from_video_jxsv(&essence, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("colorimetry").unwrap(), "BT2100");
         assert_eq!(s.get::<&str>("tcs").unwrap(), "PQ");
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_jxsv_narrow_profile_emits_tp() {
+    fn rtp_caps_from_video_jxsv_narrow_profile_emits_tp() {
         init_gst();
         let essence = jxsv_caps("image/x-jxsc", 1920, 1080, gst::Fraction::new(50, 1), None);
-        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, true).expect("synth");
+        let rtp = rtp_caps_from_video_jxsv(&essence, 96, true).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("TP").unwrap(), "2110TPN");
     }
 
     #[test]
-    fn rtp_caps_from_raw_video_jxsv_requires_width_height_framerate() {
+    fn rtp_caps_from_video_jxsv_requires_width_height_framerate() {
         init_gst();
         let no_width = gst::Caps::from_str("image/x-jxsc,height=1080,framerate=50/1").unwrap();
-        assert!(rtp_caps_from_raw_video_jxsv(&no_width, 96, false).is_err());
+        assert!(rtp_caps_from_video_jxsv(&no_width, 96, false).is_err());
         let no_fr = gst::Caps::from_str("image/x-jxsc,width=1920,height=1080").unwrap();
-        assert!(rtp_caps_from_raw_video_jxsv(&no_fr, 96, false).is_err());
+        assert!(rtp_caps_from_video_jxsv(&no_fr, 96, false).is_err());
     }
 
     #[test]
-    fn raw_caps_from_rtp_video_jxsv_yields_both_essence_structures() {
+    fn caps_from_rtp_video_jxsv_yields_both_essence_structures() {
         init_gst();
         let rtp = gst::Caps::from_str(
             "application/x-rtp,media=(string)video,clock-rate=(int)90000,\
@@ -5775,7 +5775,7 @@ mod tests {
              sampling=(string)YCbCr-4:2:2,depth=(string)10",
         )
         .unwrap();
-        let caps = raw_caps_from_rtp_video_jxsv(&rtp).expect("essence");
+        let caps = caps_from_rtp_video_jxsv(&rtp).expect("essence");
         let names: Vec<String> = (0..caps.size())
             .filter_map(|i| caps.structure(i).map(|s| s.name().to_string()))
             .collect();
@@ -5799,13 +5799,13 @@ mod tests {
     }
 
     #[test]
-    fn raw_caps_from_rtp_video_jxsv_rejects_non_jxsv_encoding() {
+    fn caps_from_rtp_video_jxsv_rejects_non_jxsv_encoding() {
         init_gst();
         let rtp = gst::Caps::from_str(
             "application/x-rtp,media=(string)video,encoding-name=(string)raw",
         )
         .unwrap();
-        assert!(raw_caps_from_rtp_video_jxsv(&rtp).is_err());
+        assert!(caps_from_rtp_video_jxsv(&rtp).is_err());
     }
 
     #[test]
@@ -6009,8 +6009,8 @@ mod tests {
             // gst-sdp upper-cases the rtpmap encoding-name on parse.
             "JXSV",
         );
-        let names: Vec<String> = (0..media.raw_caps.size())
-            .filter_map(|i| media.raw_caps.structure(i).map(|s| s.name().to_string()))
+        let names: Vec<String> = (0..media.caps.size())
+            .filter_map(|i| media.caps.structure(i).map(|s| s.name().to_string()))
             .collect();
         assert!(
             names.iter().any(|n| n == "image/x-jxsc"),
@@ -6020,7 +6020,7 @@ mod tests {
             names.iter().any(|n| n == "video/x-jxsv"),
             "names: {names:?}",
         );
-        let s0 = media.raw_caps.structure(0).unwrap();
+        let s0 = media.caps.structure(0).unwrap();
         assert_eq!(s0.get::<i32>("width").unwrap(), 1920);
         assert_eq!(
             s0.get::<gst::Fraction>("framerate").unwrap(),
@@ -6103,7 +6103,7 @@ mod tests {
         // and `get_format` match it case-sensitively. The
         // canonicaliser at `build_sdp`'s tail lower-cases the
         // gst-uppercased `SMPTE291` that
-        // [`rtp_caps_from_raw_data`] carries in the
+        // [`rtp_caps_from_data`] carries in the
         // `application/x-rtp` caps (gst convention) so the SDP
         // form lands canonical.
         assert!(
@@ -6163,7 +6163,7 @@ mod tests {
         assert_eq!(media.primary.destination_port, 5004);
         assert_eq!(media.primary.source_ip.as_deref(), Some("192.0.2.10"));
         assert_eq!(media.primary.interface_ip.as_deref(), Some("192.0.2.10"));
-        let rt_raw = media.raw_caps.structure(0).unwrap();
+        let rt_raw = media.caps.structure(0).unwrap();
         let orig_raw = essence.structure(0).unwrap();
         assert_eq!(rt_raw.get::<&str>("format"), orig_raw.get::<&str>("format"));
         assert_eq!(rt_raw.get::<i32>("width"), orig_raw.get::<i32>("width"));
@@ -6201,7 +6201,7 @@ mod tests {
         let text = from_caps(&input).expect("synth");
         let media = parse_sdp(&text).expect("round-trip parse");
         assert_eq!(media.format, FlowFormat::Data);
-        let rt_raw = media.raw_caps.structure(0).unwrap();
+        let rt_raw = media.caps.structure(0).unwrap();
         assert_eq!(rt_raw.name().as_str(), "meta/x-st-2038");
         assert_eq!(
             rt_raw.get::<gst::Fraction>("framerate").unwrap(),
@@ -6299,7 +6299,7 @@ mod tests {
         )
         .expect("video caps");
         let input = SdpBuildInput {
-            essence_caps: &essence,
+            caps: &essence,
             transport_caps: None,
             side: Side::Sender,
             name: "video1",

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -69,7 +69,7 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::sync::LazyLock;
 
-use gst_sdp::{SDPAttribute, SDPMedia, SDPMediaRef, SDPMessage};
+use gst_sdp::{SDPAttribute, SDPBandwidth, SDPMedia, SDPMediaRef, SDPMessage};
 use unicase::Ascii;
 use gstreamer as gst;
 use gstreamer_sdp as gst_sdp;
@@ -189,6 +189,11 @@ pub(crate) mod defaults {
     /// nmos-cpp emits.
     pub(crate) const ST2110_20_SSN: &str = "ST2110-20:2017";
 
+    /// ST 2110-22 §7.2 fmtp `SSN=` slot for JPEG XS. Identifies
+    /// the SDP specification revision the JPEG XS sender conforms
+    /// to. `ST2110-22:2022` is what nmos-cpp emits for `video/jxsv`.
+    pub(crate) const ST2110_22_SSN: &str = "ST2110-22:2022";
+
     // ST 2110-21 §8.1 `TP=` (video traffic profile) is intentionally omitted
     // from caps-only **video** synthesis for now — see
     // [`rtp_caps_from_raw_video`]. Without `TP=2110TPW` or `TP=2110TPN`
@@ -288,6 +293,17 @@ pub(crate) enum SdpError {
     TransportCapsMismatch {
         transport_caps: String,
         sdp: String,
+    },
+    #[error(
+        "bit-rate mismatch: properties resolve to format {property_format} / transport \
+         {property_transport} kbit/s but transport-file declares format {file_format} / \
+         transport {file_transport} kbit/s"
+    )]
+    BitRateMismatch {
+        property_format: u64,
+        property_transport: u64,
+        file_format: u64,
+        file_transport: u64,
     },
 }
 
@@ -408,6 +424,182 @@ pub(crate) struct SdpSession<'a> {
     /// media block (Rivermax / `transport=nvdsudp` sender synthesis).
     /// `transport=udp` / `udp2` and all receivers leave this false.
     pub emit_ptp_ts_refclk: bool,
+    /// Compressed-format fmtp `x-nvnmos-*-bit-rate` parameters,
+    /// appended to the media's `a=fmtp:` line. The transport side
+    /// also drives media-level `b=AS:`. Unset when both sides are
+    /// zero.
+    pub bit_rates: BitRates,
+}
+
+/// Approximate IP/UDP/RTP overhead factor — matches `nvnmos_impl.cpp`.
+pub(crate) const TRANSPORT_BIT_RATE_FACTOR: f64 = 1.05;
+
+/// Format / transport bit rates in kilobits per second (1000 bits/s).
+///
+/// Matches NMOS Flow / Sender `bit_rate`, SDP `b=AS:`, and fmtp
+/// `x-nvnmos-*-bit-rate` (AMWA BCP-006-01, RFC 9134, ST 2110-22).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct BitRates {
+    /// Coded essence (Flow) rate in kbit/s.
+    pub format_bit_rate: u64,
+    /// Transport (Sender) rate in kbit/s, including RTP/UDP/IP overhead.
+    pub transport_bit_rate: u64,
+}
+
+impl BitRates {
+    pub const UNSET: Self = Self {
+        format_bit_rate: 0,
+        transport_bit_rate: 0,
+    };
+}
+
+/// Construct bit rates from GObject property values (`format-bit-rate` /
+/// `transport-bit-rate`), deriving the missing side when only one is set.
+///
+/// `0` means unset. When exactly one side is given the other is derived via
+/// the nvnmosd 1.05 overhead factor, matching `nvnmos_impl.cpp`
+/// `get_format_bit_rate` / `get_transport_bit_rate`.
+pub(crate) fn bit_rates_from_properties(format_bit_rate: u64, transport_bit_rate: u64) -> BitRates {
+    match (format_bit_rate > 0, transport_bit_rate > 0) {
+        (true, true) => BitRates {
+            format_bit_rate,
+            transport_bit_rate,
+        },
+        (true, false) => BitRates {
+            format_bit_rate,
+            transport_bit_rate: transport_from_format_kbps(format_bit_rate),
+        },
+        (false, true) => BitRates {
+            format_bit_rate: format_from_transport_kbps(transport_bit_rate),
+            transport_bit_rate,
+        },
+        (false, false) => BitRates::UNSET,
+    }
+}
+
+/// Transport bit rate (kbit/s) derived from a format bit rate (kbit/s).
+///
+/// Matches `nvnmos_impl.cpp` `get_transport_bit_rate`: the result is rounded to
+/// the nearest Mbit/s (still in kbit/s units), per the VSF TR-08:2022 examples.
+fn transport_from_format_kbps(format_bit_rate: u64) -> u64 {
+    ((format_bit_rate as f64 * TRANSPORT_BIT_RATE_FACTOR / 1e3) + 0.5) as u64 * 1000
+}
+
+/// Format bit rate (kbit/s) derived from a transport bit rate (kbit/s).
+///
+/// Matches `nvnmos_impl.cpp` `get_format_bit_rate`.
+fn format_from_transport_kbps(transport_bit_rate: u64) -> u64 {
+    (transport_bit_rate as f64 / TRANSPORT_BIT_RATE_FACTOR) as u64
+}
+
+const FMTP_FORMAT_BIT_RATE: &str = "x-nvnmos-format-bit-rate";
+const FMTP_TRANSPORT_BIT_RATE: &str = "x-nvnmos-transport-bit-rate";
+
+/// Format-specific parameters from the media's `a=fmtp:` attribute (`<pt> <params>`).
+fn fmtp_params_from_media(m: &SDPMediaRef) -> Option<&str> {
+    for idx in 0..m.attributes_len() {
+        let attr = m.attribute(idx)?;
+        if attr.key() != "fmtp" {
+            continue;
+        }
+        return attr
+            .value()?
+            .split_once(' ')
+            .map(|(_, fmtp_params)| fmtp_params);
+    }
+    None
+}
+
+fn fmtp_param<T: std::str::FromStr>(fmtp_params: &str, key: &str) -> Option<T> {
+    for kv in fmtp_params.split(';') {
+        let Some((k, v)) = kv.split_once('=') else {
+            continue;
+        };
+        if k.eq_ignore_ascii_case(key) {
+            return v.parse().ok();
+        }
+    }
+    None
+}
+
+fn as_bandwidth_from_media(m: &SDPMediaRef) -> Option<u64> {
+    for idx in 0..m.bandwidths_len() {
+        let bw = m.bandwidth(idx)?;
+        if bw.bwtype().is_some_and(|t| t.eq_ignore_ascii_case("AS")) {
+            return Some(u64::from(bw.value()));
+        }
+    }
+    None
+}
+
+/// Parse JPEG XS bit rates from an SDP media block.
+///
+/// Mirrors `nvnmos_impl.cpp` `get_format_bit_rate` /
+/// `get_transport_bit_rate`: fmtp `x-nvnmos-*-bit-rate` first, then
+/// derive the missing side from the other fmtp key or `b=AS:`.
+pub(crate) fn bit_rates_from_media(m: &SDPMediaRef) -> BitRates {
+    let params = fmtp_params_from_media(m);
+    let fmtp_format =
+        params.and_then(|params| fmtp_param::<u64>(params, FMTP_FORMAT_BIT_RATE));
+    let fmtp_transport =
+        params.and_then(|params| fmtp_param::<u64>(params, FMTP_TRANSPORT_BIT_RATE));
+    let b_as = as_bandwidth_from_media(m);
+
+    let format_bit_rate = fmtp_format
+        .or_else(|| fmtp_transport.map(format_from_transport_kbps))
+        .or_else(|| b_as.map(format_from_transport_kbps))
+        .unwrap_or(0);
+
+    let transport_bit_rate = fmtp_transport
+        .or_else(|| fmtp_format.map(transport_from_format_kbps))
+        .or(b_as)
+        .unwrap_or(0);
+
+    if format_bit_rate == 0 && transport_bit_rate == 0 {
+        BitRates::UNSET
+    } else {
+        BitRates {
+            format_bit_rate,
+            transport_bit_rate,
+        }
+    }
+}
+
+/// Parse bit rates from the first `m=` block of a configuring SDP.
+pub(crate) fn bit_rates_from_sdp_text(text: &str) -> Result<BitRates, SdpError> {
+    let msg = SDPMessage::parse_buffer(text.as_bytes())
+        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let media = msg.media(0).ok_or(SdpError::NoMedia)?;
+    Ok(bit_rates_from_media(media))
+}
+
+/// Cross-check property bit rates against a supplied transport file.
+///
+/// When both sides declare a rate, the resolved pair must match exactly.
+pub(crate) fn cross_check_bit_rates(property: BitRates, file: BitRates) -> Result<(), SdpError> {
+    if property == BitRates::UNSET || file == BitRates::UNSET {
+        return Ok(());
+    }
+    if property.format_bit_rate != file.format_bit_rate
+        || property.transport_bit_rate != file.transport_bit_rate
+    {
+        return Err(SdpError::BitRateMismatch {
+            property_format: property.format_bit_rate,
+            property_transport: property.transport_bit_rate,
+            file_format: file.format_bit_rate,
+            file_transport: file.transport_bit_rate,
+        });
+    }
+    Ok(())
+}
+
+/// Property bit rates win when set; otherwise fall back to parsed SDP rates.
+pub(crate) fn effective_bit_rates(property: BitRates, file: BitRates) -> BitRates {
+    if property != BitRates::UNSET {
+        property
+    } else {
+        file
+    }
 }
 
 /// Whether an SDP transport file advertises wide Receiver Caps via
@@ -432,6 +624,7 @@ struct ParsedMediaEssence {
     format: FlowFormat,
     rtp_caps: gst::Caps,
     raw_caps: gst::Caps,
+    bit_rates: BitRates,
 }
 
 /// True when the media block carries `a=inactive` (IS-05 `rtp_enabled: false`).
@@ -528,6 +721,11 @@ fn parse_media_essence(msg: &SDPMessage, media: &SDPMediaRef) -> Result<ParsedMe
     };
 
     let raw_caps = match format {
+        // RFC 9134 / ST 2110-22 JPEG XS rides `m=video` with
+        // encoding-name `jxsv`; plain RFC 4175 video is `raw`.
+        FlowFormat::Video if encoding_name.eq_ignore_ascii_case("jxsv") => {
+            raw_caps_from_rtp_video_jxsv(&rtp_caps)?
+        }
         FlowFormat::Video => raw_caps_from_rtp_video(&rtp_caps)?,
         FlowFormat::Audio => raw_caps_from_rtp_audio(&rtp_caps)?,
         FlowFormat::Data => raw_caps_from_rtp_data(&rtp_caps)?,
@@ -541,6 +739,7 @@ fn parse_media_essence(msg: &SDPMessage, media: &SDPMediaRef) -> Result<ParsedMe
         format,
         rtp_caps,
         raw_caps,
+        bit_rates: bit_rates_from_media(media),
     })
 }
 
@@ -615,6 +814,7 @@ fn active_legs_to_udp_media(
         secondary,
         rtp_caps: essence.rtp_caps,
         raw_caps: essence.raw_caps,
+        bit_rates: essence.bit_rates,
     }
 }
 
@@ -645,6 +845,7 @@ pub(crate) fn parse_sdp(text: &str) -> Result<UdpMedia, SdpError> {
             secondary: None,
             rtp_caps: essence.rtp_caps,
             raw_caps: essence.raw_caps,
+            bit_rates: essence.bit_rates,
         });
     }
 
@@ -715,6 +916,7 @@ pub(crate) fn normalise_to_single_active_leg(text: &str) -> Result<String, SdpEr
         group_hint: session_attribute_value(&msg, "x-nvnmos-group-hint"),
         advertise_caps: false,
         emit_ptp_ts_refclk,
+        bit_rates: BitRates::UNSET,
     };
     build_sdp(&media, session)
 }
@@ -831,6 +1033,12 @@ pub(crate) fn build_sdp(media: &UdpMedia, session: SdpSession<'_>) -> Result<Str
     // argument (see `gst_sdp_strips_ttl_for_unicast_c_lines`),
     // so we can pass `MULTICAST_TTL` unconditionally.
     m.add_connection("IN", "IP4", &leg.destination_ip, defaults::MULTICAST_TTL, 0);
+    // `b=AS:` is transport kbit/s (no unit conversion).
+    if session.bit_rates.transport_bit_rate > 0
+        && let Ok(kbps) = u32::try_from(session.bit_rates.transport_bit_rate)
+    {
+        m.add_bandwidth("AS", kbps);
+    }
     m.set_media_from_caps(&media.rtp_caps)
         .map_err(|e| SdpError::BuildMediaFromCaps(e.to_string()))?;
     // `gstreamer-sdp`'s SDP → caps direction (`caps_from_media`)
@@ -839,6 +1047,9 @@ pub(crate) fn build_sdp(media: &UdpMedia, session: SdpSession<'_>) -> Result<Str
     // `nmos-cpp`'s `find_fmtp` / `get_format` parsers expect the
     // canonical case.
     canonicalise_st2110_sdp_case(&mut m);
+    // `set_media_from_caps` may emit `x-nvnmos-*-bit-rate` as standalone `a=`
+    // attributes; `nvnmosd` reads them from fmtp.
+    upsert_nvnmos_bit_rates_in_fmtp(&mut m, session.bit_rates);
 
     // ST 2110-10 §6.1 reference clock — synthesis default for
     // `transport=nvdsudp` senders only. Passthrough SDPs keep the
@@ -954,6 +1165,83 @@ fn canonicalise_st2110_sdp_case(m: &mut SDPMedia) {
     for idx in 0..m.attributes_len() {
         canonicalise_media_attribute_at(m, idx);
     }
+}
+
+fn upsert_nvnmos_bit_rates_in_fmtp(m: &mut SDPMediaRef, bit_rates: BitRates) {
+    if bit_rates == BitRates::UNSET {
+        return;
+    }
+    for idx in 0..m.attributes_len() {
+        let Some(attr) = m.attribute(idx) else {
+            continue;
+        };
+        if attr.key() != "fmtp" {
+            continue;
+        }
+        let Some(value) = attr.value() else {
+            continue;
+        };
+        let Some((pt, fmtp_params)) = value.split_once(' ') else {
+            continue;
+        };
+        let kept: Vec<&str> = fmtp_params
+            .split(';')
+            .filter(|kv| {
+                kv.split_once('=')
+                    .map(|(key, _)| {
+                        !key.eq_ignore_ascii_case(FMTP_FORMAT_BIT_RATE)
+                            && !key.eq_ignore_ascii_case(FMTP_TRANSPORT_BIT_RATE)
+                    })
+                    .unwrap_or(true)
+            })
+            .collect();
+        let mut new_fmtp_params = kept.join(";");
+        if bit_rates.format_bit_rate > 0 {
+            if !new_fmtp_params.is_empty() {
+                new_fmtp_params.push(';');
+            }
+            new_fmtp_params.push_str(&format!(
+                "{FMTP_FORMAT_BIT_RATE}={}",
+                bit_rates.format_bit_rate
+            ));
+        }
+        if bit_rates.transport_bit_rate > 0 {
+            if !new_fmtp_params.is_empty() {
+                new_fmtp_params.push(';');
+            }
+            new_fmtp_params.push_str(&format!(
+                "{FMTP_TRANSPORT_BIT_RATE}={}",
+                bit_rates.transport_bit_rate
+            ));
+        }
+        let new_value = format!("{pt} {new_fmtp_params}");
+        let _ = m.replace_attribute(idx, SDPAttribute::new("fmtp", Some(&new_value)));
+        return;
+    }
+}
+
+fn upsert_as_bandwidth(m: &mut SDPMediaRef, kbps: u32) {
+    for idx in 0..m.bandwidths_len() {
+        let bw = m.bandwidth(idx).expect("bandwidth index in range");
+        if bw.bwtype().is_some_and(|t| t.eq_ignore_ascii_case("AS")) {
+            let _ = m.replace_bandwidth(idx, SDPBandwidth::new("AS", kbps));
+            return;
+        }
+    }
+    m.add_bandwidth("AS", kbps);
+}
+
+/// Splice resolved bit rates into a parsed SDP media block.
+pub(crate) fn apply_bit_rates_to_media(m: &mut SDPMediaRef, bit_rates: BitRates) {
+    if bit_rates == BitRates::UNSET {
+        return;
+    }
+    if bit_rates.transport_bit_rate > 0
+        && let Ok(kbps) = u32::try_from(bit_rates.transport_bit_rate)
+    {
+        upsert_as_bandwidth(m, kbps);
+    }
+    upsert_nvnmos_bit_rates_in_fmtp(m, bit_rates);
 }
 
 /// Canonicalise a single media attribute we just wrote (rtpmap/fmtp
@@ -1120,6 +1408,9 @@ pub(crate) struct SdpOverrides<'a> {
     /// also takes the enum by value and reads `Auto` as "leave
     /// it alone".
     pub caps_mode: CapsMode,
+    /// JPEG XS bit rates to splice when the transport file omits them.
+    /// [`BitRates::UNSET`] leaves the file untouched.
+    pub bit_rates: BitRates,
 }
 
 pub(crate) use crate::sdp_passthrough::{
@@ -1206,7 +1497,10 @@ pub(crate) fn cross_check_essence(
 fn essence_caps_format(caps: &gst::Caps) -> Option<FlowFormat> {
     let s = caps.structure(0)?;
     match s.name().as_str() {
-        "video/x-raw" => Some(FlowFormat::Video),
+        // RFC 9134 / ST 2110-22 JPEG XS rides `urn:x-nmos:format:video`
+        // whether carried as a bare codestream (`image/x-jxsc`) or as
+        // RFC 9134 picture segments (`video/x-jxsv`).
+        "video/x-raw" | "image/x-jxsc" | "video/x-jxsv" => Some(FlowFormat::Video),
         "audio/x-raw" => Some(FlowFormat::Audio),
         "meta/x-st-2038" => Some(FlowFormat::Data),
         _ => None,
@@ -1358,6 +1652,12 @@ pub(crate) struct SdpBuildInput<'a> {
     /// When true, emit `TP=2110TPN` on video fmtp (Rivermax / `nvdsudp`
     /// narrow traffic profile). `udp` / `udp2` leave this unset.
     pub narrow_traffic_profile: bool,
+    /// Coded essence (Flow) bit rate in kilobits per second (1000 bits/s).
+    /// 0 = unset.
+    pub format_bit_rate: u64,
+    /// Transport (Sender) bit rate in kilobits per second (1000 bits/s).
+    /// 0 = unset.
+    pub transport_bit_rate: u64,
 }
 
 /// Synthesise a full configuring SDP from caps-only
@@ -1393,7 +1693,25 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
 
     let rtp_caps = match format {
         FlowFormat::Video => {
-            rtp_caps_from_raw_video(input.essence_caps, payload_type, input.narrow_traffic_profile)?
+            // JPEG XS essence (`image/x-jxsc` bare codestream or
+            // `video/x-jxsv` picture segment) vs RFC 4175 raw video.
+            let is_jxsv = input
+                .essence_caps
+                .structure(0)
+                .is_some_and(|s| matches!(s.name().as_str(), "image/x-jxsc" | "video/x-jxsv"));
+            if is_jxsv {
+                rtp_caps_from_raw_video_jxsv(
+                    input.essence_caps,
+                    payload_type,
+                    input.narrow_traffic_profile,
+                )?
+            } else {
+                rtp_caps_from_raw_video(
+                    input.essence_caps,
+                    payload_type,
+                    input.narrow_traffic_profile,
+                )?
+            }
         }
         FlowFormat::Audio => {
             let (ptime_ns, maxptime_ns) = resolve_audio_ptime(input.transport_caps);
@@ -1417,6 +1735,7 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
     };
 
     let raw_caps = crate::essence_caps::caps_from(input.essence_caps, Some(&rtp_caps));
+    let bit_rates = bit_rates_from_properties(input.format_bit_rate, input.transport_bit_rate);
 
     let media = UdpMedia {
         format,
@@ -1424,6 +1743,7 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         secondary: None,
         rtp_caps,
         raw_caps,
+        bit_rates,
     };
 
     let origin_address = if input.interface_ip.is_empty() {
@@ -1469,6 +1789,7 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         group_hint,
         advertise_caps: input.advertise_caps,
         emit_ptp_ts_refclk,
+        bit_rates,
     };
 
     build_sdp(&media, session)
@@ -2186,6 +2507,172 @@ fn rtp_caps_from_raw_video(
     caps_text.push_str(&format!(",colorimetry=(string){colorimetry}"));
     if let Some(tcs_value) = tcs {
         caps_text.push_str(&format!(",tcs=(string){tcs_value}"));
+    }
+    if narrow_traffic_profile {
+        caps_text.push_str(",TP=(string)2110TPN");
+    }
+    gst::Caps::from_str(&caps_text)
+        .map_err(|e| SdpError::UnsupportedEssence(format!("constructing rtp caps: {e}")))
+}
+
+/// One JPEG XS essence structure (`image/x-jxsc` bare codestream
+/// or `video/x-jxsv` picture segment) carrying the fields derived
+/// from an RTP media. Both structures share the same shape; the
+/// caller assembles them into a single multi-structure caps so the
+/// depayloader can negotiate the concrete one with its downstream.
+#[allow(clippy::too_many_arguments)]
+fn jxsv_structure_caps(
+    name: &str,
+    width: Option<i32>,
+    height: Option<i32>,
+    depth: Option<i32>,
+    sampling: Option<&str>,
+    framerate: Option<(u32, u32)>,
+    profile: Option<&str>,
+    level: Option<&str>,
+    sublevel: Option<&str>,
+) -> gst::Caps {
+    let mut builder = gst::Caps::builder(name)
+        .field("alignment", "frame")
+        .field("interlace-mode", "progressive")
+        .field_if_some("width", width)
+        .field_if_some("height", height)
+        .field_if_some("depth", depth)
+        .field_if_some("sampling", sampling)
+        .field_if_some("profile", profile)
+        .field_if_some("level", level)
+        .field_if_some("sublevel", sublevel);
+    if let Some((num, den)) = framerate {
+        builder = builder.field("framerate", gst::Fraction::new(num as i32, den as i32));
+    }
+    builder.build()
+}
+
+/// Derive JPEG XS essence caps from an RFC 9134 / ST 2110-22
+/// `application/x-rtp,encoding-name=jxsv` media. Emits both
+/// `image/x-jxsc` (bare codestream) and `video/x-jxsv` (picture
+/// segment) so the `rtpjxsvdepay` negotiates the concrete essence
+/// with its downstream. Inverse of [`rtp_caps_from_raw_video_jxsv`].
+fn raw_caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
+    let s = rtp_caps
+        .structure(0)
+        .ok_or_else(|| SdpError::CapsFromMedia("rtp caps empty".to_owned()))?;
+    let encoding = s.get::<&str>("encoding-name").unwrap_or("");
+    if !encoding.eq_ignore_ascii_case("jxsv") {
+        return Err(SdpError::UnsupportedEssence(format!(
+            "JPEG XS encoding-name={encoding}"
+        )));
+    }
+    // ST 2110-22 fmtp carries width / height / depth as strings.
+    let parse_i32 = |field: &str| {
+        s.get::<&str>(field)
+            .ok()
+            .and_then(|v| v.parse::<i32>().ok())
+    };
+    let width = parse_i32("width");
+    let height = parse_i32("height");
+    let depth = parse_i32("depth");
+    let sampling = s.get::<&str>("sampling").ok();
+    let framerate = parse_exact_framerate(s.get::<&str>("exactframerate").unwrap_or(""));
+    let profile = s.get::<&str>("profile").ok();
+    let level = s.get::<&str>("level").ok();
+    let sublevel = s.get::<&str>("sublevel").ok();
+
+    let mut caps = jxsv_structure_caps(
+        "image/x-jxsc",
+        width,
+        height,
+        depth,
+        sampling,
+        framerate,
+        profile,
+        level,
+        sublevel,
+    );
+    caps.make_mut().append(jxsv_structure_caps(
+        "video/x-jxsv",
+        width,
+        height,
+        depth,
+        sampling,
+        framerate,
+        profile,
+        level,
+        sublevel,
+    ));
+    Ok(caps)
+}
+
+/// Build an `application/x-rtp,...` caps describing an RFC 9134 /
+/// ST 2110-22 JPEG XS media that wraps the supplied JPEG XS essence
+/// caps (`image/x-jxsc` or `video/x-jxsv`). Inverse of
+/// [`raw_caps_from_rtp_video_jxsv`].
+///
+/// `width` / `height` / `framerate` are required; `sampling` /
+/// `depth` / `profile` / `level` / `sublevel` are passed through
+/// when present. `SSN=ST2110-22:2022` (see
+/// [`defaults::ST2110_22_SSN`]) is always emitted; `colorimetry=`
+/// and `tcs=` are emitted only when the essence caps carry a
+/// recognised GStreamer `colorimetry`.
+fn rtp_caps_from_raw_video_jxsv(
+    raw_caps: &gst::Caps,
+    payload_type: u8,
+    narrow_traffic_profile: bool,
+) -> Result<gst::Caps, SdpError> {
+    let s = raw_caps
+        .structure(0)
+        .ok_or_else(|| SdpError::UnsupportedEssence("JPEG XS caps empty".to_owned()))?;
+    let width = s
+        .get::<i32>("width")
+        .map_err(|_| SdpError::UnsupportedEssence("JPEG XS caps missing width".to_owned()))?;
+    let height = s
+        .get::<i32>("height")
+        .map_err(|_| SdpError::UnsupportedEssence("JPEG XS caps missing height".to_owned()))?;
+    let (fr_num, fr_den) = s
+        .get::<gst::Fraction>("framerate")
+        .map(|f| (f.numer() as u32, f.denom() as u32))
+        .map_err(|_| {
+            SdpError::UnsupportedEssence("JPEG XS caps missing framerate".to_owned())
+        })?;
+    let exactframerate = format_exact_framerate(fr_num, fr_den);
+
+    // RFC 9134 §7 fmtp: `packetmode=0` (codestream) is the only
+    // required parameter; the rest mirror ST 2110-22 §7.2.
+    let mut caps_text = format!(
+        "application/x-rtp,\
+         media=(string)video,\
+         clock-rate=(int){clk},\
+         encoding-name=(string)jxsv,\
+         payload=(int){pt},\
+         packetmode=(string)0,\
+         width=(string){width},\
+         height=(string){height},\
+         exactframerate=(string){exactframerate},\
+         SSN=(string){ssn}",
+        clk = defaults::VIDEO_CLOCK_RATE,
+        pt = payload_type,
+        ssn = defaults::ST2110_22_SSN,
+    );
+    if let Ok(sampling) = s.get::<&str>("sampling") {
+        caps_text.push_str(&format!(",sampling=(string){sampling}"));
+    }
+    if let Ok(depth) = s.get::<i32>("depth") {
+        caps_text.push_str(&format!(",depth=(string){depth}"));
+    }
+    for field in ["profile", "level", "sublevel"] {
+        if let Ok(value) = s.get::<&str>(field) {
+            caps_text.push_str(&format!(",{field}=(string){value}"));
+        }
+    }
+    if let Some((colorimetry, tcs)) = s
+        .get::<&str>("colorimetry")
+        .ok()
+        .and_then(sdp_colorimetry_from_caps)
+    {
+        caps_text.push_str(&format!(",colorimetry=(string){colorimetry}"));
+        if let Some(tcs_value) = tcs {
+            caps_text.push_str(&format!(",tcs=(string){tcs_value}"));
+        }
     }
     if narrow_traffic_profile {
         caps_text.push_str(",TP=(string)2110TPN");
@@ -3085,6 +3572,7 @@ mod tests {
             group_hint: None,
             advertise_caps: false,
             emit_ptp_ts_refclk: false,
+            bit_rates: BitRates::UNSET,
         }
     }
 
@@ -4507,6 +4995,22 @@ mod tests {
         .expect("raw video caps")
     }
 
+    fn jxsv_caps(
+        name: &str,
+        width: i32,
+        height: i32,
+        framerate: gst::Fraction,
+        extras: Option<&str>,
+    ) -> gst::Caps {
+        let extras = extras.map(|s| format!(",{s}")).unwrap_or_default();
+        gst::Caps::from_str(&format!(
+            "{name},width={width},height={height},framerate={n}/{d}{extras}",
+            n = framerate.numer(),
+            d = framerate.denom(),
+        ))
+        .expect("jxsv essence caps")
+    }
+
     #[test]
     fn rtp_caps_from_raw_video_uyvy_maps_to_ycbcr422_depth8() {
         init_gst();
@@ -4928,6 +5432,8 @@ mod tests {
             advertise_caps: false,
             node_seed: "demo-node1",
             narrow_traffic_profile: false,
+            format_bit_rate: 0,
+            transport_bit_rate: 0,
         }
     }
 
@@ -5175,6 +5681,351 @@ mod tests {
             "o= sess-id is stable from node_seed+side+name:\n{text}",
         );
         assert_ne!(sess_id, "1", "sess-id must not be the old placeholder");
+    }
+
+    #[test]
+    fn rtp_caps_from_raw_video_jxsv_maps_core_fmtp_fields() {
+        init_gst();
+        let essence = jxsv_caps(
+            "image/x-jxsc",
+            1920,
+            1080,
+            gst::Fraction::new(50, 1),
+            Some(
+                "sampling=YCbCr-4:2:2,depth=10,profile=High444.12,level=2k-1,\
+                 sublevel=Sublev3bpp",
+            ),
+        );
+        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, false).expect("synth");
+        let s = rtp.structure(0).expect("rtp");
+        assert_eq!(s.name().as_str(), "application/x-rtp");
+        assert_eq!(s.get::<&str>("media").unwrap(), "video");
+        assert_eq!(s.get::<i32>("clock-rate").unwrap(), defaults::VIDEO_CLOCK_RATE);
+        assert_eq!(s.get::<&str>("encoding-name").unwrap(), "jxsv");
+        assert_eq!(s.get::<i32>("payload").unwrap(), 96);
+        assert_eq!(s.get::<&str>("packetmode").unwrap(), "0");
+        assert_eq!(s.get::<&str>("width").unwrap(), "1920");
+        assert_eq!(s.get::<&str>("height").unwrap(), "1080");
+        assert_eq!(s.get::<&str>("exactframerate").unwrap(), "50");
+        assert_eq!(s.get::<&str>("sampling").unwrap(), "YCbCr-4:2:2");
+        assert_eq!(s.get::<&str>("depth").unwrap(), "10");
+        assert_eq!(s.get::<&str>("profile").unwrap(), "High444.12");
+        assert_eq!(s.get::<&str>("level").unwrap(), "2k-1");
+        assert_eq!(s.get::<&str>("sublevel").unwrap(), "Sublev3bpp");
+        assert_eq!(s.get::<&str>("SSN").unwrap(), defaults::ST2110_22_SSN);
+    }
+
+    #[test]
+    fn rtp_caps_from_raw_video_jxsv_omits_optional_fields() {
+        init_gst();
+        let essence = jxsv_caps("video/x-jxsv", 1280, 720, gst::Fraction::new(25, 1), None);
+        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, false).expect("synth");
+        let s = rtp.structure(0).expect("rtp");
+        assert!(
+            s.get::<&str>("colorimetry").is_err(),
+            "colorimetry omitted when absent:\n{s:?}",
+        );
+        assert!(s.get::<&str>("sampling").is_err(), "sampling omitted:\n{s:?}");
+        assert!(s.get::<&str>("depth").is_err(), "depth omitted:\n{s:?}");
+        assert!(s.get::<&str>("profile").is_err(), "profile omitted:\n{s:?}");
+        assert!(s.get::<&str>("TP").is_err(), "TP omitted when wide:\n{s:?}");
+    }
+
+    #[test]
+    fn rtp_caps_from_raw_video_jxsv_emits_explicit_colorimetry() {
+        init_gst();
+        let essence = jxsv_caps(
+            "image/x-jxsc",
+            1920,
+            1080,
+            gst::Fraction::new(50, 1),
+            Some("colorimetry=bt2100-pq"),
+        );
+        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, false).expect("synth");
+        let s = rtp.structure(0).expect("rtp");
+        assert_eq!(s.get::<&str>("colorimetry").unwrap(), "BT2100");
+        assert_eq!(s.get::<&str>("tcs").unwrap(), "PQ");
+    }
+
+    #[test]
+    fn rtp_caps_from_raw_video_jxsv_narrow_profile_emits_tp() {
+        init_gst();
+        let essence = jxsv_caps("image/x-jxsc", 1920, 1080, gst::Fraction::new(50, 1), None);
+        let rtp = rtp_caps_from_raw_video_jxsv(&essence, 96, true).expect("synth");
+        let s = rtp.structure(0).expect("rtp");
+        assert_eq!(s.get::<&str>("TP").unwrap(), "2110TPN");
+    }
+
+    #[test]
+    fn rtp_caps_from_raw_video_jxsv_requires_width_height_framerate() {
+        init_gst();
+        let no_width = gst::Caps::from_str("image/x-jxsc,height=1080,framerate=50/1").unwrap();
+        assert!(rtp_caps_from_raw_video_jxsv(&no_width, 96, false).is_err());
+        let no_fr = gst::Caps::from_str("image/x-jxsc,width=1920,height=1080").unwrap();
+        assert!(rtp_caps_from_raw_video_jxsv(&no_fr, 96, false).is_err());
+    }
+
+    #[test]
+    fn raw_caps_from_rtp_video_jxsv_yields_both_essence_structures() {
+        init_gst();
+        let rtp = gst::Caps::from_str(
+            "application/x-rtp,media=(string)video,clock-rate=(int)90000,\
+             encoding-name=(string)jxsv,payload=(int)96,\
+             width=(string)1920,height=(string)1080,exactframerate=(string)50,\
+             sampling=(string)YCbCr-4:2:2,depth=(string)10",
+        )
+        .unwrap();
+        let caps = raw_caps_from_rtp_video_jxsv(&rtp).expect("essence");
+        let names: Vec<String> = (0..caps.size())
+            .filter_map(|i| caps.structure(i).map(|s| s.name().to_string()))
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "image/x-jxsc"),
+            "names: {names:?}",
+        );
+        assert!(
+            names.iter().any(|n| n == "video/x-jxsv"),
+            "names: {names:?}",
+        );
+        let s0 = caps.structure(0).unwrap();
+        assert_eq!(s0.get::<i32>("width").unwrap(), 1920);
+        assert_eq!(s0.get::<i32>("height").unwrap(), 1080);
+        assert_eq!(
+            s0.get::<gst::Fraction>("framerate").unwrap(),
+            gst::Fraction::new(50, 1),
+        );
+        assert_eq!(s0.get::<&str>("sampling").unwrap(), "YCbCr-4:2:2");
+        assert_eq!(s0.get::<i32>("depth").unwrap(), 10);
+    }
+
+    #[test]
+    fn raw_caps_from_rtp_video_jxsv_rejects_non_jxsv_encoding() {
+        init_gst();
+        let rtp = gst::Caps::from_str(
+            "application/x-rtp,media=(string)video,encoding-name=(string)raw",
+        )
+        .unwrap();
+        assert!(raw_caps_from_rtp_video_jxsv(&rtp).is_err());
+    }
+
+    #[test]
+    fn from_caps_jxsv_synthesises_st2110_22_sdp() {
+        init_gst();
+        let essence = jxsv_caps(
+            "image/x-jxsc",
+            1920,
+            1080,
+            gst::Fraction::new(50, 1),
+            Some(
+                "sampling=YCbCr-4:2:2,depth=10,profile=High444.12,level=2k-1,\
+                 sublevel=Sublev3bpp",
+            ),
+        );
+        let input = build_input(&essence, Side::Sender, None);
+        let text = from_caps(&input).expect("synth");
+        assert!(text.contains("m=video 5004 RTP/AVP 96"), "SDP:\n{text}");
+        assert!(text.contains("a=rtpmap:96 jxsv/90000"), "rtpmap:\n{text}");
+        assert!(text.contains("packetmode=0"), "packetmode:\n{text}");
+        assert!(text.contains("SSN=ST2110-22:2022"), "SSN:\n{text}");
+        assert!(text.contains("profile=High444.12"), "profile:\n{text}");
+        assert!(text.contains("sublevel=Sublev3bpp"), "sublevel:\n{text}");
+    }
+
+    #[test]
+    fn from_caps_jxsv_accepts_video_x_jxsv_essence() {
+        init_gst();
+        let essence = jxsv_caps("video/x-jxsv", 1920, 1080, gst::Fraction::new(25, 1), None);
+        let input = build_input(&essence, Side::Sender, None);
+        let text = from_caps(&input).expect("synth");
+        assert!(text.contains("a=rtpmap:96 jxsv/90000"), "rtpmap:\n{text}");
+    }
+
+    #[test]
+    fn bit_rates_from_sdp_reads_b_as_bandwidth() {
+        init_gst();
+        let sdp = concat!(
+            "v=0\r\n",
+            "o=- 0 0 IN IP4 127.0.0.1\r\n",
+            "s=test\r\n",
+            "t=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 224.0.0.1\r\n",
+            "b=AS:116000\r\n",
+            "a=rtpmap:96 jxsv/90000\r\n",
+            "a=fmtp:96 width=1280;height=720;exactframerate=60000/1001\r\n",
+        );
+        let rates = bit_rates_from_sdp_text(sdp).expect("parse");
+        assert_eq!(rates.transport_bit_rate, 116_000);
+        assert_eq!(rates.format_bit_rate, 110_476);
+    }
+
+    #[test]
+    fn cross_check_bit_rates_rejects_mismatch() {
+        let file = BitRates {
+            format_bit_rate: 110_000,
+            transport_bit_rate: 116_000,
+        };
+        let property = bit_rates_from_properties(120_000, 0);
+        let err = cross_check_bit_rates(property, file).unwrap_err();
+        assert!(
+            err.to_string().contains("bit-rate mismatch"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn passthrough_splices_bit_rates_when_file_omits_them() {
+        init_gst();
+        let sdp = concat!(
+            "v=0\r\n",
+            "o=- 0 0 IN IP4 127.0.0.1\r\n",
+            "s=test\r\n",
+            "t=0 0\r\n",
+            "m=video 5004 RTP/AVP 96\r\n",
+            "c=IN IP4 224.0.0.1\r\n",
+            "a=rtpmap:96 jxsv/90000\r\n",
+            "a=fmtp:96 width=1280;height=720;exactframerate=60000/1001\r\n",
+        );
+        let overrides = SdpOverrides {
+            bit_rates: bit_rates_from_properties(110_000, 0),
+            ..Default::default()
+        };
+        let out = passthrough_with_overrides(
+            sdp,
+            &overrides,
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("splice");
+        assert!(out.contains("b=AS:116000"), "bandwidth:\n{out}");
+        assert!(
+            out.contains("x-nvnmos-format-bit-rate=110000"),
+            "format bit rate:\n{out}",
+        );
+    }
+
+    #[test]
+    fn bit_rates_from_properties_derives_transport_from_format() {
+        let bit_rates = bit_rates_from_properties(110_000, 0);
+        assert_eq!(bit_rates.format_bit_rate, 110_000);
+        assert_eq!(bit_rates.transport_bit_rate, 116_000);
+    }
+
+    #[test]
+    fn bit_rates_from_properties_derives_format_from_transport() {
+        let bit_rates = bit_rates_from_properties(0, 116_000);
+        assert_eq!(bit_rates.transport_bit_rate, 116_000);
+        assert_eq!(bit_rates.format_bit_rate, 110_476);
+    }
+
+    #[test]
+    fn from_caps_jxsv_emits_bitrate_fields_from_format_bit_rate() {
+        init_gst();
+        let essence = jxsv_caps(
+            "image/x-jxsc",
+            1920,
+            1080,
+            gst::Fraction::new(50, 1),
+            None,
+        );
+        let mut input = build_input(&essence, Side::Sender, None);
+        input.format_bit_rate = 110_000;
+        let text = from_caps(&input).expect("synth");
+        assert!(text.contains("b=AS:116000"), "bandwidth:\n{text}");
+        assert!(
+            text.contains("x-nvnmos-format-bit-rate=110000"),
+            "format bit rate:\n{text}",
+        );
+        assert!(
+            text.contains("x-nvnmos-transport-bit-rate=116000"),
+            "transport bit rate:\n{text}",
+        );
+    }
+
+    #[test]
+    fn from_caps_jxsv_emits_bitrate_fields_from_transport_bit_rate() {
+        init_gst();
+        let essence = jxsv_caps(
+            "image/x-jxsc",
+            1280,
+            720,
+            gst::Fraction::new(60000, 1001),
+            None,
+        );
+        let mut input = build_input(&essence, Side::Receiver, None);
+        input.transport_bit_rate = 116_000;
+        let text = from_caps(&input).expect("synth");
+        assert!(text.contains("b=AS:116000"), "bandwidth:\n{text}");
+        assert!(
+            text.contains("x-nvnmos-transport-bit-rate=116000"),
+            "transport bit rate:\n{text}",
+        );
+        assert!(
+            text.contains("x-nvnmos-format-bit-rate=110476"),
+            "derived format bit rate:\n{text}",
+        );
+    }
+
+    #[test]
+    fn from_caps_jxsv_omits_bitrate_fields_when_unset() {
+        init_gst();
+        let essence = jxsv_caps("image/x-jxsc", 1920, 1080, gst::Fraction::new(50, 1), None);
+        let input = build_input(&essence, Side::Sender, None);
+        let text = from_caps(&input).expect("synth");
+        assert!(!text.contains("b=AS:"), "must omit bandwidth:\n{text}");
+        assert!(
+            !text.contains("x-nvnmos-format-bit-rate"),
+            "must omit format bit rate:\n{text}",
+        );
+        assert!(
+            !text.contains("x-nvnmos-transport-bit-rate"),
+            "must omit transport bit rate:\n{text}",
+        );
+    }
+
+    #[test]
+    fn from_caps_jxsv_round_trips_through_parse_sdp() {
+        init_gst();
+        let essence = jxsv_caps(
+            "image/x-jxsc",
+            1920,
+            1080,
+            gst::Fraction::new(30000, 1001),
+            Some(
+                "sampling=YCbCr-4:2:2,depth=10,profile=Main422.10,level=2k-1,\
+                 sublevel=Sublev3bpp",
+            ),
+        );
+        let input = build_input(&essence, Side::Sender, None);
+        let text = from_caps(&input).expect("synth");
+        let media = parse_sdp(&text).expect("round-trip parse");
+        assert_eq!(media.format, FlowFormat::Video);
+        assert_eq!(
+            media
+                .rtp_caps
+                .structure(0)
+                .unwrap()
+                .get::<&str>("encoding-name")
+                .unwrap(),
+            // gst-sdp upper-cases the rtpmap encoding-name on parse.
+            "JXSV",
+        );
+        let names: Vec<String> = (0..media.raw_caps.size())
+            .filter_map(|i| media.raw_caps.structure(i).map(|s| s.name().to_string()))
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "image/x-jxsc"),
+            "names: {names:?}",
+        );
+        assert!(
+            names.iter().any(|n| n == "video/x-jxsv"),
+            "names: {names:?}",
+        );
+        let s0 = media.raw_caps.structure(0).unwrap();
+        assert_eq!(s0.get::<i32>("width").unwrap(), 1920);
+        assert_eq!(
+            s0.get::<gst::Fraction>("framerate").unwrap(),
+            gst::Fraction::new(30000, 1001),
+        );
     }
 
     #[test]
@@ -5463,6 +6314,8 @@ mod tests {
             advertise_caps: false,
             node_seed: "demo-node1",
             narrow_traffic_profile: false,
+            format_bit_rate: 0,
+            transport_bit_rate: 0,
         };
         let text = from_caps(&input).expect("synth");
         assert!(

--- a/rust/gst-nmos-rs/src/sdp_passthrough.rs
+++ b/rust/gst-nmos-rs/src/sdp_passthrough.rs
@@ -12,7 +12,7 @@
 use gstreamer_sdp::{SDPAttribute, SDPMediaRef, SDPConnection, SDPMessage};
 
 use crate::iface;
-use crate::sdp::{self, defaults, SdpError, SdpOverrides};
+use crate::sdp::{self, defaults, BitRates, SdpError, SdpOverrides};
 use crate::types::CapsMode;
 
 /// Whether the configuring passthrough path may carry a dual-`m=` ST 2022-7 SDP.
@@ -83,6 +83,9 @@ pub(crate) fn apply_media_overrides_in_place(
     }
     if let Some(m) = msg.media_mut(0) {
         apply_primary_leg_transport_overrides(m, overrides)?;
+        if overrides.bit_rates != BitRates::UNSET {
+            sdp::apply_bit_rates_to_media(m, overrides.bit_rates);
+        }
     }
     Ok(())
 }

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -232,6 +232,31 @@ pub(crate) const CAPS_BLURB_RECEIVER: &str =
 pub(crate) const TRANSPORT_CAPS_BLURB: &str =
     "Per-transport overrides (SDP fmtp-style). Typically empty for MXL.";
 
+pub(crate) const FORMAT_BIT_RATE_BLURB: &str =
+    "Coded essence (Flow) bit rate in kilobits per second (1000 bits/s), \
+     matching NMOS Flow `bit_rate` and SDP fmtp `x-nvnmos-format-bit-rate`. \
+     On JPEG XS RTP transports, synthesises the configuring SDP \
+     `a=fmtp:… x-nvnmos-format-bit-rate=` attribute and `b=AS:` (via the \
+     derived transport rate) and sets `rtpjxsvpay max-codestream-bitrate` \
+     to this value times 1000 (bit/s) unless `pay-properties` already \
+     supplies it. 0 (the default) = unset. When only one of \
+     `format-bit-rate` and `transport-bit-rate` is set, the other is derived \
+     using the same overhead factor as `nvnmosd` (AMWA BCP-006-01 / VSF \
+     TR-08 style). With a supplied `transport-file*`, cross-checks when both \
+     sides declare a rate and splices when the file omits it. Ignored on \
+     `transport=mxl`.";
+
+pub(crate) const TRANSPORT_BIT_RATE_BLURB: &str =
+    "Transport (Sender) bit rate in kilobits per second (1000 bits/s), \
+     including RTP/UDP/IP overhead, matching NMOS Sender `bit_rate`, SDP \
+     `b=AS:`, and fmtp `x-nvnmos-transport-bit-rate`. On JPEG XS RTP \
+     transports, synthesises the configuring SDP `b=AS:` bandwidth line and \
+     `a=fmtp:… x-nvnmos-transport-bit-rate=` attribute. 0 (the default) = \
+     unset. When only one of `format-bit-rate` and `transport-bit-rate` is \
+     set, the other is derived using the same overhead factor as `nvnmosd`. \
+     With a supplied `transport-file*`, cross-checks when both sides declare \
+     a rate and splices when the file omits it. Ignored on `transport=mxl`.";
+
 pub(crate) const TRANSPORT_PROPERTIES_BLURB: &str =
     "Overrides applied to the inner source or sink (`udpsrc`, `udpsink`, \
      `nvdsudpsrc`, `nvdsudpsink`, `mxlsrc`, or `mxlsink`) every time the \
@@ -362,6 +387,14 @@ pub(crate) struct CommonSettings {
     /// synthesis path (which threads it into
     /// [`sdp::from_caps`]'s `transport_caps` slot).
     pub(crate) transport_caps: Option<gst::Caps>,
+    /// Coded essence (Flow) bit rate in kilobits per second (1000 bits/s),
+    /// excluding RTP/UDP/IP overhead. 0 = unset. On JPEG XS RTP transports,
+    /// threads into SDP synthesis and `rtpjxsvpay` configuration.
+    pub(crate) format_bit_rate: u64,
+    /// Transport (Sender) bit rate in kilobits per second (1000 bits/s),
+    /// including RTP/UDP/IP overhead. 0 = unset. On JPEG XS RTP transports,
+    /// threads into SDP `b=AS:` and fmtp synthesis.
+    pub(crate) transport_bit_rate: u64,
     /// Controls whether the resource advertises narrow or wide caps
     /// in IS-04. See [`CapsMode`] for the full semantics. Honoured
     /// only when `side` is `Receiver` (driven by the
@@ -475,6 +508,8 @@ impl Default for CommonSettings {
             group_hint: String::new(),
             caps: None,
             transport_caps: None,
+            format_bit_rate: 0,
+            transport_bit_rate: 0,
             caps_mode: CapsMode::default(),
             source_ip: String::new(),
             source_port: 0,
@@ -637,6 +672,7 @@ impl FakeKind {
 /// A later step (caps→transport-file synthesis or IS-05 activation)
 /// will supply the missing pieces and the bin will swap from fake to
 /// real.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 pub(crate) enum InnerConfig {
     Real(TransportConfig),
@@ -676,9 +712,10 @@ pub(crate) enum TransportConfig {
     /// senders and `udpsrc ! rtp*depay [! capssetter(raw_caps)]` for
     /// receivers.
     /// Wide receivers (activation SDP carries `a=x-nvnmos-caps:`)
-    /// omit `capssetter`; narrow receivers pin configuring essence
-    /// caps parsed from the transport file. The exact element factory
-    /// names dispatch on [`UdpVariant`].
+    /// omit `capssetter`; narrow receivers pass configuring essence
+    /// caps parsed from the transport file to the chain builder, which
+    /// appends a capssetter only for depayloaders that need/tolerate
+    /// one. The exact element factory names dispatch on [`UdpVariant`].
     ///
     /// Constructed at runtime by `resolve_inner_config_udp` (in
     /// `validate_and_open`) and `decide_inner_config_udp` (in
@@ -1417,6 +1454,8 @@ mod support {
             group_hint: String::new(),
             caps: None,
             transport_caps: None,
+            format_bit_rate: 0,
+            transport_bit_rate: 0,
             caps_mode: CapsMode::Auto,
             // IS-05 RTP transport_params: unset/0 for MXL
             // tests (transport=Mxl above ignores them anyway);

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -559,9 +559,9 @@ pub(crate) fn caps_from_flow_def(
     let Some(text) = transport_file.filter(|s| !s.is_empty()) else {
         return Ok(None);
     };
-    let raw_caps = crate::flow_def::caps_from(text)
+    let parsed_caps = crate::flow_def::caps_from(text)
         .map_err(|e| anyhow::anyhow!("caps from flow-def transport file: {e}"))?;
-    let caps = crate::essence_caps::caps_from(&raw_caps, None);
+    let caps = crate::essence_caps::caps_from(&parsed_caps, None);
     gst::info!(gst::CAT_DEFAULT, "{element}: caps `{caps}` from transport file");
     Ok(Some(caps))
 }
@@ -579,7 +579,7 @@ fn caps_from_transport_file(
         Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => {
             let media = crate::sdp::parse_sdp(transport_file)
                 .map_err(|e| anyhow::anyhow!("caps from SDP transport file: {e}"))?;
-            let caps = crate::essence_caps::caps_from(&media.raw_caps, Some(&media.rtp_caps));
+            let caps = crate::essence_caps::caps_from(&media.caps, Some(&media.rtp_caps));
             gst::info!(
                 gst::CAT_DEFAULT,
                 "{element}: caps `{caps}` from SDP transport file"
@@ -709,7 +709,7 @@ pub(crate) enum TransportConfig {
         transport_file: Option<String>,
     },
     /// RTP/UDP transport. The inner chain is `rtp*pay ! udpsink` for
-    /// senders and `udpsrc ! rtp*depay [! capssetter(raw_caps)]` for
+    /// senders and `udpsrc ! rtp*depay [! capssetter(caps)]` for
     /// receivers.
     /// Wide receivers (activation SDP carries `a=x-nvnmos-caps:`)
     /// omit `capssetter`; narrow receivers pass configuring essence

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -166,6 +166,8 @@ pub(super) fn sdp_build_input<'a>(
         advertise_caps,
         node_seed: &settings.node.node_seed,
         narrow_traffic_profile: settings.transport == Transport::NvDsUdp,
+        format_bit_rate: settings.format_bit_rate,
+        transport_bit_rate: settings.transport_bit_rate,
     }
 }
 
@@ -321,6 +323,7 @@ pub(crate) fn property_overrides_udp(settings: &CommonSettings) -> SdpOverrides<
         a_ptime,
         a_maxptime,
         caps_mode: settings.caps_mode,
+        bit_rates: sdp::BitRates::UNSET,
     }
 }
 fn finish_udp_inner_config(
@@ -420,6 +423,28 @@ pub(crate) fn decide_inner_config_nvdsudp(
     )
 }
 
+fn passthrough_user_transport_file(
+    element: &str,
+    settings: &CommonSettings,
+    text: &str,
+    policy: DualLegPassthroughPolicy,
+) -> Result<String, anyhow::Error> {
+    let file = sdp::bit_rates_from_sdp_text(text)
+        .with_context(|| format!("{element}: parsing bit rates from transport-file SDP"))?;
+    let property = sdp::bit_rates_from_properties(settings.format_bit_rate, settings.transport_bit_rate);
+    sdp::cross_check_bit_rates(property, file)
+        .with_context(|| format!("{element}: cross-checking bit rates against transport-file"))?;
+
+    let mut overrides = property_overrides_udp(settings);
+    if property != sdp::BitRates::UNSET && file == sdp::BitRates::UNSET {
+        overrides.bit_rates = property;
+    }
+
+    sdp::passthrough_with_overrides(text, &overrides, policy).with_context(|| {
+        format!("{element}: applying property overrides to transport-file SDP")
+    })
+}
+
 pub(super) fn resolve_inner_config_nvdsudp(
     cat: &gst::DebugCategory,
     element: &str,
@@ -431,16 +456,12 @@ pub(super) fn resolve_inner_config_nvdsudp(
         synthesise_or_passthrough_udp(cat, element, settings, resolved_transport_file)?;
 
     let resolved_transport_file = match resolved_transport_file {
-        Some(text) if had_user_transport_file => Some(
-            sdp::passthrough_with_overrides(
-                &text,
-                &property_overrides_udp(settings),
-                DualLegPassthroughPolicy::AllowDualLeg,
-            )
-            .with_context(|| {
-                format!("{element}: applying property overrides to transport-file SDP")
-            })?,
-        ),
+        Some(text) if had_user_transport_file => Some(passthrough_user_transport_file(
+            element,
+            settings,
+            &text,
+            DualLegPassthroughPolicy::AllowDualLeg,
+        )?),
         other => other,
     };
     let inner = gate_deferred_sender_udp(
@@ -499,16 +520,12 @@ pub(super) fn resolve_inner_config_udp(
     // runs at startup only. Synthesised SDPs already bake every
     // property in via [`sdp::from_caps`]; skip the second pass.
     let resolved_transport_file = match resolved_transport_file {
-        Some(text) if had_user_transport_file => Some(
-            sdp::passthrough_with_overrides(
-                &text,
-                &property_overrides_udp(settings),
-                DualLegPassthroughPolicy::RejectDualLeg,
-            )
-            .with_context(|| {
-                format!("{element}: applying property overrides to transport-file SDP")
-            })?,
-        ),
+        Some(text) if had_user_transport_file => Some(passthrough_user_transport_file(
+            element,
+            settings,
+            &text,
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )?),
         other => other,
     };
     let inner = gate_deferred_sender_udp(
@@ -561,6 +578,7 @@ mod tests {
                 "video/x-raw,format=v210,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
+            bit_rates: sdp::BitRates::UNSET,
         }
     }
 
@@ -1234,6 +1252,44 @@ mod tests {
                         }
                     }
                 }
+            }
+
+            const JXSV_MCAST_SDP: &str = concat!(
+                "v=0\r\n",
+                "o=- 1 0 IN IP4 192.0.2.10\r\n",
+                "s=test\r\n",
+                "t=0 0\r\n",
+                "m=video 5004 RTP/AVP 96\r\n",
+                "c=IN IP4 239.1.1.1/64\r\n",
+                "a=rtpmap:96 jxsv/90000\r\n",
+                "a=fmtp:96 packetmode=0; profile=High444.12; level=2k-1; sublevel=Sublev3bpp;",
+                " sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25; depth=10\r\n",
+            );
+
+            /// JPEG XS configuring SDP: property overrides rewrite network
+            /// fields while fmtp profile / level / sublevel survive.
+            #[test]
+            fn receiver_passthrough_jxsv_preserves_fmtp_and_overrides_interface_ip() {
+                let settings = receiver_settings(true, true, false);
+                let spliced = splice(JXSV_MCAST_SDP, &settings);
+                assert_c_contains(&spliced, PROP_MCAST);
+                assert_iface_attr(&spliced, Some(PROP_IFACE));
+                assert!(
+                    spliced.contains("profile=High444.12"),
+                    "profile must survive passthrough:\n{spliced}",
+                );
+                assert!(
+                    spliced.contains("level=2k-1"),
+                    "level must survive passthrough:\n{spliced}",
+                );
+                assert!(
+                    spliced.contains("sublevel=Sublev3bpp"),
+                    "sublevel must survive passthrough:\n{spliced}",
+                );
+                assert!(
+                    spliced.contains("a=rtpmap:96 jxsv/90000"),
+                    "jxsv rtpmap must survive passthrough:\n{spliced}",
+                );
             }
         }
 

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -140,7 +140,7 @@ pub(super) fn udp_eager_blocked(side: Side, inner: &InnerConfig) -> Option<&'sta
 /// sender AddSender.
 pub(super) fn sdp_build_input<'a>(
     settings: &'a CommonSettings,
-    essence_caps: &'a gst::Caps,
+    caps: &'a gst::Caps,
 ) -> sdp::SdpBuildInput<'a> {
     let destination_ip = match settings.side {
         Side::Sender => settings.destination_ip.as_str(),
@@ -151,7 +151,7 @@ pub(super) fn sdp_build_input<'a>(
         CapsMode::Wide => true,
     };
     sdp::SdpBuildInput {
-        essence_caps,
+        caps,
         transport_caps: settings.transport_caps.as_ref(),
         side: settings.side,
         name: &settings.name,
@@ -186,9 +186,9 @@ pub(super) fn synthesise_or_passthrough_udp(
             Ok(Some(text))
         }
         (Some(text), None) => Ok(Some(text)),
-        (None, Some(essence_caps)) => {
+        (None, Some(caps)) => {
             validate_rtp_configuring_minimum(element, settings)?;
-            let text = sdp::from_caps(&sdp_build_input(settings, essence_caps))
+            let text = sdp::from_caps(&sdp_build_input(settings, caps))
                 .with_context(|| format!("{element}: synthesising SDP from caps"))?;
             gst::info!(
                 cat,
@@ -230,10 +230,10 @@ fn gate_deferred_sender_udp(inner: InnerConfig, settings: &CommonSettings) -> In
 pub(super) fn synthesise_deferred_sender_udp(
     element: &str,
     settings: &CommonSettings,
-    essence_caps: &gst::Caps,
+    caps: &gst::Caps,
 ) -> Result<(String, InnerConfig), anyhow::Error> {
     validate_rtp_configuring_minimum(element, settings)?;
-    let text = sdp::from_caps(&sdp_build_input(settings, essence_caps))
+    let text = sdp::from_caps(&sdp_build_input(settings, caps))
         .map_err(anyhow::Error::from)
         .with_context(|| format!("{element}: synthesising SDP from peer caps"))?;
     let inner = match settings.transport {
@@ -363,7 +363,7 @@ fn finish_udp_inner_config(
     // The SDP cannot carry caps features; re-attach any requested on
     // the `caps` property (e.g. `memory:NVMM`) so the inner element
     // (for example, nvdsudpsrc) sees them and negotiates accordingly.
-    media.raw_caps = crate::essence_caps::overlay_features(&media.raw_caps, settings.caps.as_ref());
+    media.caps = crate::essence_caps::overlay_features(&media.caps, settings.caps.as_ref());
     Ok(build_real(media))
 }
 
@@ -574,7 +574,7 @@ mod tests {
                 "application/x-rtp,media=video,clock-rate=90000,encoding-name=RAW,payload=96",
             )
             .expect("static rtp caps parse"),
-            raw_caps: gst::Caps::from_str(
+            caps: gst::Caps::from_str(
                 "video/x-raw,format=v210,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
@@ -659,7 +659,7 @@ mod tests {
             assert_eq!(m.primary.source_port, Some(5004));
             assert!(m.secondary.is_none());
             assert!(!m.rtp_caps.is_empty());
-            assert!(!m.raw_caps.is_empty());
+            assert!(!m.caps.is_empty());
         }
 
         #[test]
@@ -1933,7 +1933,7 @@ mod tests {
                 InnerConfig::Real(TransportConfig::Udp { media, .. }) => {
                     assert_eq!(
                         media
-                            .raw_caps
+                            .caps
                             .structure(0)
                             .and_then(|s| s.get::<i32>("channels").ok()),
                         Some(1),
@@ -2128,7 +2128,7 @@ mod tests {
                     | InnerConfig::Real(TransportConfig::Udp { media, .. }) => {
                         assert_eq!(media.format, FlowFormat::Data);
                         assert_eq!(
-                            media.raw_caps.structure(0).unwrap().name(),
+                            media.caps.structure(0).unwrap().name(),
                             "meta/x-st-2038",
                         );
                     }

--- a/rust/gst-nmos-rs/src/session/udp/types.rs
+++ b/rust/gst-nmos-rs/src/session/udp/types.rs
@@ -21,7 +21,7 @@ use crate::types::FlowFormat;
 /// ST 2022-7 separate destination addresses mode uses two `m=` lines with
 /// common media attributes; parsing folds these onto one [`UdpMedia`].
 ///
-/// Essence-level state (`format`, `rtp_caps`, `raw_caps`) is shared
+/// Essence-level state (`format`, `rtp_caps`, `caps`) is shared
 /// across legs because both legs of an ST 2022-7 pair carry the
 /// same essence with the same PT / clock-rate / encoding-name; only
 /// the network params differ. Per-leg state lives on [`UdpLeg`].
@@ -75,7 +75,7 @@ pub(crate) struct UdpMedia {
     /// src pad so downstream caps queries see the concrete shape
     /// the flow will carry, mirroring the MXL path's
     /// `advertise_caps` derived from the flow_def.
-    pub(crate) raw_caps: gst::Caps,
+    pub(crate) caps: gst::Caps,
     /// Resolved format / transport bit rates from SDP `b=AS:` and fmtp
     /// `x-nvnmos-*-bit-rate` (kbit/s). [`crate::sdp::BitRates::UNSET`]
     /// when absent.

--- a/rust/gst-nmos-rs/src/session/udp/types.rs
+++ b/rust/gst-nmos-rs/src/session/udp/types.rs
@@ -76,6 +76,10 @@ pub(crate) struct UdpMedia {
     /// the flow will carry, mirroring the MXL path's
     /// `advertise_caps` derived from the flow_def.
     pub(crate) raw_caps: gst::Caps,
+    /// Resolved format / transport bit rates from SDP `b=AS:` and fmtp
+    /// `x-nvnmos-*-bit-rate` (kbit/s). [`crate::sdp::BitRates::UNSET`]
+    /// when absent.
+    pub(crate) bit_rates: crate::sdp::BitRates,
 }
 
 /// One network leg of a [`UdpMedia`]. Non-redundant RTP has a single


### PR DESCRIPTION
Adds JPEG XS video transport to `gst-nmos-rs` for `udp` / `udp2`, following AMWA BCP-006-01, RFC 9134, and ST 2110-22.

### What this enables

- **SDP synthesis and parsing** for `video/jxsv` (`encoding-name=JXSV`), including RFC 9134 fmtp fields (`packetmode`, `profile`, `level`, `sublevel`, `sampling`, `width`, `height`, `exactframerate`, `depth`, `colorimetry`, `TP`, `SSN`, and related ST 2110-21 timing attributes where present).
- **Essence caps** for both `image/x-jxsc` and `video/x-jxsv`, mapped to a common RTP representation and back.
- **GStreamer chain selection** via `rtpjxsvpay` / `rtpjxsvdepay` ([soon](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/3166) to be) from `gst-plugins-rs` (`rsrtp` plugin), with `format-bit-rate` driving `rtpjxsvpay max-codestream-bitrate` when not overridden in `pay-properties`.
- **`format-bit-rate` / `transport-bit-rate` GObject properties** (kbit/s) on `nmossink` / `nmossrc`, synthesised into SDP `b=AS:`, fmtp `x-nvnmos-format-bit-rate`, and fmtp `x-nvnmos-transport-bit-rate`, with cross-check / splice behaviour on the transport-file path (same model as other UDP transports).
- **Example pipelines** (prop-driven and transport-file-driven, sender and receiver) plus a minimal JXSV SDP fixture.
- **Unit tests** covering caps ↔ RTP ↔ SDP round-trips, bit-rate synthesis, transport-file passthrough, and chain construction (soft-skipped when `rtpjxsv*` is not installed).

### Scope and limits

- **`udp` / `udp2` only** — not `nvdsudp` (DeepStream packetization has no JXSV path today).
- **`packetmode=0` (codestream)** only for now.
- **Progressive** only for now.
- Live end-to-end JXSV in CI is out of scope for this PR (depends on a pinned `gst-plugins-rs` ref with `rtpjxsv*` and a suitable payloader source).

### Follow-on cleanup (second commit)

Renames `raw_caps` → `caps` across UDP transport state and SDP helpers (`caps_from_rtp_*`, `rtp_caps_from_*`, nvdsudp `*_from_caps`), so naming matches the fact that essence caps are not always `video/x-raw`.
