### PR TITLE
ci: enforce workspace rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
         with:
           rust-src-dir: rust
-          components: clippy
+          components: clippy, rustfmt
           rustflags: ""
 
       - name: Print Rust toolchain
@@ -119,6 +119,10 @@ jobs:
           rustc --version
           cargo --version
           cargo clippy --version
+
+      - name: Cargo fmt (workspace)
+        working-directory: rust
+        run: cargo fmt --all -- --check
 
       - name: Cargo clippy (workspace)
         working-directory: rust

--- a/rust/gst-nmos-rs/src/channel_mapping/active_map.rs
+++ b/rust/gst-nmos-rs/src/channel_mapping/active_map.rs
@@ -26,10 +26,7 @@ pub(crate) enum ActiveMapError {
     #[error("active-map output channel {0} is duplicated")]
     DuplicateOutputChannel(u32),
     #[error("active-map value for output channel {output_channel}: {reason}")]
-    InvalidValue {
-        output_channel: u32,
-        reason: String,
-    },
+    InvalidValue { output_channel: u32, reason: String },
 }
 
 /// Parse `inputId:channel_index` (e.g. `input0:2`).
@@ -62,14 +59,19 @@ pub(crate) fn parse_active_map_structure(
         if !seen_outputs.insert(output_channel) {
             return Err(ActiveMapError::DuplicateOutputChannel(output_channel));
         }
-        let value = structure.get::<Option<String>>(key).map_err(|e| ActiveMapError::InvalidValue {
-            output_channel,
-            reason: format!("field value is not a string: {e}"),
-        })?;
+        let value =
+            structure
+                .get::<Option<String>>(key)
+                .map_err(|e| ActiveMapError::InvalidValue {
+                    output_channel,
+                    reason: format!("field value is not a string: {e}"),
+                })?;
         // `active-map` is intended to be sparse, but allow explicit unrouted channels.
         // Support both 'correct', `(string)NULL` GValue (None), and 'incorrect', `NULL` or `null` string.
         let Some(value) = value else { continue };
-        if value.eq_ignore_ascii_case("null") { continue }
+        if value.eq_ignore_ascii_case("null") {
+            continue;
+        }
         let (input_id, input_channel) =
             parse_input_channel_ref(&value).map_err(|reason| ActiveMapError::InvalidValue {
                 output_channel,
@@ -120,13 +122,7 @@ pub(crate) fn active_map_entries_for_src(
     let routes = if let Some(structure) = src.active_map.as_ref() {
         parse_active_map_structure(structure)?
     } else {
-        default_identity_routes(
-            topology,
-            src_index,
-            output_channels,
-            sinks,
-            src_count,
-        )
+        default_identity_routes(topology, src_index, output_channels, sinks, src_count)
     };
     Ok(active_map_entries_from_routes(output_channels, &routes))
 }
@@ -202,10 +198,7 @@ mod tests {
 
     #[test]
     fn parse_input_channel_ref_valid() {
-        assert_eq!(
-            parse_input_channel_ref("input0:2").unwrap(),
-            ("input0", 2)
-        );
+        assert_eq!(parse_input_channel_ref("input0:2").unwrap(), ("input0", 2));
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/channel_mapping/matrix.rs
+++ b/rust/gst-nmos-rs/src/channel_mapping/matrix.rs
@@ -16,7 +16,9 @@ use crate::channel_mapping_session::ChannelMappingActivationRequest;
 pub(crate) enum ActiveMapValidationError {
     #[error("unknown input id `{0}`")]
     UnknownInputId(String),
-    #[error("input channel {input_channel} out of range for input `{input_id}` (max {max_channel})")]
+    #[error(
+        "input channel {input_channel} out of range for input `{input_id}` (max {max_channel})"
+    )]
     InputChannelOutOfRange {
         input_id: String,
         input_channel: u32,
@@ -85,11 +87,7 @@ pub(crate) fn validate_active_map_for_output(
             .iter()
             .position(|id| id == &route.input_id)
             .ok_or_else(|| ActiveMapValidationError::UnknownInputId(route.input_id.clone()))?;
-        let max_ch = topology
-            .input_channels
-            .get(pad_idx)
-            .copied()
-            .unwrap_or(0);
+        let max_ch = topology.input_channels.get(pad_idx).copied().unwrap_or(0);
         if route.input_channel >= max_ch {
             return Err(ActiveMapValidationError::InputChannelOutOfRange {
                 input_id: route.input_id.clone(),
@@ -148,17 +146,16 @@ use glib::prelude::*;
 /// Pack `out-channels × in-channels` matrix for `audiomixmatrix.matrix` (coefficients are `double`).
 pub(crate) fn matrix_to_audiomixmatrix_gvalue(rows: &[Vec<f32>]) -> gst::Array {
     gst::Array::from_values(rows.iter().map(|row| {
-        let inner = gst::Array::from_values(
-            row.iter()
-                .copied()
-                .map(|v| (f64::from(v)).to_send_value()),
-        );
+        let inner =
+            gst::Array::from_values(row.iter().copied().map(|v| (f64::from(v)).to_send_value()));
         glib::SendValue::from_owned(inner)
     }))
 }
 
 /// Build `converter-config` for an audiomixer sink pad (`input_bus_channels × input_channels` mix matrix).
-pub(crate) fn input_bus_converter_config(matrix: &[Vec<f32>]) -> gstreamer_audio::AudioConverterConfig {
+pub(crate) fn input_bus_converter_config(
+    matrix: &[Vec<f32>],
+) -> gstreamer_audio::AudioConverterConfig {
     let mut config = gstreamer_audio::AudioConverterConfig::new();
     config.set_mix_matrix(matrix);
     config
@@ -338,13 +335,7 @@ mod tests {
         let src_count = srcs.len();
         for src_idx in 0..src_count {
             let out_ch = topology.output_channels[src_idx];
-            let routes = default_identity_routes(
-                &topology,
-                src_idx,
-                out_ch,
-                &sinks,
-                src_count,
-            );
+            let routes = default_identity_routes(&topology, src_idx, out_ch, &sinks, src_count);
             let mix = build_output_mix_matrix(&topology, out_ch, &routes).unwrap();
             let el = gstreamer::ElementFactory::make("audiomixmatrix")
                 .property("in-channels", topology.input_bus_channels)

--- a/rust/gst-nmos-rs/src/channel_mapping/request.rs
+++ b/rust/gst-nmos-rs/src/channel_mapping/request.rs
@@ -4,8 +4,7 @@
 //! Build `AddChannelMappingRequest` from pad snapshots.
 
 use nvnmos_rpc::v1::{
-    AddChannelMappingRequest, ChannelMappingInput, ChannelMappingOutput,
-    ChannelMappingParentType,
+    AddChannelMappingRequest, ChannelMappingInput, ChannelMappingOutput, ChannelMappingParentType,
 };
 
 use super::types::{SinkPadSnapshot, SrcPadSnapshot};
@@ -25,10 +24,7 @@ pub(crate) fn build_add_channel_mapping_request(
     srcs: &[SrcPadSnapshot],
     restrict_routable_inputs: bool,
 ) -> AddChannelMappingRequest {
-    let input_ids_for_routable: Vec<String> = sinks
-        .iter()
-        .map(|s| s.input_id.clone())
-        .collect();
+    let input_ids_for_routable: Vec<String> = sinks.iter().map(|s| s.input_id.clone()).collect();
 
     let inputs = sinks
         .iter()
@@ -92,13 +88,7 @@ mod tests {
             negotiated_channels: 2,
             active_map: None,
         }];
-        let req = build_add_channel_mapping_request(
-            "sess",
-            "studio",
-            &sinks,
-            &srcs,
-            true,
-        );
+        let req = build_add_channel_mapping_request("sess", "studio", &sinks, &srcs, true);
         assert_eq!(req.name, "studio");
         assert_eq!(req.inputs.len(), 1);
         assert_eq!(req.inputs[0].parent_name, "rx1");

--- a/rust/gst-nmos-rs/src/channel_mapping_session.rs
+++ b/rust/gst-nmos-rs/src/channel_mapping_session.rs
@@ -21,7 +21,7 @@ use tonic::transport::Channel;
 
 use gstreamer as gst;
 
-use crate::daemon::{connect_uds, parse_unix_uri, DaemonError};
+use crate::daemon::{DaemonError, connect_uds, parse_unix_uri};
 use crate::runtime::SHARED_RUNTIME;
 use crate::session::channel_mapping::ChannelMappingSettings;
 
@@ -123,9 +123,7 @@ impl ChannelMappingSession {
     }
 
     pub(crate) fn channelmapping_handle(&self) -> Option<&str> {
-        self.channelmapping
-            .as_ref()
-            .map(|cm| cm.handle.as_str())
+        self.channelmapping.as_ref().map(|cm| cm.handle.as_str())
     }
 
     pub(crate) async fn add_channel_mapping(
@@ -135,11 +133,7 @@ impl ChannelMappingSession {
         if self.channelmapping.is_some() {
             return Err(DaemonError::AlreadyAdded);
         }
-        let resp = self
-            .client
-            .add_channel_mapping(request)
-            .await?
-            .into_inner();
+        let resp = self.client.add_channel_mapping(request).await?.into_inner();
         self.channelmapping = Some(AddedChannelMapping {
             handle: resp.channelmapping_handle.clone(),
         });
@@ -279,8 +273,8 @@ mod session_integration {
     use super::*;
     use crate::channel_mapping::request::build_add_channel_mapping_request;
     use crate::channel_mapping::types::{SinkPadSnapshot, SrcPadSnapshot};
-    use crate::session::channel_mapping::ChannelMappingSettings;
     use crate::session::NodeSettings;
+    use crate::session::channel_mapping::ChannelMappingSettings;
     use std::path::PathBuf;
     use std::process::{Child, Command, Stdio};
     use std::sync::Arc;
@@ -312,7 +306,12 @@ mod session_integration {
     fn libnvnmos_dir() -> Option<PathBuf> {
         let mut dirs: Vec<PathBuf> = Vec::new();
         if let Ok(paths) = std::env::var("LD_LIBRARY_PATH") {
-            dirs.extend(paths.split(':').filter(|s| !s.is_empty()).map(PathBuf::from));
+            dirs.extend(
+                paths
+                    .split(':')
+                    .filter(|s| !s.is_empty())
+                    .map(PathBuf::from),
+            );
         }
         if let Ok(dir) = std::env::var("NVNMOS_LIB_DIR") {
             dirs.push(PathBuf::from(dir));
@@ -354,7 +353,10 @@ mod session_integration {
             command
                 .arg("--uds")
                 .arg(&socket)
-                .env("RUST_LOG", std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+                .env(
+                    "RUST_LOG",
+                    std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
+                )
                 .stdout(Stdio::null())
                 .stderr(Stdio::inherit());
             // nvnmosd links libnvnmos.so; surface NVNMOS_LIB_DIR to the loader even

--- a/rust/gst-nmos-rs/src/daemon.rs
+++ b/rust/gst-nmos-rs/src/daemon.rs
@@ -30,9 +30,9 @@ use std::time::Duration;
 use hyper_util::rt::TokioIo;
 use nvnmos_rpc::v1::nvnmos_daemon_client::NvnmosDaemonClient;
 use nvnmos_rpc::v1::{
-    AckActivationRequest, ActivationEvent, AddReceiverRequest, AddSenderRequest, CloseSessionRequest,
-    OpenSessionRequest, Side as ProtoSide, SubscribeActivationsRequest, SyncResourceStateRequest,
-    Transport as ProtoTransport,
+    AckActivationRequest, ActivationEvent, AddReceiverRequest, AddSenderRequest,
+    CloseSessionRequest, OpenSessionRequest, Side as ProtoSide, SubscribeActivationsRequest,
+    SyncResourceStateRequest, Transport as ProtoTransport,
 };
 use thiserror::Error;
 use tokio::net::UnixStream;
@@ -45,8 +45,8 @@ use gstreamer as gst;
 
 use crate::CAT;
 use crate::runtime::SHARED_RUNTIME;
-use crate::session::types::Side;
 use crate::session::CommonSettings;
+use crate::session::types::Side;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -121,9 +121,7 @@ pub(crate) enum DaemonError {
     Transport(#[from] Box<tonic::transport::Error>),
     #[error("RPC error: {0}")]
     Rpc(#[from] Box<tonic::Status>),
-    #[error(
-        "session already has a resource added; deferred AddSender is a one-shot operation"
-    )]
+    #[error("session already has a resource added; deferred AddSender is a one-shot operation")]
     AlreadyAdded,
     #[error(
         "session has no resource added yet; auto-activate sync cannot run before AddSender / AddReceiver"
@@ -217,28 +215,22 @@ impl Session {
         );
 
         let resource = match transport_file {
-            Some(file) => match add_resource(
-                &mut client,
-                &session_handle,
-                side,
-                name,
-                transport,
-                file,
-            )
-            .await
-            {
-                Ok(r) => Some(r),
-                Err(e) => {
-                    activation_task.abort();
-                    let _ = activation_task.await;
-                    let _ = client
-                        .close_session(CloseSessionRequest {
-                            session_handle: session_handle.clone(),
-                        })
-                        .await;
-                    return Err(e);
+            Some(file) => {
+                match add_resource(&mut client, &session_handle, side, name, transport, file).await
+                {
+                    Ok(r) => Some(r),
+                    Err(e) => {
+                        activation_task.abort();
+                        let _ = activation_task.await;
+                        let _ = client
+                            .close_session(CloseSessionRequest {
+                                session_handle: session_handle.clone(),
+                            })
+                            .await;
+                        return Err(e);
+                    }
                 }
-            },
+            }
             None => None,
         };
 

--- a/rust/gst-nmos-rs/src/domain.rs
+++ b/rust/gst-nmos-rs/src/domain.rs
@@ -107,8 +107,10 @@ pub(crate) fn read_domain_def_id(domain_path: &Path) -> Result<Option<String>, D
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(source) => return Err(DomainError::Read { path: file, source }),
     };
-    let parsed: DomainDef = serde_json::from_str(&text)
-        .map_err(|source| DomainError::Parse { path: file.clone(), source })?;
+    let parsed: DomainDef = serde_json::from_str(&text).map_err(|source| DomainError::Parse {
+        path: file.clone(),
+        source,
+    })?;
     let id = parsed.id.unwrap_or_default();
     if id.is_empty() {
         return Err(DomainError::MissingId { path: file });

--- a/rust/gst-nmos-rs/src/essence_caps.rs
+++ b/rust/gst-nmos-rs/src/essence_caps.rs
@@ -15,10 +15,7 @@ use gstreamer as gst;
 /// is taken from the fmtp slot on the companion `application/x-rtp`
 /// caps; otherwise audio defaults use channel count (`M` / `ST` / `Uxx`).
 pub(crate) fn caps_from(caps: &gst::Caps, rtp_caps: Option<&gst::Caps>) -> gst::Caps {
-    if caps
-        .structure(0)
-        .is_some_and(|s| s.name() == "audio/x-raw")
-    {
+    if caps.structure(0).is_some_and(|s| s.name() == "audio/x-raw") {
         let channel_order = rtp_caps
             .and_then(|rtp| rtp.structure(0))
             .and_then(channel_order_from_rtp_structure);
@@ -113,9 +110,7 @@ pub(crate) fn default_smpte2110_channel_order(channels: i32) -> String {
 /// Read `channel-order` from parsed `application/x-rtp` caps (the
 /// fmtp `channel-order=` slot from SDP).
 pub(crate) fn channel_order_from_rtp_structure(s: &gst::StructureRef) -> Option<String> {
-    s.get::<&str>("channel-order")
-        .ok()
-        .map(str::to_owned)
+    s.get::<&str>("channel-order").ok().map(str::to_owned)
 }
 
 fn default_channel_mask(channels: i32) -> Option<gst::Bitmask> {
@@ -156,10 +151,9 @@ mod tests {
     #[test]
     fn caps_from_leaves_video_unchanged() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=UYVY,width=1920,height=1080,framerate=25/1",
-        )
-        .expect("video caps");
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=UYVY,width=1920,height=1080,framerate=25/1")
+                .expect("video caps");
         let out = caps_from(&caps, None);
         assert_eq!(out.to_string(), caps.to_string());
     }
@@ -221,7 +215,10 @@ mod tests {
         let s = out.structure(0).expect("structure");
         assert_eq!(
             s.get::<gst::Bitmask>("channel-mask").unwrap(),
-            caps.structure(0).unwrap().get::<gst::Bitmask>("channel-mask").unwrap(),
+            caps.structure(0)
+                .unwrap()
+                .get::<gst::Bitmask>("channel-mask")
+                .unwrap(),
         );
     }
 }

--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -239,16 +239,21 @@ pub(crate) fn resolve_mxl_flow_meta(
     let (id, id_origin) = resolve_id(property_id, file_meta.as_ref().map(|m| m.id.as_str()))?;
     let (format, format_origin) = resolve_format(
         property_format,
-        file_meta.as_ref().map(|m| m.format).unwrap_or(FlowFormat::Unspecified),
+        file_meta
+            .as_ref()
+            .map(|m| m.format)
+            .unwrap_or(FlowFormat::Unspecified),
     )?;
 
-    Ok(FlowResolution { id, id_origin, format, format_origin })
+    Ok(FlowResolution {
+        id,
+        id_origin,
+        format,
+        format_origin,
+    })
 }
 
-fn resolve_id(
-    property: &str,
-    file: Option<&str>,
-) -> Result<(String, ValueOrigin), FlowDefError> {
+fn resolve_id(property: &str, file: Option<&str>) -> Result<(String, ValueOrigin), FlowDefError> {
     let file_present = file.filter(|s| !s.is_empty());
     match (property.is_empty(), file_present) {
         (true, Some(f)) => Ok((f.to_owned(), ValueOrigin::File)),
@@ -272,7 +277,10 @@ fn resolve_format(
         (p, Unspecified) => Ok((p, ValueOrigin::Property)),
         (Unspecified, f) => Ok((f, ValueOrigin::File)),
         (p, f) if p == f => Ok((p, ValueOrigin::Both)),
-        (p, f) => Err(FlowDefError::FormatMismatch { property: p, file: f }),
+        (p, f) => Err(FlowDefError::FormatMismatch {
+            property: p,
+            file: f,
+        }),
     }
 }
 
@@ -323,7 +331,10 @@ pub(crate) fn splice_overrides(
     let object = value.as_object_mut().ok_or(FlowDefError::NotAnObject)?;
 
     if let Some(flow_id) = overrides.flow_id {
-        object.insert("id".to_owned(), serde_json::Value::String(flow_id.to_owned()));
+        object.insert(
+            "id".to_owned(),
+            serde_json::Value::String(flow_id.to_owned()),
+        );
     }
     if let Some(label) = overrides.label {
         object.insert(
@@ -377,10 +388,7 @@ pub(crate) fn splice_overrides(
                 tags.remove("urn:x-nvnmos:tag:caps");
             }
             CapsMode::Wide => {
-                tags.insert(
-                    "urn:x-nvnmos:tag:caps".to_owned(),
-                    serde_json::json!([""]),
-                );
+                tags.insert("urn:x-nvnmos:tag:caps".to_owned(), serde_json::json!([""]));
             }
         }
     }
@@ -457,10 +465,7 @@ pub(crate) fn from_caps(input: &FlowDefBuildInput<'_>) -> Result<String, FlowDef
     if input.mxl_domain_id.is_empty() {
         return Err(FlowDefError::MissingMxlDomainId);
     }
-    let structure = input
-        .caps
-        .structure(0)
-        .ok_or(FlowDefError::EmptyCaps)?;
+    let structure = input.caps.structure(0).ok_or(FlowDefError::EmptyCaps)?;
 
     let name = structure.name();
     let (format, body) = match name.as_str() {
@@ -548,7 +553,10 @@ fn build_video_body(
 
     let chroma_width = width / 2;
     let mut fields: Vec<(String, serde_json::Value)> = vec![
-        ("media_type".to_owned(), serde_json::Value::String(media_type.to_owned())),
+        (
+            "media_type".to_owned(),
+            serde_json::Value::String(media_type.to_owned()),
+        ),
         (
             "grain_rate".to_owned(),
             serde_json::json!({
@@ -558,7 +566,10 @@ fn build_video_body(
         ),
         ("frame_width".to_owned(), serde_json::json!(width)),
         ("frame_height".to_owned(), serde_json::json!(height)),
-        ("colorspace".to_owned(), serde_json::Value::String("BT709".to_owned())),
+        (
+            "colorspace".to_owned(),
+            serde_json::Value::String("BT709".to_owned()),
+        ),
         (
             "components".to_owned(),
             serde_json::json!([
@@ -597,7 +608,10 @@ fn build_audio_body(
     let channels = caps_field_i32(structure, "channels")?;
 
     let fields: Vec<(String, serde_json::Value)> = vec![
-        ("media_type".to_owned(), serde_json::Value::String(media_type.to_owned())),
+        (
+            "media_type".to_owned(),
+            serde_json::Value::String(media_type.to_owned()),
+        ),
         (
             "sample_rate".to_owned(),
             serde_json::json!({ "numerator": rate, "denominator": 1 }),
@@ -653,10 +667,7 @@ pub(crate) enum FlowDefCapsError {
     )]
     UnsupportedMediaType(String),
     #[error("transport file `{field}` has an out-of-range value `{value}` (must fit in i32)")]
-    OutOfRangeField {
-        field: &'static str,
-        value: i64,
-    },
+    OutOfRangeField { field: &'static str, value: i64 },
 }
 
 /// Reverse of [`from_caps`]: turn an MXL `flow_def` JSON
@@ -717,12 +728,13 @@ pub(crate) fn caps_from(text: &str) -> Result<gst::Caps, FlowDefCapsError> {
                     value: rate.denominator,
                 });
             }
-            let rate_i32: i32 = rate.numerator.try_into().map_err(|_| {
-                FlowDefCapsError::OutOfRangeField {
-                    field: "sample_rate.numerator",
-                    value: rate.numerator,
-                }
-            })?;
+            let rate_i32: i32 =
+                rate.numerator
+                    .try_into()
+                    .map_err(|_| FlowDefCapsError::OutOfRangeField {
+                        field: "sample_rate.numerator",
+                        value: rate.numerator,
+                    })?;
             Ok(gst::Caps::builder("audio/x-raw")
                 .field("format", "F32LE")
                 .field("rate", rate_i32)
@@ -777,10 +789,7 @@ fn caps_field_string(
         })
 }
 
-fn caps_field_i32(
-    structure: &gst::StructureRef,
-    field: &'static str,
-) -> Result<i32, FlowDefError> {
+fn caps_field_i32(structure: &gst::StructureRef, field: &'static str) -> Result<i32, FlowDefError> {
     structure
         .get::<i32>(field)
         .map_err(|_| FlowDefError::MissingCapsField {
@@ -850,9 +859,12 @@ mod tests {
 
     #[test]
     fn unknown_format_urn_is_hard_error() {
-        let err =
-            read_flow_def_meta(&format!(r#"{{"id":"{UUID_A}","format":"urn:bogus"}}"#)).unwrap_err();
-        assert!(matches!(err, FlowDefError::UnknownFormat(_)), "got: {err:?}");
+        let err = read_flow_def_meta(&format!(r#"{{"id":"{UUID_A}","format":"urn:bogus"}}"#))
+            .unwrap_err();
+        assert!(
+            matches!(err, FlowDefError::UnknownFormat(_)),
+            "got: {err:?}"
+        );
     }
 
     #[test]
@@ -872,8 +884,8 @@ mod tests {
 
     #[test]
     fn file_only() {
-        let r =
-            resolve_mxl_flow_meta("", FlowFormat::Unspecified, Some(&video_flow_def(UUID_A))).unwrap();
+        let r = resolve_mxl_flow_meta("", FlowFormat::Unspecified, Some(&video_flow_def(UUID_A)))
+            .unwrap();
         assert_eq!(r.id, UUID_A);
         assert_eq!(r.id_origin, ValueOrigin::File);
         assert_eq!(r.format, FlowFormat::Video);
@@ -882,8 +894,8 @@ mod tests {
 
     #[test]
     fn both_agree() {
-        let r =
-            resolve_mxl_flow_meta(UUID_A, FlowFormat::Video, Some(&video_flow_def(UUID_A))).unwrap();
+        let r = resolve_mxl_flow_meta(UUID_A, FlowFormat::Video, Some(&video_flow_def(UUID_A)))
+            .unwrap();
         assert_eq!(r.id, UUID_A);
         assert_eq!(r.id_origin, ValueOrigin::Both);
         assert_eq!(r.format, FlowFormat::Video);
@@ -892,17 +904,26 @@ mod tests {
 
     #[test]
     fn id_mismatch_is_hard_error() {
-        let err =
-            resolve_mxl_flow_meta(UUID_B, FlowFormat::Unspecified, Some(&video_flow_def(UUID_A)))
-                .unwrap_err();
-        assert!(matches!(err, FlowDefError::IdMismatch { .. }), "got: {err:?}");
+        let err = resolve_mxl_flow_meta(
+            UUID_B,
+            FlowFormat::Unspecified,
+            Some(&video_flow_def(UUID_A)),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, FlowDefError::IdMismatch { .. }),
+            "got: {err:?}"
+        );
     }
 
     #[test]
     fn format_mismatch_is_hard_error() {
-        let err =
-            resolve_mxl_flow_meta("", FlowFormat::Audio, Some(&video_flow_def(UUID_A))).unwrap_err();
-        assert!(matches!(err, FlowDefError::FormatMismatch { .. }), "got: {err:?}");
+        let err = resolve_mxl_flow_meta("", FlowFormat::Audio, Some(&video_flow_def(UUID_A)))
+            .unwrap_err();
+        assert!(
+            matches!(err, FlowDefError::FormatMismatch { .. }),
+            "got: {err:?}"
+        );
     }
 
     #[test]
@@ -972,7 +993,10 @@ mod tests {
         )
         .unwrap();
         let v = parse_value(&spliced);
-        assert_eq!(v["tags"]["urn:x-nvnmos:tag:name"], serde_json::json!(["new-name"]));
+        assert_eq!(
+            v["tags"]["urn:x-nvnmos:tag:name"],
+            serde_json::json!(["new-name"])
+        );
         assert_eq!(
             v["tags"]["urn:x-nvnmos:tag:mxl-domain-id"],
             serde_json::json!([DOMAIN_ID])
@@ -996,7 +1020,10 @@ mod tests {
         )
         .unwrap();
         let v = parse_value(&spliced);
-        assert_eq!(v["tags"]["urn:x-nvnmos:tag:name"], serde_json::json!(["foo"]));
+        assert_eq!(
+            v["tags"]["urn:x-nvnmos:tag:name"],
+            serde_json::json!(["foo"])
+        );
     }
 
     #[test]
@@ -1014,7 +1041,11 @@ mod tests {
         .unwrap();
         let v = parse_value(&spliced);
         assert!(
-            v["tags"].as_object().unwrap().get("urn:x-nvnmos:tag:caps").is_none(),
+            v["tags"]
+                .as_object()
+                .unwrap()
+                .get("urn:x-nvnmos:tag:caps")
+                .is_none(),
             "tag should be removed; got {v}"
         );
     }
@@ -1036,7 +1067,10 @@ mod tests {
             .expect("caps tag must be an array");
         // libnvnmos's rule is "present + non-empty array means wide";
         // assert that's what we wrote.
-        assert!(!arr.is_empty(), "wide-mode array must be non-empty; got {v}");
+        assert!(
+            !arr.is_empty(),
+            "wide-mode array must be non-empty; got {v}"
+        );
     }
 
     #[test]
@@ -1068,7 +1102,10 @@ mod tests {
         let v = parse_value(&still_without);
         // No tags object was needed, so none should have been
         // synthesised either.
-        assert!(v.get("tags").is_none(), "auto must not synthesise tags; got {v}");
+        assert!(
+            v.get("tags").is_none(),
+            "auto must not synthesise tags; got {v}"
+        );
     }
 
     #[test]
@@ -1101,11 +1138,7 @@ mod tests {
 
     const DOMAIN_ID: &str = "1ac254d9-c9be-475a-93a7-f80b9c1063a8";
 
-    fn input<'a>(
-        flow_id: &'a str,
-        name: &'a str,
-        caps: &'a gst::Caps,
-    ) -> FlowDefBuildInput<'a> {
+    fn input<'a>(flow_id: &'a str, name: &'a str, caps: &'a gst::Caps) -> FlowDefBuildInput<'a> {
         FlowDefBuildInput {
             flow_id,
             name,
@@ -1123,9 +1156,8 @@ mod tests {
 
     #[test]
     fn build_video_v210_minimal() {
-        let caps = caps_from_str(
-            "video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001",
-        );
+        let caps =
+            caps_from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001");
         let json = from_caps(&input(UUID_A, "cam-1", &caps)).unwrap();
         let v = parse(&json);
         assert_eq!(v["id"], UUID_A);
@@ -1135,8 +1167,14 @@ mod tests {
         assert_eq!(v["frame_height"], 1080);
         assert_eq!(v["grain_rate"]["numerator"], 30000);
         assert_eq!(v["grain_rate"]["denominator"], 1001);
-        assert_eq!(v["label"], "cam-1", "label falls back to name when property is empty");
-        assert_eq!(v["description"], "", "description is emitted even when empty");
+        assert_eq!(
+            v["label"], "cam-1",
+            "label falls back to name when property is empty"
+        );
+        assert_eq!(
+            v["description"], "",
+            "description is emitted even when empty"
+        );
         assert_eq!(v["parents"], serde_json::json!([]));
         assert!(
             v["tags"]["urn:x-nmos:tag:grouphint/v1.0"].is_null(),
@@ -1152,7 +1190,10 @@ mod tests {
             serde_json::json!([DOMAIN_ID]),
             "libnvnmos requires the mxl-domain-id tag",
         );
-        assert!(v.get("interlace_mode").is_none(), "no caps field → no interlace_mode emitted");
+        assert!(
+            v.get("interlace_mode").is_none(),
+            "no caps field → no interlace_mode emitted"
+        );
         assert_eq!(v["colorspace"], "BT709", "BT709 default for v210");
         let components = v["components"].as_array().expect("components is an array");
         assert_eq!(components.len(), 3, "Y/Cb/Cr triple");
@@ -1177,16 +1218,18 @@ mod tests {
         })
         .unwrap();
         let v = parse(&json);
-        assert_eq!(v["label"], "Studio A v210", "property wins over name fallback");
+        assert_eq!(
+            v["label"], "Studio A v210",
+            "property wins over name fallback"
+        );
         assert_eq!(v["description"], "long description goes here");
         assert_eq!(v["interlace_mode"], "interlaced_tff");
     }
 
     #[test]
     fn build_audio_f32le_minimal() {
-        let caps = caps_from_str(
-            "audio/x-raw,format=F32LE,rate=48000,channels=2,layout=interleaved",
-        );
+        let caps =
+            caps_from_str("audio/x-raw,format=F32LE,rate=48000,channels=2,layout=interleaved");
         let json = from_caps(&input(UUID_A, "mic-1", &caps)).unwrap();
         let v = parse(&json);
         assert_eq!(v["format"], "urn:x-nmos:format:audio");
@@ -1195,8 +1238,14 @@ mod tests {
         assert_eq!(v["sample_rate"]["denominator"], 1);
         assert_eq!(v["channel_count"], 2);
         assert_eq!(v["bit_depth"], 32);
-        assert_eq!(v["label"], "mic-1", "label falls back to name when property is empty");
-        assert_eq!(v["description"], "", "description is emitted even when empty");
+        assert_eq!(
+            v["label"], "mic-1",
+            "label falls back to name when property is empty"
+        );
+        assert_eq!(
+            v["description"], "",
+            "description is emitted even when empty"
+        );
         assert!(
             v["tags"]["urn:x-nmos:tag:grouphint/v1.0"].is_null(),
             "group hint tag omitted when property is unset",
@@ -1207,8 +1256,7 @@ mod tests {
 
     #[test]
     fn from_caps_emits_group_hint_when_set() {
-        let caps =
-            caps_from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=25/1");
+        let caps = caps_from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=25/1");
         let json = from_caps(&FlowDefBuildInput {
             group_hint: "SDI 1:Video",
             ..input(UUID_A, "cam-1", &caps)
@@ -1261,8 +1309,17 @@ mod tests {
         let caps = caps_from_str("meta/x-st-2038");
         let err = from_caps(&input(UUID_A, "anc-1", &caps)).unwrap_err();
         let msg = err.to_string();
-        assert!(matches!(err, FlowDefError::MissingCapsField { field: "framerate", .. }));
-        assert!(msg.contains("capsfilter"), "missing-framerate error guides the user: {msg}");
+        assert!(matches!(
+            err,
+            FlowDefError::MissingCapsField {
+                field: "framerate",
+                ..
+            }
+        ));
+        assert!(
+            msg.contains("capsfilter"),
+            "missing-framerate error guides the user: {msg}"
+        );
     }
 
     #[test]
@@ -1271,7 +1328,10 @@ mod tests {
             caps_from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001");
         let json = from_caps(&input("", "cam-1", &caps)).expect("registration synthesis");
         let v = parse(&json);
-        assert!(v.get("id").is_none(), "empty flow_id must omit top-level `id`");
+        assert!(
+            v.get("id").is_none(),
+            "empty flow_id must omit top-level `id`"
+        );
         assert_eq!(v["format"], "urn:x-nmos:format:video");
     }
 
@@ -1292,7 +1352,10 @@ mod tests {
             ..input(UUID_A, "cam-1", &caps)
         })
         .unwrap_err();
-        assert!(matches!(err, FlowDefError::MissingMxlDomainId), "got: {err:?}");
+        assert!(
+            matches!(err, FlowDefError::MissingMxlDomainId),
+            "got: {err:?}"
+        );
     }
 
     #[test]
@@ -1301,7 +1364,13 @@ mod tests {
             caps_from_str("video/x-raw,format=I420,width=1920,height=1080,framerate=30000/1001");
         let err = from_caps(&input(UUID_A, "cam-1", &caps)).unwrap_err();
         assert!(
-            matches!(err, FlowDefError::UnsupportedCapsValue { field: "format", .. }),
+            matches!(
+                err,
+                FlowDefError::UnsupportedCapsValue {
+                    field: "format",
+                    ..
+                }
+            ),
             "got: {err:?}"
         );
     }
@@ -1310,7 +1379,10 @@ mod tests {
     fn unsupported_caps_is_hard_error() {
         let caps = caps_from_str("application/x-rtp,media=video");
         let err = from_caps(&input(UUID_A, "cam-1", &caps)).unwrap_err();
-        assert!(matches!(err, FlowDefError::UnsupportedCaps(_)), "got: {err:?}");
+        assert!(
+            matches!(err, FlowDefError::UnsupportedCaps(_)),
+            "got: {err:?}"
+        );
     }
 
     #[test]
@@ -1318,7 +1390,13 @@ mod tests {
         let caps = caps_from_str("video/x-raw,format=v210,width=1920,height=1080");
         let err = from_caps(&input(UUID_A, "cam-1", &caps)).unwrap_err();
         assert!(
-            matches!(err, FlowDefError::MissingCapsField { field: "framerate", .. }),
+            matches!(
+                err,
+                FlowDefError::MissingCapsField {
+                    field: "framerate",
+                    ..
+                }
+            ),
             "got: {err:?}",
         );
     }
@@ -1448,7 +1526,10 @@ mod tests {
         #[test]
         fn unsupported_media_type_is_error() {
             let err = super::caps_from(r#"{"media_type":"image/jpeg"}"#).unwrap_err();
-            assert!(matches!(err, FlowDefCapsError::UnsupportedMediaType(_)), "got: {err:?}");
+            assert!(
+                matches!(err, FlowDefCapsError::UnsupportedMediaType(_)),
+                "got: {err:?}"
+            );
         }
 
         #[test]
@@ -1478,14 +1559,18 @@ mod tests {
         #[test]
         fn parse_error_is_surfaced() {
             let err = super::caps_from("not json").unwrap_err();
-            assert!(matches!(err, FlowDefCapsError::Parse { .. }), "got: {err:?}");
+            assert!(
+                matches!(err, FlowDefCapsError::Parse { .. }),
+                "got: {err:?}"
+            );
         }
 
         #[test]
         fn round_trip_with_build_from_caps_video() {
             init_gst();
-            let original_caps =
-                caps_from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001");
+            let original_caps = caps_from_str(
+                "video/x-raw,format=v210,width=1920,height=1080,framerate=30000/1001",
+            );
             let json = from_caps(&input(UUID_A, "cam-1", &original_caps)).unwrap();
             let derived = super::caps_from(&json).unwrap();
             // Both should agree on the structure name + the essence

--- a/rust/gst-nmos-rs/src/iface.rs
+++ b/rust/gst-nmos-rs/src/iface.rs
@@ -94,10 +94,7 @@ pub(crate) fn iface_name_for_ip(_target: std::net::IpAddr) -> Option<String> {
 }
 
 #[cfg(unix)]
-fn port_id_for_interface(
-    addrs: &[nix::ifaddrs::InterfaceAddress],
-    ifname: &str,
-) -> Option<String> {
+fn port_id_for_interface(addrs: &[nix::ifaddrs::InterfaceAddress], ifname: &str) -> Option<String> {
     for ifa in addrs {
         if ifa.interface_name != ifname {
             continue;
@@ -177,7 +174,10 @@ mod tests {
         let Some(name) = iface_name_for_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)) else {
             return;
         };
-        assert!(!name.is_empty(), "`::1` resolution must yield a non-empty name");
+        assert!(
+            !name.is_empty(),
+            "`::1` resolution must yield a non-empty name"
+        );
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -68,11 +68,11 @@ use gstreamer as gst;
 use gstreamer::prelude::*;
 
 use crate::nvdsudp::packetization::{
-    self, Packetization, ANC_HEADER_SIZE, AUDIO_HEADER_SIZE, VIDEO_HEADER_SIZE,
+    self, ANC_HEADER_SIZE, AUDIO_HEADER_SIZE, Packetization, VIDEO_HEADER_SIZE,
 };
 use crate::nvdsudp::sdp_file::SdpFileGuard;
-use crate::session::udp::types::{UdpLeg, UdpMedia};
 use crate::session::udp::UdpVariant;
+use crate::session::udp::types::{UdpLeg, UdpMedia};
 use crate::types::FlowFormat;
 
 /// Name of the permanent anchor element inside every `nmossink` /
@@ -172,16 +172,16 @@ pub(crate) fn rebuild_chain_with_opts(
         gst::PadDirection::Src => ("sink", "src"),
         _ => bail!("ghost pad direction is neither Sink nor Src"),
     };
-    let probe_pad = anchor.static_pad(probe_pad_name).ok_or_else(|| {
-        anyhow!("anchor `{ANCHOR_NAME}` missing `{probe_pad_name}` pad")
-    })?;
+    let probe_pad = anchor
+        .static_pad(probe_pad_name)
+        .ok_or_else(|| anyhow!("anchor `{ANCHOR_NAME}` missing `{probe_pad_name}` pad"))?;
 
     if opts.drain_downstream {
         flush_external_of_ghost(cat, ghost);
     }
 
-    let probe_id = block_and_wait(cat, &probe_pad)
-        .context("blocking anchor pad before chain rebuild")?;
+    let probe_id =
+        block_and_wait(cat, &probe_pad).context("blocking anchor pad before chain rebuild")?;
 
     // Always remove the probe on the way out, even on error, so the
     // pipeline can drain — a stuck probe with no chain behind it is a
@@ -205,7 +205,14 @@ pub(crate) fn rebuild_chain(
     new_chain: &gst::Element,
     pad_name: &str,
 ) -> Result<(), anyhow::Error> {
-    rebuild_chain_with_opts(cat, bin, ghost, new_chain, pad_name, RebuildChainOpts::default())
+    rebuild_chain_with_opts(
+        cat,
+        bin,
+        ghost,
+        new_chain,
+        pad_name,
+        RebuildChainOpts::default(),
+    )
 }
 
 /// Inner half of [`rebuild_chain_with_opts`] — runs with the anchor pad held
@@ -232,9 +239,9 @@ fn swap_chain_inner(
         gst::PadDirection::Src => ("sink", "src"),
         _ => unreachable!("checked in rebuild_chain"),
     };
-    let link_pad = anchor.static_pad(link_pad_name).ok_or_else(|| {
-        anyhow!("anchor `{ANCHOR_NAME}` missing `{link_pad_name}` pad")
-    })?;
+    let link_pad = anchor
+        .static_pad(link_pad_name)
+        .ok_or_else(|| anyhow!("anchor `{ANCHOR_NAME}` missing `{link_pad_name}` pad"))?;
 
     // The anchor's chain-side pad usually has a peer — the chain we're
     // about to replace. But if a previous `rebuild_chain` errored out
@@ -261,7 +268,10 @@ fn swap_chain_inner(
             _ => unreachable!(),
         }
         .map_err(|e| {
-            anyhow!("unlinking anchor from old chain `{}`: {e}", old_chain.name())
+            anyhow!(
+                "unlinking anchor from old chain `{}`: {e}",
+                old_chain.name()
+            )
         })?;
 
         stop_chain(cat, &old_chain)
@@ -279,12 +289,12 @@ fn swap_chain_inner(
     bin.add(new_chain)
         .with_context(|| format!("adding new chain `{}`", new_chain.name()))?;
 
-    let new_chain_pad = new_chain
-        .static_pad(new_chain_pad_name)
-        .ok_or_else(|| anyhow!(
+    let new_chain_pad = new_chain.static_pad(new_chain_pad_name).ok_or_else(|| {
+        anyhow!(
             "new chain `{}` missing `{new_chain_pad_name}` pad",
             new_chain.name(),
-        ))?;
+        )
+    })?;
 
     // The anchor retains sticky events (e.g. CAPS) from the previous
     // inner chain after unlink. Default pad-link caps/template checks
@@ -396,7 +406,10 @@ fn block_and_wait(
         }
     }
     drop(f);
-    gst::debug!(cat, "rebuild_chain: anchor pad `{pad_name}` is blocked + idle");
+    gst::debug!(
+        cat,
+        "rebuild_chain: anchor pad `{pad_name}` is blocked + idle"
+    );
     Ok(probe_id)
 }
 
@@ -473,10 +486,7 @@ fn wait_for_chain_state(
 /// Take `chain` to `Null` with a bounded wait. Called from the
 /// `call_async` worker while the anchor block probe is installed, so
 /// an unbounded `set_state(Null)` would wedge the data path.
-fn stop_chain(
-    cat: &gst::DebugCategory,
-    chain: &gst::Element,
-) -> Result<(), anyhow::Error> {
+fn stop_chain(cat: &gst::DebugCategory, chain: &gst::Element) -> Result<(), anyhow::Error> {
     let name = chain.name();
     chain
         .set_state(gst::State::Null)
@@ -625,9 +635,7 @@ pub(crate) fn build_fake_sink(caps: Option<&gst::Caps>) -> Result<gst::Element, 
 /// real activation. Callers are expected to pass `Some(caps)`
 /// whenever a `caps` property, `transport-file`, or
 /// `transport-file-path` source is available.
-pub(crate) fn build_fake_src(
-    caps: Option<&gst::Caps>,
-) -> Result<gst::Element, anyhow::Error> {
+pub(crate) fn build_fake_src(caps: Option<&gst::Caps>) -> Result<gst::Element, anyhow::Error> {
     let elem = gst::ElementFactory::make("appsrc")
         .name("nmossrc-fake")
         .property("is-live", true)
@@ -697,7 +705,10 @@ pub(crate) struct NvDsUdpSrcChain {
     pub transport: gst::Element,
 }
 
-pub(crate) fn build_mxlsink(domain_path: &str, flow_id: &str) -> Result<MxlSinkChain, anyhow::Error> {
+pub(crate) fn build_mxlsink(
+    domain_path: &str,
+    flow_id: &str,
+) -> Result<MxlSinkChain, anyhow::Error> {
     require_mxl_factory("mxlsink")?;
     let mxlsink = gst::ElementFactory::make("mxlsink")
         .name("nmossink-mxl")
@@ -705,9 +716,7 @@ pub(crate) fn build_mxlsink(domain_path: &str, flow_id: &str) -> Result<MxlSinkC
         .property("flow-id", flow_id)
         .build()
         .with_context(|| {
-            format!(
-                "instantiating `mxlsink` with domain={domain_path:?}, flow-id={flow_id}"
-            )
+            format!("instantiating `mxlsink` with domain={domain_path:?}, flow-id={flow_id}")
         })?;
     Ok(MxlSinkChain {
         bin: mxlsink.clone(),
@@ -752,9 +761,7 @@ pub(crate) fn build_mxlsrc(
         .property(prop, flow_id)
         .build()
         .with_context(|| {
-            format!(
-                "instantiating `mxlsrc` with domain={domain_path:?}, {prop}={flow_id}"
-            )
+            format!("instantiating `mxlsrc` with domain={domain_path:?}, {prop}={flow_id}")
         })?;
 
     let Some(caps) = advertise_caps else {
@@ -887,9 +894,7 @@ pub(crate) fn build_udpsink(
         .get::<i32>("payload")
         .map_err(|e| anyhow!("UdpMedia.rtp_caps missing `payload` field: {e}"))?;
     if !(0..=127).contains(&pt) {
-        bail!(
-            "UdpMedia.rtp_caps `payload`={pt} out of valid RTP payload-type range 0..=127"
-        );
+        bail!("UdpMedia.rtp_caps `payload`={pt} out of valid RTP payload-type range 0..=127");
     }
     let ptime_ns = if matches!(media.format, FlowFormat::Audio) {
         ptime_ns_from_rtp_caps(rtp_s)?
@@ -902,9 +907,7 @@ pub(crate) fn build_udpsink(
         .name("nmossink-payloader")
         .property("pt", pt as u32)
         .build()
-        .with_context(|| {
-            format!("instantiating payloader `{payloader_factory}` (pt={pt})")
-        })?;
+        .with_context(|| format!("instantiating payloader `{payloader_factory}` (pt={pt})"))?;
     if let Some(ns) = ptime_ns {
         payloader.set_property("min-ptime", ns);
         payloader.set_property("max-ptime", ns);
@@ -1323,9 +1326,7 @@ pub(crate) fn build_udpsrc(
                 .property("caps", caps)
                 .build()
                 .map_err(|e| {
-                    anyhow!(
-                        "instantiating `{tail_factory}` for nmossrc caps advertisement: {e}"
-                    )
+                    anyhow!("instantiating `{tail_factory}` for nmossrc caps advertisement: {e}")
                 })?;
             bin.add(&tail)
                 .map_err(|e| anyhow!("adding tail {tail_factory} to inner bin: {e}"))?;
@@ -1449,10 +1450,9 @@ pub(crate) fn build_nvdsudpsink(
     let sdp_for_sink = if media.secondary.is_none()
         && crate::sdp::sdp_media_block_count(sdp_text).is_ok_and(|n| n > 1)
     {
-        crate::sdp::normalise_to_single_active_leg(sdp_text)
-            .with_context(|| {
-                "nvdsudpsink: normalising dual-leg SDP with only one leg active to single-leg SDP"
-            })?
+        crate::sdp::normalise_to_single_active_leg(sdp_text).with_context(
+            || "nvdsudpsink: normalising dual-leg SDP with only one leg active to single-leg SDP",
+        )?
     } else {
         sdp_text.to_owned()
     };
@@ -1738,9 +1738,9 @@ pub(crate) fn build_initial(
     };
     link_result.map_err(|e| glib::bool_error!("linking anchor to initial fake chain: {e}"))?;
 
-    let outer_pad = anchor
-        .static_pad(outer_pad_name)
-        .ok_or_else(|| glib::bool_error!("anchor `{ANCHOR_NAME}` missing `{outer_pad_name}` pad"))?;
+    let outer_pad = anchor.static_pad(outer_pad_name).ok_or_else(|| {
+        glib::bool_error!("anchor `{ANCHOR_NAME}` missing `{outer_pad_name}` pad")
+    })?;
     let ghost = gst::GhostPad::builder(direction).name(pad_name).build();
     ghost
         .set_target(Some(&outer_pad))
@@ -1750,7 +1750,6 @@ pub(crate) fn build_initial(
         .map_err(|e| glib::bool_error!("activating ghost pad: {e}"))?;
     Ok(ghost)
 }
-
 
 /// Apply a `GstStructure` bag of GObject property overrides to a freshly
 /// built inner transport source or sink, payloader, or depayloader element.
@@ -1922,9 +1921,9 @@ pub(crate) fn apply_nvdsudp_src_inner_properties(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::LazyLock;
     use crate::session::udp::types::UdpLeg;
     use std::str::FromStr;
+    use std::sync::LazyLock;
 
     use crate::test_support::init_gst;
 
@@ -1986,10 +1985,8 @@ mod tests {
                  encoding-name=SMPTE291,payload=100",
             )
             .expect("static rtp caps parse"),
-            caps: gst::Caps::from_str(
-                "meta/x-st-2038,framerate=60/1",
-            )
-            .expect("static raw caps parse"),
+            caps: gst::Caps::from_str("meta/x-st-2038,framerate=60/1")
+                .expect("static raw caps parse"),
             bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
@@ -2027,10 +2024,8 @@ mod tests {
                  encoding-name=JXSV,payload=96",
             )
             .expect("static rtp caps parse"),
-            caps: gst::Caps::from_str(
-                "image/x-jxsc,width=1920,height=1080,framerate=50/1",
-            )
-            .expect("static raw caps parse"),
+            caps: gst::Caps::from_str("image/x-jxsc,width=1920,height=1080,framerate=50/1")
+                .expect("static raw caps parse"),
             bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
@@ -2081,8 +2076,8 @@ mod tests {
     #[test]
     fn build_fake_sink_with_caps_is_capsfilter_bin() {
         init_gst();
-        let caps = gst::Caps::from_str("audio/x-raw,format=(string)S24BE,channels=(int)2")
-            .expect("caps");
+        let caps =
+            gst::Caps::from_str("audio/x-raw,format=(string)S24BE,channels=(int)2").expect("caps");
         let chain = build_fake_sink(Some(&caps)).expect("capped fake sink");
         let bin = chain.downcast::<gst::Bin>().expect("returns a bin");
         assert!(
@@ -2112,7 +2107,10 @@ mod tests {
     fn build_udpsink_video_v1_uses_rtpvrawpay_and_udpsink() {
         let chain = build_udpsink(&minimal_udp_media(), UdpVariant::V1)
             .expect("V1 video sender chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let pay = child(&bin, "nmossink-payloader");
         assert_eq!(
             pay.factory().expect("payloader has a factory").name(),
@@ -2125,7 +2123,10 @@ mod tests {
             "payloader `pt` must match rtp_caps `payload`",
         );
         let udpsink = child(&bin, "nmossink-udpsink");
-        assert_eq!(udpsink.factory().expect("udpsink has a factory").name(), "udpsink");
+        assert_eq!(
+            udpsink.factory().expect("udpsink has a factory").name(),
+            "udpsink"
+        );
         assert_eq!(udpsink.property::<String>("host"), "239.1.1.1");
         assert_eq!(udpsink.property::<i32>("port"), 5004);
         assert!(udpsink.property::<bool>("sync"));
@@ -2163,7 +2164,10 @@ mod tests {
     fn build_udpsink_audio_l24_pins_min_max_ptime_ns() {
         let chain = build_udpsink(&audio_l24_ptime_media(), UdpVariant::V1)
             .expect("L24 audio sender chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let pay = child(&bin, "nmossink-payloader");
         assert_eq!(
             pay.factory().expect("payloader has a factory").name(),
@@ -2195,10 +2199,17 @@ mod tests {
              encoding-params=(string)2,payload=98",
         )
         .expect("static rtp caps parse");
-        let chain = build_udpsink(&media, UdpVariant::V1).expect("L16 audio sender chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let chain =
+            build_udpsink(&media, UdpVariant::V1).expect("L16 audio sender chain must construct");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let pay = child(&bin, "nmossink-payloader");
-        assert_eq!(pay.factory().expect("payloader has a factory").name(), "rtpL16pay");
+        assert_eq!(
+            pay.factory().expect("payloader has a factory").name(),
+            "rtpL16pay"
+        );
     }
 
     #[test]
@@ -2211,9 +2222,13 @@ mod tests {
         // never fails when V1 is present, even if no V2 sibling
         // is"; the test accepting either factory name keeps it
         // valid in both environments.
-        let chain = build_udpsink(&audio_l24_ptime_media(), UdpVariant::V2)
-            .expect("V2 L24 chain must construct (picks `rtpL24pay2` if present, else `rtpL24pay`)");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let chain = build_udpsink(&audio_l24_ptime_media(), UdpVariant::V2).expect(
+            "V2 L24 chain must construct (picks `rtpL24pay2` if present, else `rtpL24pay`)",
+        );
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let pay = child(&bin, "nmossink-payloader");
         let factory_name = pay.factory().expect("payloader has a factory").name();
         assert!(
@@ -2237,7 +2252,11 @@ mod tests {
              tolerate hand-built caps from non-SDP call sites",
         );
         assert_eq!(
-            chain.pay.factory().map(|f| f.name().to_string()).unwrap_or_default(),
+            chain
+                .pay
+                .factory()
+                .map(|f| f.name().to_string())
+                .unwrap_or_default(),
             "rtpL24pay",
             "lower-case encoding-name must still resolve to `rtpL24pay`",
         );
@@ -2255,8 +2274,7 @@ mod tests {
         );
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("unsupported essence")
-                && msg.contains("encoding-name=`H264`"),
+            msg.contains("unsupported essence") && msg.contains("encoding-name=`H264`"),
             "expected unsupported-essence attribution: {msg}",
         );
     }
@@ -2293,7 +2311,10 @@ mod tests {
         }
         let chain = build_udpsink(&anc_smpte291_media(), UdpVariant::V1)
             .expect("ANC sender chain must construct when rtpsmpte291pay is available");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let pay = child(&bin, "nmossink-payloader");
         assert_eq!(
             pay.factory().expect("payloader has a factory").name(),
@@ -2315,7 +2336,10 @@ mod tests {
         }
         let chain = build_udpsink(&jxsv_media(), UdpVariant::V1)
             .expect("JPEG XS sender chain must construct when rtpjxsvpay is available");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let pay = child(&bin, "nmossink-payloader");
         assert_eq!(
             pay.factory().expect("payloader has a factory").name(),
@@ -2335,12 +2359,7 @@ mod tests {
         if !chain.pay.has_property("max-codestream-bitrate") {
             return;
         }
-        apply_format_bit_rate_to_jxsv_payloader(
-            &jxsv_media(),
-            &chain.pay,
-            110_000,
-            None,
-        );
+        apply_format_bit_rate_to_jxsv_payloader(&jxsv_media(), &chain.pay, 110_000, None);
         assert_eq!(
             chain.pay.property::<u64>("max-codestream-bitrate"),
             110_000_000,
@@ -2384,9 +2403,13 @@ mod tests {
         // variant choice is essence-orthogonal for ANC, unlike RAW
         // / L16 / L24 where V2 prefers the `*pay2` form.
         for variant in [UdpVariant::V1, UdpVariant::V2] {
-            let chain = build_udpsink(&anc_smpte291_media(), variant)
-                .unwrap_or_else(|e| panic!("ANC sender chain must construct for {variant:?}: {e:#}"));
-            let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+            let chain = build_udpsink(&anc_smpte291_media(), variant).unwrap_or_else(|e| {
+                panic!("ANC sender chain must construct for {variant:?}: {e:#}")
+            });
+            let bin = chain
+                .bin
+                .downcast::<gst::Bin>()
+                .expect("returned element is a Bin");
             let pay = child(&bin, "nmossink-payloader");
             assert_eq!(
                 pay.factory().expect("payloader has a factory").name(),
@@ -2399,10 +2422,9 @@ mod tests {
     #[test]
     fn build_udpsink_rejects_missing_payload() {
         let mut media = minimal_udp_media();
-        media.rtp_caps = gst::Caps::from_str(
-            "application/x-rtp,media=video,clock-rate=90000,encoding-name=RAW",
-        )
-        .expect("static rtp caps parse");
+        media.rtp_caps =
+            gst::Caps::from_str("application/x-rtp,media=video,clock-rate=90000,encoding-name=RAW")
+                .expect("static rtp caps parse");
         let err = build_udpsink(&media, UdpVariant::V1)
             .expect_err("rtp_caps without `payload` must be rejected");
         let msg = format!("{err:#}");
@@ -2480,7 +2502,10 @@ mod tests {
     fn build_udpsink_pins_multicast_iface_when_destination_is_multicast() {
         let chain = build_udpsink(&multicast_udp_media_with_loopback_iface(), UdpVariant::V1)
             .expect("multicast sender chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsink = child(&bin, "nmossink-udpsink");
         let iface = udpsink.property::<String>("multicast-iface");
         assert!(
@@ -2496,9 +2521,12 @@ mod tests {
         let mut media = minimal_udp_media();
         media.primary.destination_ip = "192.0.2.50".to_owned();
         media.primary.interface_ip = Some("127.0.0.1".to_owned());
-        let chain = build_udpsink(&media, UdpVariant::V1)
-            .expect("unicast sender chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let chain =
+            build_udpsink(&media, UdpVariant::V1).expect("unicast sender chain must construct");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsink = child(&bin, "nmossink-udpsink");
         assert_eq!(
             udpsink.property::<Option<String>>("multicast-iface"),
@@ -2512,9 +2540,15 @@ mod tests {
     fn build_udpsrc_video_v1_uses_rtpvrawdepay_and_udpsrc() {
         let chain = build_udpsrc(&minimal_udp_media(), UdpVariant::V1, None)
             .expect("V1 video receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
-        assert_eq!(udpsrc.factory().expect("udpsrc has a factory").name(), "udpsrc");
+        assert_eq!(
+            udpsrc.factory().expect("udpsrc has a factory").name(),
+            "udpsrc"
+        );
         assert_eq!(udpsrc.property::<String>("address"), "239.1.1.1");
         assert_eq!(udpsrc.property::<i32>("port"), 5004);
         let caps_on_udpsrc = udpsrc
@@ -2539,7 +2573,10 @@ mod tests {
     fn build_udpsrc_audio_l24_uses_rtpl24depay() {
         let chain = build_udpsrc(&audio_l24_ptime_media(), UdpVariant::V1, None)
             .expect("L24 audio receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let depay = child(&bin, "nmossrc-depayloader");
         assert_eq!(
             depay.factory().expect("depayloader has a factory").name(),
@@ -2558,7 +2595,10 @@ mod tests {
         .expect("static rtp caps parse");
         let chain = build_udpsrc(&media, UdpVariant::V1, None)
             .expect("L16 audio receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let depay = child(&bin, "nmossrc-depayloader");
         assert_eq!(
             depay.factory().expect("depayloader has a factory").name(),
@@ -2568,9 +2608,16 @@ mod tests {
 
     #[test]
     fn build_udpsrc_pins_multicast_iface_when_destination_is_multicast() {
-        let chain = build_udpsrc(&multicast_udp_media_with_loopback_iface(), UdpVariant::V1, None)
-            .expect("multicast receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let chain = build_udpsrc(
+            &multicast_udp_media_with_loopback_iface(),
+            UdpVariant::V1,
+            None,
+        )
+        .expect("multicast receiver chain must construct");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
         let iface = udpsrc.property::<String>("multicast-iface");
         assert!(
@@ -2588,21 +2635,24 @@ mod tests {
         media.primary.interface_ip = Some("127.0.0.1".to_owned());
         let chain = build_udpsrc(&media, UdpVariant::V1, None)
             .expect("unicast receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
-        assert_eq!(
-            udpsrc.property::<Option<String>>("multicast-iface"),
-            None,
-        );
+        assert_eq!(udpsrc.property::<Option<String>>("multicast-iface"), None,);
     }
 
     #[test]
     fn build_udpsrc_pins_ssm_source_filter_via_multicast_source() {
         let mut media = multicast_udp_media_with_loopback_iface();
         media.primary.source_ip = Some("192.0.2.100".to_owned());
-        let chain = build_udpsrc(&media, UdpVariant::V1, None)
-            .expect("SSM receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let chain =
+            build_udpsrc(&media, UdpVariant::V1, None).expect("SSM receiver chain must construct");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
         assert_eq!(
             udpsrc.property::<String>("multicast-source"),
@@ -2619,7 +2669,10 @@ mod tests {
         media.primary.source_ip = Some("192.0.2.100".to_owned());
         let chain = build_udpsrc(&media, UdpVariant::V1, None)
             .expect("unicast receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
         assert_eq!(
             udpsrc.property::<Option<String>>("multicast-source"),
@@ -2639,13 +2692,15 @@ mod tests {
         // framerate (and any other field the depay leaves wrong),
         // not just intersect. `capssetter` is the gst-plugins-good
         // element that does exactly that.
-        let advertise = gst::Caps::from_str(
-            "video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1",
-        )
-        .unwrap();
+        let advertise =
+            gst::Caps::from_str("video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1")
+                .unwrap();
         let chain = build_udpsrc(&minimal_udp_media(), UdpVariant::V1, Some(&advertise))
             .expect("V1 video receiver chain with advertise_caps must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let tail = child(&bin, "nmossrc-caps");
         assert_eq!(
             tail.factory().unwrap().name(),
@@ -2673,7 +2728,10 @@ mod tests {
         .unwrap();
         let chain = build_udpsrc(&audio_l24_ptime_media(), UdpVariant::V1, Some(&advertise))
             .expect("audio receiver chain with advertise_caps must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let tail = child(&bin, "nmossrc-caps");
         assert_eq!(
             tail.factory().unwrap().name(),
@@ -2695,12 +2753,11 @@ mod tests {
         )
         .expect("static rtp caps parse");
         let err = build_udpsrc(&media, UdpVariant::V1, None).expect_err(
-            "H264 must be rejected (today only RAW/JXSV/L24/L16/SMPTE291 are supported)"
+            "H264 must be rejected (today only RAW/JXSV/L24/L16/SMPTE291 are supported)",
         );
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("unsupported essence")
-                && msg.contains("encoding-name=`H264`"),
+            msg.contains("unsupported essence") && msg.contains("encoding-name=`H264`"),
             "expected unsupported-essence attribution: {msg}",
         );
     }
@@ -2712,7 +2769,10 @@ mod tests {
         }
         let chain = build_udpsrc(&anc_smpte291_media(), UdpVariant::V1, None)
             .expect("ANC receiver chain must construct when rtpsmpte291depay is available");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let depay = child(&bin, "nmossrc-depayloader");
         assert_eq!(
             depay.factory().expect("depayloader has a factory").name(),
@@ -2731,7 +2791,10 @@ mod tests {
         // with the downstream itself; no `capssetter` tail is inserted.
         let chain = build_udpsrc(&media, UdpVariant::V1, Some(&media.caps))
             .expect("JPEG XS receiver chain must construct when rtpjxsvdepay is available");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let depay = child(&bin, "nmossrc-depayloader");
         assert_eq!(
             depay.factory().expect("depayloader has a factory").name(),
@@ -2755,9 +2818,13 @@ mod tests {
         // accidentally route ANC down a variant-suffixed path that
         // doesn't exist.
         for variant in [UdpVariant::V1, UdpVariant::V2] {
-            let chain = build_udpsrc(&anc_smpte291_media(), variant, None)
-                .unwrap_or_else(|e| panic!("ANC receiver chain must construct for {variant:?}: {e:#}"));
-            let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+            let chain = build_udpsrc(&anc_smpte291_media(), variant, None).unwrap_or_else(|e| {
+                panic!("ANC receiver chain must construct for {variant:?}: {e:#}")
+            });
+            let bin = chain
+                .bin
+                .downcast::<gst::Bin>()
+                .expect("returned element is a Bin");
             let depay = child(&bin, "nmossrc-depayloader");
             assert_eq!(
                 depay.factory().expect("depayloader has a factory").name(),
@@ -2789,8 +2856,8 @@ mod tests {
         if !nvdsudp_available() {
             return;
         }
-        let chain =
-            build_nvdsudpsink(&anc_smpte291_media(), ANC_NVDSUDP_SDP).expect("ANC nvdsudpsink chain");
+        let chain = build_nvdsudpsink(&anc_smpte291_media(), ANC_NVDSUDP_SDP)
+            .expect("ANC nvdsudpsink chain");
         // The bin wraps `capsfilter ! nvdsudpsink` so its sink pad advertises the
         // per-frame grouping `nvdsudpsink`'s own `ANY` pad can't (see the wrap in
         // build_nvdsudpsink): a `packet`/`line` peer must fail negotiation here.
@@ -2802,9 +2869,8 @@ mod tests {
         let sink_pad = chain.bin.static_pad("sink").expect("bin sink pad");
         let advertised = sink_pad.query_caps(None);
         assert!(
-            advertised.can_intersect(
-                &gst::Caps::from_str("meta/x-st-2038,alignment=frame").unwrap()
-            ),
+            advertised
+                .can_intersect(&gst::Caps::from_str("meta/x-st-2038,alignment=frame").unwrap()),
             "ANC sink bin must advertise alignment=frame, got {advertised}"
         );
         assert!(
@@ -2820,8 +2886,8 @@ mod tests {
         if !nvdsudp_available() {
             return;
         }
-        let chain = build_nvdsudpsrc(&anc_smpte291_media(), ANC_NVDSUDP_SDP)
-            .expect("ANC nvdsudpsrc chain");
+        let chain =
+            build_nvdsudpsrc(&anc_smpte291_media(), ANC_NVDSUDP_SDP).expect("ANC nvdsudpsrc chain");
         assert_eq!(chain.transport.property::<u32>("header-size"), 20);
     }
 
@@ -2832,9 +2898,7 @@ mod tests {
         }
         let mut media = anc_smpte291_media();
         media.primary.interface_ip = Some("192.0.2.11".to_owned());
-        let sdp = format!(
-            "{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",
-        );
+        let sdp = format!("{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",);
         let chain = build_nvdsudpsrc(&media, &sdp).expect("nvdsudpsrc chain");
         assert_eq!(
             chain.transport.property::<String>("ptp-src"),
@@ -2851,19 +2915,14 @@ mod tests {
         let mut media = anc_smpte291_media();
         media.primary.source_ip = Some("192.0.2.11".to_owned());
         assert!(media.primary.interface_ip.is_none());
-        let sdp = format!(
-            "{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",
-        );
+        let sdp = format!("{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",);
         let chain = build_nvdsudpsink(&media, &sdp).expect("nvdsudpsink chain");
         assert_eq!(
             chain.transport.property::<String>("local-iface-ip"),
             "192.0.2.11",
             "sender SSM source-filter source must drive local-iface-ip when x-nvnmos-iface-ip absent",
         );
-        assert_eq!(
-            chain.transport.property::<String>("ptp-src"),
-            "192.0.2.11",
-        );
+        assert_eq!(chain.transport.property::<String>("ptp-src"), "192.0.2.11",);
     }
 
     #[test]
@@ -2875,12 +2934,13 @@ mod tests {
         // SSM sender pin — must not substitute for receiver interface IP.
         media.primary.source_ip = Some("192.0.2.30".to_owned());
         assert!(media.primary.receiver_interface_ip().is_none());
-        let sdp = format!(
-            "{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",
-        );
+        let sdp = format!("{ANC_NVDSUDP_SDP}a=ts-refclk:ptp=IEEE1588-2008:traceable\r\n",);
         let chain = build_nvdsudpsrc(&media, &sdp).expect("nvdsudpsrc chain");
         assert!(
-            chain.transport.property::<Option<String>>("ptp-src").is_none(),
+            chain
+                .transport
+                .property::<Option<String>>("ptp-src")
+                .is_none(),
             "receiver ptp-src must require a=x-nvnmos-iface-ip, not source-filter source",
         );
     }
@@ -2892,9 +2952,13 @@ mod tests {
         // pins the "V2 dispatch never fails when V1 is present"
         // semantic and accepts either factory so it stays valid
         // whether or not the V2 sibling is installed.
-        let chain = build_udpsrc(&audio_l24_ptime_media(), UdpVariant::V2, None)
-            .expect("V2 L24 receiver must construct (picks `rtpL24depay2` if present, else `rtpL24depay`)");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let chain = build_udpsrc(&audio_l24_ptime_media(), UdpVariant::V2, None).expect(
+            "V2 L24 receiver must construct (picks `rtpL24depay2` if present, else `rtpL24depay`)",
+        );
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let depay = child(&bin, "nmossrc-depayloader");
         let factory_name = depay.factory().expect("depayloader has a factory").name();
         assert!(
@@ -2957,7 +3021,10 @@ mod tests {
         }
         let chain = build_udpsrc(&minimal_udp_media(), UdpVariant::V2, None)
             .expect("V2 receiver must construct against udpsrc2");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
         assert_eq!(
             udpsrc.factory().expect("udpsrc has a factory").name(),
@@ -2986,7 +3053,10 @@ mod tests {
         media.primary.source_ip = Some("192.0.2.100".to_owned());
         let chain = build_udpsrc(&media, UdpVariant::V2, None)
             .expect("V2 SSM receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
         assert_eq!(
             udpsrc.factory().expect("udpsrc has a factory").name(),
@@ -3026,9 +3096,15 @@ mod tests {
         media.primary.source_ip = Some("192.0.2.100".to_owned());
         let chain = build_udpsrc(&media, UdpVariant::V2, None)
             .expect("V2 unicast receiver chain must construct");
-        let bin = chain.bin.downcast::<gst::Bin>().expect("returned element is a Bin");
+        let bin = chain
+            .bin
+            .downcast::<gst::Bin>()
+            .expect("returned element is a Bin");
         let udpsrc = child(&bin, "nmossrc-udpsrc");
-        assert_eq!(udpsrc.factory().expect("udpsrc has a factory").name(), "udpsrc2");
+        assert_eq!(
+            udpsrc.factory().expect("udpsrc has a factory").name(),
+            "udpsrc2"
+        );
         // `udpsrc2.source-filter` has no pspec default, so unset
         // reads back as `None` (not an empty string). For unicast
         // the IP layer already filters by source, so we leave the
@@ -3105,7 +3181,10 @@ mod tests {
             return;
         };
         assert_ne!(chain.bin.as_ptr(), chain.transport.as_ptr());
-        let wrapper = chain.bin.downcast_ref::<gst::Bin>().expect("wrapper is a Bin");
+        let wrapper = chain
+            .bin
+            .downcast_ref::<gst::Bin>()
+            .expect("wrapper is a Bin");
         assert!(wrapper.by_name("nmossrc-mxl").is_some());
     }
 
@@ -3114,16 +3193,10 @@ mod tests {
         init_gst();
         let udp_sink = build_udpsink(&minimal_udp_media(), UdpVariant::V1)
             .expect("udp sink chain must construct");
-        assert_eq!(
-            udp_sink.transport.factory().unwrap().name(),
-            "udpsink",
-        );
+        assert_eq!(udp_sink.transport.factory().unwrap().name(), "udpsink",);
         let udp_src = build_udpsrc(&minimal_udp_media(), UdpVariant::V1, None)
             .expect("udp src chain must construct");
-        assert_eq!(
-            udp_src.transport.factory().unwrap().name(),
-            "udpsrc",
-        );
+        assert_eq!(udp_src.transport.factory().unwrap().name(), "udpsrc",);
         if gst::ElementFactory::find("mxlsink").is_some() {
             let mxl_sink = build_mxlsink("/tmp/domain", "00000000-0000-0000-0000-000000000004")
                 .expect("mxlsink chain must construct");
@@ -3268,7 +3341,10 @@ mod tests {
         let chain2 = build_udpsrc(&minimal_udp_media(), UdpVariant::V1, None)
             .expect("second chain must construct");
         apply_udp_src_inner_properties(test_log_cat(), "nmossrc", &chain2, None, None);
-        assert_eq!(chain2.transport.property::<i32>("buffer-size"), default_buffer_size);
+        assert_eq!(
+            chain2.transport.property::<i32>("buffer-size"),
+            default_buffer_size
+        );
     }
 
     #[test]
@@ -3281,13 +3357,7 @@ mod tests {
             .expect("mxlsink chain must construct");
         let mut pay_props = gst::Structure::new_empty("properties");
         pay_props.set("perfect-rtptime", false);
-        apply_mxl_sink_inner_properties(
-            test_log_cat(),
-            "nmossink",
-            &chain,
-            None,
-            Some(&pay_props),
-        );
+        apply_mxl_sink_inner_properties(test_log_cat(), "nmossink", &chain, None, Some(&pay_props));
     }
 
     #[test]
@@ -3299,8 +3369,8 @@ mod tests {
             .property("is-live", true)
             .build()
             .expect("fakesrc");
-        let ghost =
-            build_initial(&nmos_bin, initial, "src", gst::PadDirection::Src).expect("build_initial");
+        let ghost = build_initial(&nmos_bin, initial, "src", gst::PadDirection::Src)
+            .expect("build_initial");
         nmos_bin.add_pad(&ghost).expect("add ghost");
         assert!(ghost.peer().is_none());
 
@@ -3315,10 +3385,9 @@ mod tests {
 
     /// Minimal nmossink topology with a live upstream source at PLAYING.
     fn playing_nmossink_sim_bin() -> (gst::Pipeline, gst::Bin, gst::GhostPad) {
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=RGBA,width=320,height=240,framerate=30/1",
-        )
-        .expect("test caps");
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=RGBA,width=320,height=240,framerate=30/1")
+                .expect("test caps");
         let pipeline = gst::Pipeline::new();
         let src = gst::ElementFactory::make("videotestsrc")
             .property("is-live", true)

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -142,8 +142,8 @@ use std::sync::LazyLock;
 use gst::glib;
 use gstreamer as gst;
 
-mod channel_mapping_session;
 mod channel_mapping;
+mod channel_mapping_session;
 mod daemon;
 mod domain;
 mod essence_caps;
@@ -151,14 +151,14 @@ mod flow_def;
 mod iface;
 mod inner;
 mod network_services;
-mod nvdsudp;
+mod nmosaudiochannelmap;
 mod nmossink;
 mod nmossrc;
+mod nvdsudp;
 mod runtime;
 mod sdp;
 mod sdp_passthrough;
 mod session;
-mod nmosaudiochannelmap;
 mod types;
 
 /// Shared test-only helpers for the crate's unit tests.

--- a/rust/gst-nmos-rs/src/network_services.rs
+++ b/rust/gst-nmos-rs/src/network_services.rs
@@ -112,13 +112,19 @@ mod tests {
 
     #[test]
     fn parse_rejects_https() {
-        let parts = parse_nmos_url("https://reg.example/x-nmos/registration/v1.3", "registration");
+        let parts = parse_nmos_url(
+            "https://reg.example/x-nmos/registration/v1.3",
+            "registration",
+        );
         assert!(!parts.valid);
     }
 
     #[test]
     fn parse_rejects_invalid_port() {
-        let parts = parse_nmos_url("http://reg.example:99999/x-nmos/registration/v1.3", "registration");
+        let parts = parse_nmos_url(
+            "http://reg.example:99999/x-nmos/registration/v1.3",
+            "registration",
+        );
         assert!(!parts.valid);
     }
 
@@ -133,7 +139,9 @@ mod tests {
         let config = node.to_node_config();
         assert_eq!(config.seed, "seed-a");
         assert_eq!(config.host_name, "studio-a");
-        let ns = config.network_services.expect("domain should populate network_services");
+        let ns = config
+            .network_services
+            .expect("domain should populate network_services");
         assert_eq!(ns.domain, "local");
     }
 
@@ -146,7 +154,9 @@ mod tests {
             ..NodeSettings::default()
         };
         let config = node.to_node_config();
-        let ns = config.network_services.expect("urls should populate network_services");
+        let ns = config
+            .network_services
+            .expect("urls should populate network_services");
         assert_eq!(ns.registration_address, "reg");
         assert_eq!(ns.registration_port, 3210);
         assert_eq!(ns.registration_version, "v1.3");

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/caps.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/caps.rs
@@ -11,11 +11,7 @@ pub(crate) fn sequential_channel_mask(channels: u32) -> Option<gst::Bitmask> {
     if !(1..=64).contains(&ch) {
         return None;
     }
-    let mask = if ch == 64 {
-        u64::MAX
-    } else {
-        (1u64 << ch) - 1
-    };
+    let mask = if ch == 64 { u64::MAX } else { (1u64 << ch) - 1 };
     Some(gst::Bitmask::new(mask))
 }
 

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/imp.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/imp.rs
@@ -3,11 +3,10 @@
 
 use std::sync::{Arc, LazyLock, Mutex};
 
-use anyhow::{bail, Context};
-use gstreamer as gst;
-use gstreamer::glib;
-use gstreamer::prelude::*;
-use gstreamer::subclass::prelude::*;
+use super::internals::InternalGraph;
+use super::pad::{
+    NmosAudioChannelMapSinkPad, NmosAudioChannelMapSrcPad, sink_pad_templates, src_pad_templates,
+};
 use crate::channel_mapping::active_map::{
     active_map_entries_for_src, default_identity_routes, parse_active_map_structure,
 };
@@ -19,14 +18,15 @@ use crate::channel_mapping_session::{
     ChannelMappingActivationRequest, ChannelMappingSession,
 };
 use crate::session::channel_mapping::{
-    close as close_session, validate_and_open, ChannelMappingSettings,
-    CHANNELMAPPING_NAME_BLURB, RESTRICT_ROUTABLE_INPUTS_BLURB,
+    CHANNELMAPPING_NAME_BLURB, ChannelMappingSettings, RESTRICT_ROUTABLE_INPUTS_BLURB,
+    close as close_session, validate_and_open,
 };
 use crate::types::DEFAULT_DAEMON_URI;
-use super::internals::InternalGraph;
-use super::pad::{
-    sink_pad_templates, src_pad_templates, NmosAudioChannelMapSinkPad, NmosAudioChannelMapSrcPad,
-};
+use anyhow::{Context, bail};
+use gstreamer as gst;
+use gstreamer::glib;
+use gstreamer::prelude::*;
+use gstreamer::subclass::prelude::*;
 
 static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
     gst::DebugCategory::new(
@@ -203,7 +203,8 @@ impl ChildProxyImpl for NmosAudioChannelMap {
             .into_iter()
             .filter(|p| p.name().starts_with("sink_") || p.name().starts_with("src_"))
             .collect();
-        pads.get(index as usize).map(|p| p.upcast_ref::<glib::Object>().clone())
+        pads.get(index as usize)
+            .map(|p| p.upcast_ref::<glib::Object>().clone())
     }
 
     fn children_count(&self) -> u32 {
@@ -314,9 +315,13 @@ impl ElementImpl for NmosAudioChannelMap {
             gst::StateChange::NullToReady => {
                 let settings = self.settings.lock().unwrap().clone();
                 let handler = self.activation_handler();
-                if let Err(e) =
-                    validate_and_open(&CAT, "nmosaudiochannelmap", &(&settings).into(), &self.session, handler)
-                {
+                if let Err(e) = validate_and_open(
+                    &CAT,
+                    "nmosaudiochannelmap",
+                    &(&settings).into(),
+                    &self.session,
+                    handler,
+                ) {
                     element.post_error_message(gst::error_msg!(
                         gst::ResourceError::OpenRead,
                         ["failed to open channel mapping session: {e:#}"]
@@ -402,7 +407,11 @@ impl NmosAudioChannelMap {
                 };
             }
         };
-        let src_index = match topology.output_ids.iter().position(|id| id == &req.output_id) {
+        let src_index = match topology
+            .output_ids
+            .iter()
+            .position(|id| id == &req.output_id)
+        {
             Some(i) => i,
             None => {
                 return ChannelMappingActivationOutcome::Failed {
@@ -499,8 +508,8 @@ impl NmosAudioChannelMap {
                 &src_snapshots,
                 settings.restrict_routable_inputs,
             );
-            let resp = block_on_async(session.add_channel_mapping(req))
-                .context("AddChannelMapping")?;
+            let resp =
+                block_on_async(session.add_channel_mapping(req)).context("AddChannelMapping")?;
             for (snap, id) in sink_snapshots.iter_mut().zip(resp.input_ids.iter()) {
                 if snap.input_id.is_empty() {
                     snap.input_id.clone_from(id);
@@ -543,13 +552,8 @@ impl NmosAudioChannelMap {
         let mut output_routes = Vec::new();
         let mut sync_entries = Vec::new();
         for (src_idx, src) in src_snapshots.iter().enumerate() {
-            let entries = active_map_entries_for_src(
-                &topology,
-                src,
-                src_idx,
-                &sink_snapshots,
-                src_count,
-            )?;
+            let entries =
+                active_map_entries_for_src(&topology, src, src_idx, &sink_snapshots, src_count)?;
             let routes = if let Some(structure) = src.active_map.as_ref() {
                 parse_active_map_structure(structure)?
             } else {
@@ -565,13 +569,7 @@ impl NmosAudioChannelMap {
             sync_entries.push((src.output_id.clone(), entries));
         }
 
-        let graph = InternalGraph::build(
-            bin,
-            &topology,
-            &sink_pads,
-            &src_pads,
-            &output_routes,
-        )?;
+        let graph = InternalGraph::build(bin, &topology, &sink_pads, &src_pads, &output_routes)?;
 
         for pad in sink_pads.iter().chain(src_pads.iter()) {
             if let Some(sink) = pad.downcast_ref::<NmosAudioChannelMapSinkPad>() {

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/internals.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/internals.rs
@@ -3,18 +3,18 @@
 
 //! Internal `audiomixer` + `audiomixmatrix` subgraph.
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use gstreamer as gst;
 use gstreamer::prelude::*;
 
+use super::caps::{caps_with_channel_count, caps_with_channel_mask, sequential_channel_mask};
+use super::pad::{NmosAudioChannelMapSinkPad, NmosAudioChannelMapSrcPad};
 use crate::channel_mapping::active_map::ActiveMapRoute;
 use crate::channel_mapping::matrix::{
     build_input_bus_mix_matrix, build_output_mix_matrix, input_bus_converter_config,
     matrix_to_audiomixmatrix_gvalue,
 };
 use crate::channel_mapping::types::FrozenTopology;
-use super::caps::{caps_with_channel_count, caps_with_channel_mask, sequential_channel_mask};
-use super::pad::{NmosAudioChannelMapSinkPad, NmosAudioChannelMapSrcPad};
 
 // Extra wait the live audiomixer allows for jittery inputs before emitting.
 // Covers software-receive scheduling jitter at small RTP packet times.
@@ -102,11 +102,8 @@ impl InternalGraph {
                 .ok_or_else(|| anyhow::anyhow!("audiomixer request sink pad failed"))?;
             let input_ch = topology.input_channels[idx];
             let bus_offset = topology.input_bus_offsets[idx];
-            let matrix = build_input_bus_mix_matrix(
-                topology.input_bus_channels,
-                input_ch,
-                bus_offset,
-            );
+            let matrix =
+                build_input_bus_mix_matrix(topology.input_bus_channels, input_ch, bus_offset);
             mixer_sink.set_property("converter-config", input_bus_converter_config(&matrix));
 
             // Pin each input leg to exactly its channel count: the converter-config
@@ -140,10 +137,9 @@ impl InternalGraph {
                 .link(&mixer_sink)
                 .context("linking sink queue to audiomixer")?;
 
-            let ghost: NmosAudioChannelMapSinkPad = sink_pad
-                .clone()
-                .downcast()
-                .map_err(|_| anyhow::anyhow!("pad `{}` is not a sink ghost pad", sink_pad.name()))?;
+            let ghost: NmosAudioChannelMapSinkPad = sink_pad.clone().downcast().map_err(|_| {
+                anyhow::anyhow!("pad `{}` is not a sink ghost pad", sink_pad.name())
+            })?;
             ghost.set_target(sink_capsfilter.static_pad("sink").as_ref())?;
             ghost.set_active(true)?;
             sink_capsfilters.push(sink_capsfilter);

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/pad.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/pad.rs
@@ -289,14 +289,16 @@ mod imp {
 pub(crate) fn sink_pad_templates() -> &'static [gst::PadTemplate] {
     static TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
         let caps = gst::Caps::builder("audio/x-raw").build();
-        vec![gst::PadTemplate::with_gtype(
-            "sink_%u",
-            gst::PadDirection::Sink,
-            gst::PadPresence::Request,
-            &caps,
-            NmosAudioChannelMapSinkPad::static_type(),
-        )
-        .expect("sink pad template")]
+        vec![
+            gst::PadTemplate::with_gtype(
+                "sink_%u",
+                gst::PadDirection::Sink,
+                gst::PadPresence::Request,
+                &caps,
+                NmosAudioChannelMapSinkPad::static_type(),
+            )
+            .expect("sink pad template"),
+        ]
     });
     TEMPLATES.as_ref()
 }
@@ -304,14 +306,16 @@ pub(crate) fn sink_pad_templates() -> &'static [gst::PadTemplate] {
 pub(crate) fn src_pad_templates() -> &'static [gst::PadTemplate] {
     static TEMPLATES: LazyLock<Vec<gst::PadTemplate>> = LazyLock::new(|| {
         let caps = gst::Caps::builder("audio/x-raw").build();
-        vec![gst::PadTemplate::with_gtype(
-            "src_%u",
-            gst::PadDirection::Src,
-            gst::PadPresence::Request,
-            &caps,
-            NmosAudioChannelMapSrcPad::static_type(),
-        )
-        .expect("src pad template")]
+        vec![
+            gst::PadTemplate::with_gtype(
+                "src_%u",
+                gst::PadDirection::Src,
+                gst::PadPresence::Request,
+                &caps,
+                NmosAudioChannelMapSrcPad::static_type(),
+            )
+            .expect("src pad template"),
+        ]
     });
     TEMPLATES.as_ref()
 }

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -603,11 +603,7 @@ impl NmosSink {
         Ok(())
     }
 
-    fn activate_inner(
-        &self,
-        bin: &gst::Bin,
-        outcome: &InnerConfig,
-    ) -> Result<(), anyhow::Error> {
+    fn activate_inner(&self, bin: &gst::Bin, outcome: &InnerConfig) -> Result<(), anyhow::Error> {
         match outcome {
             InnerConfig::Real(transport) => {
                 let settings = self.settings.lock().unwrap();
@@ -703,7 +699,11 @@ impl NmosSink {
             .clone()
             .ok_or_else(|| anyhow!("nmossink ghost pad missing"))?;
         let peer_caps = ghost.peer_query_caps(None);
-        gst::debug!(CAT, imp = self, "deferred fake-chain peer_query_caps -> {peer_caps}");
+        gst::debug!(
+            CAT,
+            imp = self,
+            "deferred fake-chain peer_query_caps -> {peer_caps}"
+        );
         let fixated = crate::session::prepare_deferred_peer_caps("nmossink", peer_caps)?;
         gst::info!(CAT, "nmossink pinning deferred fake chain to `{fixated}`");
         let fake = inner::build_fake_sink(Some(&fixated))?;
@@ -768,7 +768,11 @@ impl NmosSink {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("nmossink ghost pad missing"))?;
         let peer_caps = ghost.peer_query_caps(None);
-        gst::debug!(CAT, imp = self, "deferred mode peer_query_caps -> {peer_caps}");
+        gst::debug!(
+            CAT,
+            imp = self,
+            "deferred mode peer_query_caps -> {peer_caps}"
+        );
 
         let common: crate::session::CommonSettings = snapshot.into();
         let outcome = crate::session::add_deferred_sender(
@@ -791,21 +795,23 @@ impl NmosSink {
     /// the bin alive on its own.
     fn activation_handler(&self) -> ActivationHandler {
         let weak: glib::WeakRef<super::NmosSink> = self.obj().downgrade();
-        Arc::new(move |req: ActivationRequest, tx: oneshot::Sender<ActivationOutcome>| {
-            let Some(bin) = weak.upgrade() else {
-                let _ = tx.send(ActivationOutcome::Failed {
-                    reason: "nmossink element was dropped before activation could be applied"
-                        .to_owned(),
+        Arc::new(
+            move |req: ActivationRequest, tx: oneshot::Sender<ActivationOutcome>| {
+                let Some(bin) = weak.upgrade() else {
+                    let _ = tx.send(ActivationOutcome::Failed {
+                        reason: "nmossink element was dropped before activation could be applied"
+                            .to_owned(),
+                    });
+                    return;
+                };
+                // Hop onto the GStreamer thread to inspect state and
+                // touch the bin's children. `call_async` is the
+                // canonical bridge from a tokio worker.
+                bin.call_async(move |bin| {
+                    bin.imp().apply_activation(req, tx);
                 });
-                return;
-            };
-            // Hop onto the GStreamer thread to inspect state and
-            // touch the bin's children. `call_async` is the
-            // canonical bridge from a tokio worker.
-            bin.call_async(move |bin| {
-                bin.imp().apply_activation(req, tx);
-            });
-        })
+            },
+        )
     }
 
     /// Apply an activation. Runs on a GStreamer worker thread (via
@@ -857,9 +863,7 @@ impl NmosSink {
         let bin_ref: &gst::Bin = bin.upcast_ref();
         let settings = self.settings.lock().unwrap().clone();
 
-        if matches!(plan.inner, InnerConfig::Real(_))
-            && self.current_chain_is_real()
-        {
+        if matches!(plan.inner, InnerConfig::Real(_)) && self.current_chain_is_real() {
             gst::debug!(
                 CAT,
                 "nmossink activation is real\u{2192}real; inserting fake hop \
@@ -871,33 +875,27 @@ impl NmosSink {
                 Ok(p) => {
                     if let Err(e) = self.swap_inner(bin_ref, &p) {
                         return ActivationOutcome::Failed {
-                            reason: format!(
-                                "nmossink: intermediate fake-chain swap failed: {e:#}"
-                            ),
+                            reason: format!("nmossink: intermediate fake-chain swap failed: {e:#}"),
                         };
                     }
                 }
                 Err(e) => {
                     return ActivationOutcome::Failed {
-                        reason: format!(
-                            "nmossink: building intermediate fake chain: {e:#}"
-                        ),
+                        reason: format!("nmossink: building intermediate fake chain: {e:#}"),
                     };
                 }
             }
         }
 
         let new_inner = match &plan.inner {
-            InnerConfig::Real(transport) => {
-                match build_real_sink(transport, &settings) {
-                    Ok(bin) => bin,
-                    Err(e) => {
-                        return ActivationOutcome::Failed {
-                            reason: format!("nmossink: building inner transport chain: {e:#}"),
-                        };
-                    }
+            InnerConfig::Real(transport) => match build_real_sink(transport, &settings) {
+                Ok(bin) => bin,
+                Err(e) => {
+                    return ActivationOutcome::Failed {
+                        reason: format!("nmossink: building inner transport chain: {e:#}"),
+                    };
                 }
-            }
+            },
             InnerConfig::Fake { .. } => {
                 // Deactivation, side mismatch, missing config, etc.
                 // The bin may be in PLAYING when this happens, so
@@ -927,10 +925,7 @@ impl NmosSink {
             // is left in a known state even on the failure path.
             if let Ok(p) = build_fake_sink_for_settings(&settings) {
                 if let Err(e2) = self.swap_inner(bin_ref, &p) {
-                    gst::warning!(
-                        CAT,
-                        "nmossink fake-chain restore also failed: {e2:#}",
-                    );
+                    gst::warning!(CAT, "nmossink fake-chain restore also failed: {e2:#}",);
                 }
             }
             return ActivationOutcome::Failed {
@@ -954,7 +949,11 @@ fn build_real_sink(
     settings: &Settings,
 ) -> Result<gst::Element, anyhow::Error> {
     let (bin, transport_sink) = match transport {
-        TransportConfig::Mxl { domain_path, flow_id, .. } => {
+        TransportConfig::Mxl {
+            domain_path,
+            flow_id,
+            ..
+        } => {
             let chain = inner::build_mxlsink(domain_path, flow_id)?;
             inner::apply_mxl_sink_inner_properties(
                 &CAT,
@@ -967,8 +966,10 @@ fn build_real_sink(
         }
         TransportConfig::Udp { variant, media, .. } => {
             let chain = inner::build_udpsink(media, *variant)?;
-            let property =
-                crate::sdp::bit_rates_from_properties(settings.format_bit_rate, settings.transport_bit_rate);
+            let property = crate::sdp::bit_rates_from_properties(
+                settings.format_bit_rate,
+                settings.transport_bit_rate,
+            );
             let bit_rates = crate::sdp::effective_bit_rates(property, media.bit_rates);
             inner::apply_format_bit_rate_to_jxsv_payloader(
                 media,
@@ -985,7 +986,11 @@ fn build_real_sink(
             );
             (chain.bin, chain.transport)
         }
-        TransportConfig::NvDsUdp { media, transport_file, .. } => {
+        TransportConfig::NvDsUdp {
+            media,
+            transport_file,
+            ..
+        } => {
             let sdp = transport_file.as_deref().unwrap_or("");
             let chain = inner::build_nvdsudpsink(media, sdp)?;
             inner::apply_nvdsudp_sink_inner_properties(
@@ -1129,8 +1134,14 @@ mod tests {
         assert_eq!(cs.source_port, 5005);
         assert_eq!(cs.destination_ip, "239.1.1.1");
         assert_eq!(cs.destination_port, 5004);
-        assert_eq!(cs.interface_ip, "", "receiver-only on the Sender side must be empty");
-        assert_eq!(cs.multicast_ip, "", "receiver-only on the Sender side must be empty");
+        assert_eq!(
+            cs.interface_ip, "",
+            "receiver-only on the Sender side must be empty"
+        );
+        assert_eq!(
+            cs.multicast_ip, "",
+            "receiver-only on the Sender side must be empty"
+        );
         assert_eq!(cs.side, crate::session::types::Side::Sender);
     }
 
@@ -1162,7 +1173,10 @@ mod tests {
         let cs: CommonSettings = s.into();
         assert_eq!(cs.node.host_name, "studio-a");
         assert_eq!(cs.node.domain, "local");
-        assert_eq!(cs.node.registration_url, "http://reg:3210/x-nmos/registration/v1.3");
+        assert_eq!(
+            cs.node.registration_url,
+            "http://reg:3210/x-nmos/registration/v1.3"
+        );
         assert_eq!(cs.node.system_url, "http://sys:10641/x-nmos/system/v1.0");
     }
 
@@ -1170,9 +1184,8 @@ mod tests {
     fn from_settings_forwards_transport_caps() {
         use std::str::FromStr;
         init_gst();
-        let caps =
-            gst::Caps::from_str("application/x-rtp,media=audio,payload=99,clock-rate=48000")
-                .expect("valid caps");
+        let caps = gst::Caps::from_str("application/x-rtp,media=audio,payload=99,clock-rate=48000")
+            .expect("valid caps");
         let s = Settings {
             transport_caps: Some(caps.clone()),
             ..Settings::default()
@@ -1210,34 +1223,30 @@ mod tests {
             "a=rtpmap:96 raw/90000\r\n",
             "a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; exactframerate=25/1; depth=10\r\n",
         );
-        let activation_caps = intermediate_fake_sink_caps(
-            &udp_activation_plan(NARROW_SDP),
-            &Settings::default(),
-        )
-        .expect("activation caps")
-        .expect("narrow UDP must pin fake-hop caps");
-        let structure = activation_caps
-            .structure(0)
-            .expect("structure");
+        let activation_caps =
+            intermediate_fake_sink_caps(&udp_activation_plan(NARROW_SDP), &Settings::default())
+                .expect("activation caps")
+                .expect("narrow UDP must pin fake-hop caps");
+        let structure = activation_caps.structure(0).expect("structure");
         assert_eq!(structure.name(), "video/x-raw");
         assert_eq!(structure.get::<&str>("format").ok(), Some("UYVP"));
 
-        let stale_element_caps = gst::Caps::from_str(
-            "video/x-raw,format=RGB,width=640,height=480,framerate=30/1",
-        )
-        .expect("stale caps");
+        let stale_element_caps =
+            gst::Caps::from_str("video/x-raw,format=RGB,width=640,height=480,framerate=30/1")
+                .expect("stale caps");
         let settings = Settings {
             caps: Some(stale_element_caps),
             ..Settings::default()
         };
-        let hop_caps = intermediate_fake_sink_caps(
-            &udp_activation_plan(NARROW_SDP),
-            &settings,
-        )
-        .expect("activation caps")
-        .expect("narrow UDP must pin fake-hop caps");
+        let hop_caps = intermediate_fake_sink_caps(&udp_activation_plan(NARROW_SDP), &settings)
+            .expect("activation caps")
+            .expect("narrow UDP must pin fake-hop caps");
         assert_eq!(
-            hop_caps.structure(0).expect("structure").get::<&str>("format").ok(),
+            hop_caps
+                .structure(0)
+                .expect("structure")
+                .get::<&str>("format")
+                .ok(),
             Some("UYVP"),
             "fake-hop caps must follow activation media, not element property",
         );
@@ -1247,10 +1256,9 @@ mod tests {
     fn intermediate_fake_sink_caps_mxl_uses_element_settings() {
         use std::str::FromStr;
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=v210,width=1920,height=1080,framerate=25/1",
-        )
-        .expect("caps");
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=25/1")
+                .expect("caps");
         let settings = Settings {
             caps: Some(caps.clone()),
             ..Settings::default()
@@ -1269,5 +1277,4 @@ mod tests {
             Some(caps),
         );
     }
-
 }

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -581,11 +581,7 @@ impl NmosSrc {
         Ok(())
     }
 
-    fn activate_inner(
-        &self,
-        bin: &gst::Bin,
-        outcome: &InnerConfig,
-    ) -> Result<(), anyhow::Error> {
+    fn activate_inner(&self, bin: &gst::Bin, outcome: &InnerConfig) -> Result<(), anyhow::Error> {
         match outcome {
             InnerConfig::Real(transport) => {
                 let new_inner = match transport {
@@ -595,8 +591,7 @@ impl NmosSrc {
                         format,
                         transport_file,
                     } => {
-                        let capssetter_caps =
-                            mxl_capssetter_caps(transport_file.as_deref())?;
+                        let capssetter_caps = mxl_capssetter_caps(transport_file.as_deref())?;
                         {
                             let chain = inner::build_mxlsrc(
                                 domain_path,
@@ -620,14 +615,10 @@ impl NmosSrc {
                         media,
                         transport_file,
                     } => {
-                        let capssetter_caps =
-                            udp_capssetter_caps(transport_file.as_deref(), media);
+                        let capssetter_caps = udp_capssetter_caps(transport_file.as_deref(), media);
                         {
-                            let chain = inner::build_udpsrc(
-                                media,
-                                *variant,
-                                capssetter_caps.as_ref(),
-                            )?;
+                            let chain =
+                                inner::build_udpsrc(media, *variant, capssetter_caps.as_ref())?;
                             let settings = self.settings.lock().unwrap();
                             inner::apply_udp_src_inner_properties(
                                 &CAT,
@@ -639,20 +630,22 @@ impl NmosSrc {
                             chain.bin
                         }
                     }
-                    TransportConfig::NvDsUdp { media, transport_file, .. } => {
-                        {
-                            let sdp = transport_file.as_deref().unwrap_or("");
-                            let chain = inner::build_nvdsudpsrc(media, sdp)?;
-                            let settings = self.settings.lock().unwrap();
-                            inner::apply_nvdsudp_src_inner_properties(
-                                &CAT,
-                                "nmossrc",
-                                &chain,
-                                settings.transport_properties.as_ref(),
-                                settings.depay_properties.as_ref(),
-                            );
-                            chain.bin
-                        }
+                    TransportConfig::NvDsUdp {
+                        media,
+                        transport_file,
+                        ..
+                    } => {
+                        let sdp = transport_file.as_deref().unwrap_or("");
+                        let chain = inner::build_nvdsudpsrc(media, sdp)?;
+                        let settings = self.settings.lock().unwrap();
+                        inner::apply_nvdsudp_src_inner_properties(
+                            &CAT,
+                            "nmossrc",
+                            &chain,
+                            settings.transport_properties.as_ref(),
+                            settings.depay_properties.as_ref(),
+                        );
+                        chain.bin
                     }
                 };
                 self.swap_inner(bin, &new_inner, inner::RebuildChainOpts::default())?;
@@ -691,7 +684,8 @@ impl NmosSrc {
         let snapshot = self.settings.lock().unwrap().clone();
         match build_fake_src_for_settings(&snapshot) {
             Ok(fake) => {
-                if let Err(e) = self.swap_inner(bin_ref, &fake, inner::RebuildChainOpts::default()) {
+                if let Err(e) = self.swap_inner(bin_ref, &fake, inner::RebuildChainOpts::default())
+                {
                     gst::warning!(CAT, "restoring nmossrc fake chain: {e:#}");
                 }
             }
@@ -760,18 +754,20 @@ impl NmosSrc {
     /// the bin alive on its own.
     fn activation_handler(&self) -> ActivationHandler {
         let weak: glib::WeakRef<super::NmosSrc> = self.obj().downgrade();
-        Arc::new(move |req: ActivationRequest, tx: oneshot::Sender<ActivationOutcome>| {
-            let Some(bin) = weak.upgrade() else {
-                let _ = tx.send(ActivationOutcome::Failed {
-                    reason: "nmossrc element was dropped before activation could be applied"
-                        .to_owned(),
+        Arc::new(
+            move |req: ActivationRequest, tx: oneshot::Sender<ActivationOutcome>| {
+                let Some(bin) = weak.upgrade() else {
+                    let _ = tx.send(ActivationOutcome::Failed {
+                        reason: "nmossrc element was dropped before activation could be applied"
+                            .to_owned(),
+                    });
+                    return;
+                };
+                bin.call_async(move |bin| {
+                    bin.imp().apply_activation(req, tx);
                 });
-                return;
-            };
-            bin.call_async(move |bin| {
-                bin.imp().apply_activation(req, tx);
-            });
-        })
+            },
+        )
     }
 
     /// Apply an activation. Runs on a GStreamer worker thread (via
@@ -828,11 +824,9 @@ impl NmosSrc {
         let bin_ref: &gst::Bin = bin.upcast_ref();
         let from_real = self.current_chain_is_real();
         let to_real = matches!(plan.inner, InnerConfig::Real(_));
-        let drain_downstream = (from_real || to_real)
-            && bin_ref.current_state() == gst::State::Playing;
-        let reroute_opts = inner::RebuildChainOpts {
-            drain_downstream,
-        };
+        let drain_downstream =
+            (from_real || to_real) && bin_ref.current_state() == gst::State::Playing;
+        let reroute_opts = inner::RebuildChainOpts { drain_downstream };
         let settings = self.settings.lock().unwrap().clone();
 
         if from_real && to_real {
@@ -847,17 +841,13 @@ impl NmosSrc {
                 Ok(fake) => {
                     if let Err(e) = self.swap_inner(bin_ref, &fake, reroute_opts) {
                         return ActivationOutcome::Failed {
-                            reason: format!(
-                                "nmossrc: intermediate fake-chain swap failed: {e:#}"
-                            ),
+                            reason: format!("nmossrc: intermediate fake-chain swap failed: {e:#}"),
                         };
                     }
                 }
                 Err(e) => {
                     return ActivationOutcome::Failed {
-                        reason: format!(
-                            "nmossrc: building intermediate fake chain: {e:#}"
-                        ),
+                        reason: format!("nmossrc: building intermediate fake chain: {e:#}"),
                     };
                 }
             }
@@ -865,7 +855,10 @@ impl NmosSrc {
 
         let new_inner = match &plan.inner {
             InnerConfig::Real(TransportConfig::Mxl {
-                domain_path, flow_id, format, transport_file,
+                domain_path,
+                flow_id,
+                format,
+                transport_file,
             }) => {
                 let capssetter_caps = match mxl_capssetter_caps(transport_file.as_deref()) {
                     Ok(c) => c,
@@ -901,8 +894,7 @@ impl NmosSrc {
                 media,
                 transport_file,
             }) => {
-                let capssetter_caps =
-                    udp_capssetter_caps(transport_file.as_deref(), media);
+                let capssetter_caps = udp_capssetter_caps(transport_file.as_deref(), media);
                 let settings = self.settings.lock().unwrap();
                 match inner::build_udpsrc(media, *variant, capssetter_caps.as_ref()) {
                     Ok(chain) => {
@@ -922,7 +914,11 @@ impl NmosSrc {
                     }
                 }
             }
-            InnerConfig::Real(TransportConfig::NvDsUdp { media, transport_file, .. }) => {
+            InnerConfig::Real(TransportConfig::NvDsUdp {
+                media,
+                transport_file,
+                ..
+            }) => {
                 let settings = self.settings.lock().unwrap();
                 let sdp = transport_file.as_deref().unwrap_or("");
                 match inner::build_nvdsudpsrc(media, sdp) {
@@ -975,10 +971,7 @@ impl NmosSrc {
             // twice.
             if let Ok(p) = build_fake_src_for_settings(&settings) {
                 if let Err(e2) = self.swap_inner(bin_ref, &p, inner::RebuildChainOpts::default()) {
-                    gst::warning!(
-                        CAT,
-                        "nmossrc fake-chain restore also failed: {e2:#}",
-                    );
+                    gst::warning!(CAT, "nmossrc fake-chain restore also failed: {e2:#}",);
                 }
             }
             return ActivationOutcome::Failed {
@@ -999,8 +992,7 @@ fn install_initial_fake_chain(bin: &gst::Bin) -> Result<gst::GhostPad, glib::Boo
     // so we have no caps source. Build a bare `appsrc` without caps;
     // it'll be replaced at NULL→READY (`activate_inner`) once `caps`
     // / `transport-file*` are known.
-    let fake = inner::build_fake_src(None)
-        .map_err(|e| glib::bool_error!("{e}"))?;
+    let fake = inner::build_fake_src(None).map_err(|e| glib::bool_error!("{e}"))?;
     let ghost = inner::build_initial(bin, fake, "src", gst::PadDirection::Src)?;
     bin.add_pad(&ghost)
         .map_err(|e| glib::bool_error!("adding ghost pad to nmossrc: {e}"))?;
@@ -1062,9 +1054,7 @@ fn mxl_indicates_wide_receiver_caps(text: &str) -> bool {
 /// transport file indicates wide Receiver Caps, return `None` so runtime
 /// caps come from the filesystem flow via bare `mxlsrc`; otherwise pin
 /// configuring essence caps from the same file.
-fn mxl_capssetter_caps(
-    transport_file: Option<&str>,
-) -> Result<Option<gst::Caps>, anyhow::Error> {
+fn mxl_capssetter_caps(transport_file: Option<&str>) -> Result<Option<gst::Caps>, anyhow::Error> {
     if transport_file
         .filter(|s| !s.is_empty())
         .is_some_and(mxl_indicates_wide_receiver_caps)
@@ -1115,9 +1105,7 @@ fn udp_capssetter_caps(
 /// caps and the pipeline will fail caps negotiation if it tries
 /// to reach PLAYING in that state. Filesystem / parse errors when
 /// a source is set are propagated as `Err`.
-fn fake_caps_from_settings(
-    settings: &Settings,
-) -> Result<Option<gst::Caps>, anyhow::Error> {
+fn fake_caps_from_settings(settings: &Settings) -> Result<Option<gst::Caps>, anyhow::Error> {
     crate::session::fake_caps_from_settings(
         "nmossrc",
         settings.transport,
@@ -1204,8 +1192,14 @@ mod tests {
         assert_eq!(cs.interface_ip, "192.0.2.20");
         assert_eq!(cs.multicast_ip, "239.1.1.1");
         assert_eq!(cs.destination_port, 5004);
-        assert_eq!(cs.source_port, 0, "sender-only on the Receiver side must be 0");
-        assert_eq!(cs.destination_ip, "", "sender-only on the Receiver side must be empty");
+        assert_eq!(
+            cs.source_port, 0,
+            "sender-only on the Receiver side must be 0"
+        );
+        assert_eq!(
+            cs.destination_ip, "",
+            "sender-only on the Receiver side must be empty"
+        );
         assert_eq!(cs.side, crate::session::types::Side::Receiver);
     }
 
@@ -1229,9 +1223,8 @@ mod tests {
     fn from_settings_forwards_transport_caps() {
         use std::str::FromStr;
         init_gst();
-        let caps =
-            gst::Caps::from_str("application/x-rtp,media=audio,payload=99,clock-rate=48000")
-                .expect("valid caps");
+        let caps = gst::Caps::from_str("application/x-rtp,media=audio,payload=99,clock-rate=48000")
+            .expect("valid caps");
         let s = Settings {
             transport_caps: Some(caps.clone()),
             ..Settings::default()
@@ -1269,21 +1262,15 @@ mod tests {
         )
         .expect("wide splice");
         assert!(
-            mxl_capssetter_caps(Some(&spliced_wide))
-                .unwrap()
-                .is_none(),
+            mxl_capssetter_caps(Some(&spliced_wide)).unwrap().is_none(),
             "post-splice wide transport file must skip capssetter",
         );
         assert!(
-            mxl_capssetter_caps(Some(wide_file))
-                .unwrap()
-                .is_none(),
+            mxl_capssetter_caps(Some(wide_file)).unwrap().is_none(),
             "activation/configuring file with wide caps tag must skip capssetter",
         );
         assert!(
-            mxl_capssetter_caps(Some(narrow_file))
-                .unwrap()
-                .is_some(),
+            mxl_capssetter_caps(Some(narrow_file)).unwrap().is_some(),
             "narrow transport file still uses capssetter",
         );
         let spliced_narrow = splice_overrides(
@@ -1384,10 +1371,9 @@ mod tests {
             "frame_height":1080,
             "tags":{"urn:x-nvnmos:tag:caps":[""]}
         }"#;
-        let narrow_element_caps = gst::Caps::from_str(
-            "video/x-raw,format=v210,width=1920,height=1080,framerate=25/1",
-        )
-        .expect("narrow caps");
+        let narrow_element_caps =
+            gst::Caps::from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=25/1")
+                .expect("narrow caps");
         let snapshot = Settings {
             caps: Some(narrow_element_caps),
             ..Settings::default()
@@ -1452,10 +1438,9 @@ mod tests {
     fn intermediate_fake_src_caps_deactivation_uses_element_settings() {
         use std::str::FromStr;
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=v210,width=1920,height=1080,framerate=25/1",
-        )
-        .expect("caps");
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=25/1")
+                .expect("caps");
         let snapshot = Settings {
             caps: Some(caps.clone()),
             ..Settings::default()
@@ -1472,5 +1457,4 @@ mod tests {
             Some(caps),
         );
     }
-
 }

--- a/rust/gst-nmos-rs/src/nvdsudp/packetization.rs
+++ b/rust/gst-nmos-rs/src/nvdsudp/packetization.rs
@@ -254,9 +254,7 @@ fn parse_ptime_ms_as_ns(value: &str) -> Result<u64, anyhow::Error> {
     if v.is_empty() {
         bail!("empty ptime");
     }
-    let ms: f64 = v
-        .parse()
-        .with_context(|| format!("ptime `{v}`"))?;
+    let ms: f64 = v.parse().with_context(|| format!("ptime `{v}`"))?;
     if !ms.is_finite() || ms <= 0.0 {
         bail!("ptime=`{v}` ms must be a finite positive value");
     }
@@ -318,8 +316,7 @@ pub(crate) fn audio_from_caps(
         );
     }
     let sink_payload_size = src_payload + AUDIO_HEADER_SIZE;
-    let payload_multiple =
-        ((DEFAULT_AUDIO_BUFFER_NS + ptime_ns / 2) / ptime_ns).max(1) as u32;
+    let payload_multiple = ((DEFAULT_AUDIO_BUFFER_NS + ptime_ns / 2) / ptime_ns).max(1) as u32;
 
     Ok(AudioPacketization {
         sink_payload_size,
@@ -370,7 +367,9 @@ pub(crate) fn reconcile_sink_video_packetization(
     if configured_stride == target_stride {
         return Ok(());
     }
-    let s = caps.structure(0).ok_or_else(|| anyhow::anyhow!("raw caps empty"))?;
+    let s = caps
+        .structure(0)
+        .ok_or_else(|| anyhow::anyhow!("raw caps empty"))?;
     let format = s.get::<&str>("format").unwrap_or("?");
     let width = s.get::<i32>("width").unwrap_or(0);
     gst::warning!(
@@ -397,10 +396,9 @@ mod tests {
     #[test]
     fn uyvp_1920x1080_matches_deepstream_table() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=UYVP,width=1920,height=1080,framerate=60/1",
-        )
-        .unwrap();
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=UYVP,width=1920,height=1080,framerate=60/1")
+                .unwrap();
         let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 4);
         assert_eq!(pkt.src_payload_size, 1200);
@@ -410,10 +408,9 @@ mod tests {
     #[test]
     fn uyvp_1280x720_matches_rivermax_minimum_packet_size() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=UYVP,width=1280,height=720,framerate=60/1",
-        )
-        .unwrap();
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=UYVP,width=1280,height=720,framerate=60/1")
+                .unwrap();
         let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 4);
         assert_eq!(pkt.src_payload_size, 800);
@@ -423,10 +420,9 @@ mod tests {
     #[test]
     fn video_configured_stride_detects_mismatch() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1",
-        )
-        .unwrap();
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1")
+                .unwrap();
         let target = video_target_stride(&caps).unwrap();
         let calculated = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(
@@ -440,10 +436,9 @@ mod tests {
     #[test]
     fn uyvp_3840x2160_10bit_matches_calculated_stride() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=UYVP,width=3840,height=2160,framerate=60/1",
-        )
-        .unwrap();
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=UYVP,width=3840,height=2160,framerate=60/1")
+                .unwrap();
         let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 8);
         assert_eq!(pkt.src_payload_size, 1200);
@@ -453,10 +448,9 @@ mod tests {
     #[test]
     fn uyvy_1920x1080_8bit_matches_deepstream_table() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=UYVY,width=1920,height=1080,framerate=60/1",
-        )
-        .unwrap();
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=UYVY,width=1920,height=1080,framerate=60/1")
+                .unwrap();
         let pkt = video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).unwrap();
         assert_eq!(pkt.packets_per_line, 3);
         assert_eq!(pkt.sink_payload_size, 1300);
@@ -503,8 +497,7 @@ mod tests {
     #[test]
     fn anc_from_meta_st2038_frame_alignment() {
         init_gst();
-        let caps = gst::Caps::from_str("meta/x-st-2038,alignment=frame,framerate=60/1")
-            .unwrap();
+        let caps = gst::Caps::from_str("meta/x-st-2038,alignment=frame,framerate=60/1").unwrap();
         let pkt = from_media(FlowFormat::Data, &caps, &gst::Caps::new_empty())
             .expect("ANC packetization");
         assert!(matches!(pkt, Packetization::Anc));
@@ -532,10 +525,9 @@ mod tests {
     #[test]
     fn unsupported_video_format_errors() {
         init_gst();
-        let caps = gst::Caps::from_str(
-            "video/x-raw,format=v210,width=1920,height=1080,framerate=60/1",
-        )
-        .unwrap();
+        let caps =
+            gst::Caps::from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=60/1")
+                .unwrap();
         assert!(video_from_caps(&caps, DEFAULT_MAX_VIDEO_RTP_PAYLOAD).is_err());
     }
 }

--- a/rust/gst-nmos-rs/src/nvdsudp/sdp_file.rs
+++ b/rust/gst-nmos-rs/src/nvdsudp/sdp_file.rs
@@ -15,9 +15,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use tempfile::Builder;
 use glib::object::ObjectExt;
 use gstreamer as gst;
+use tempfile::Builder;
 
 /// GObject qdata key for [`SdpFileGuard`] on the inner `nvdsudpsink`.
 const SDP_FILE_GUARD_KEY: &str = "nvnmos-nvdsudp-sdp-file";
@@ -41,9 +41,7 @@ impl SdpFileGuard {
             .context("creating nvdsudpsink sdp temp file")?;
         file.write_all(sdp_text.as_bytes())
             .with_context(|| format!("writing nvdsudpsink sdp-file `{}`", file.path().display()))?;
-        let (_, path) = file
-            .keep()
-            .context("keeping nvdsudpsink sdp temp file")?;
+        let (_, path) = file.keep().context("keeping nvdsudpsink sdp temp file")?;
         Ok(Self { path })
     }
 
@@ -117,6 +115,9 @@ mod tests {
         };
         assert!(path.exists(), "file must outlive the Rust guard move");
         drop(element);
-        assert!(!path.exists(), "file must be removed when element is finalized");
+        assert!(
+            !path.exists(),
+            "file must be removed when element is finalized"
+        );
     }
 }

--- a/rust/gst-nmos-rs/src/nvdsudp/ts_refclk.rs
+++ b/rust/gst-nmos-rs/src/nvdsudp/ts_refclk.rs
@@ -96,7 +96,10 @@ mod tests {
 
     #[test]
     fn absent_ts_refclk_is_unset() {
-        assert_eq!(ptp_src_from_sdp("a=mediaclk:direct=0\r\n"), PtpSrcResolution::Unset);
+        assert_eq!(
+            ptp_src_from_sdp("a=mediaclk:direct=0\r\n"),
+            PtpSrcResolution::Unset
+        );
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -62,18 +62,17 @@
 //! round-trips them as standalone `a=…:` lines on build — see
 //! [`caps_from_rtp_audio`] for the reasoning.
 
-
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::sync::LazyLock;
 
 use gst_sdp::{SDPAttribute, SDPBandwidth, SDPMedia, SDPMediaRef, SDPMessage};
-use unicase::Ascii;
 use gstreamer as gst;
 use gstreamer_sdp as gst_sdp;
 use thiserror::Error;
+use unicase::Ascii;
 
 use crate::session::types::Side;
 use crate::session::udp::types::{UdpLeg, UdpMedia};
@@ -230,13 +229,9 @@ pub(crate) enum SdpError {
         "dual-leg SDP requires transport=nvdsudp; transport=udp/udp2 supports single-leg RTP only"
     )]
     DualLegNotSupported,
-    #[error(
-        "cannot normalise SDP to a single active leg: expected exactly one active `m=` block"
-    )]
+    #[error("cannot normalise SDP to a single active leg: expected exactly one active `m=` block")]
     NotExactlyOneActiveLeg,
-    #[error(
-        "SDP `m=` blocks carry mismatched essence (PT / rtpmap / fmtp differ across legs)"
-    )]
+    #[error("SDP `m=` blocks carry mismatched essence (PT / rtpmap / fmtp differ across legs)")]
     DualLegEssenceMismatch,
     #[error("SDP has {0} media lines; at most two same-essence legs are supported")]
     TooManyMediaBlocks(usize),
@@ -276,9 +271,7 @@ pub(crate) enum SdpError {
     // `FlowDefError::FormatMismatch` on the MXL path so both
     // transport stacks reject the same misconfigurations with
     // parallel attribution.
-    #[error(
-        "essence format mismatch: `caps` declares `{caps:?}` but SDP declares `{sdp:?}`"
-    )]
+    #[error("essence format mismatch: `caps` declares `{caps:?}` but SDP declares `{sdp:?}`")]
     FormatMismatch { caps: FlowFormat, sdp: FlowFormat },
     #[error(
         "essence shape mismatch: `caps` `{caps}` does not intersect \
@@ -290,10 +283,7 @@ pub(crate) enum SdpError {
          SDP-derived RTP caps `{sdp}` (override-class fields `payload`, \
          `a-ptime`, `a-maxptime` excluded from the comparison)"
     )]
-    TransportCapsMismatch {
-        transport_caps: String,
-        sdp: String,
-    },
+    TransportCapsMismatch { transport_caps: String, sdp: String },
     #[error(
         "bit-rate mismatch: properties resolve to format {property_format} / transport \
          {property_transport} kbit/s but transport-file declares format {file_format} / \
@@ -539,8 +529,7 @@ fn as_bandwidth_from_media(m: &SDPMediaRef) -> Option<u64> {
 /// derive the missing side from the other fmtp key or `b=AS:`.
 pub(crate) fn bit_rates_from_media(m: &SDPMediaRef) -> BitRates {
     let params = fmtp_params_from_media(m);
-    let fmtp_format =
-        params.and_then(|params| fmtp_param::<u64>(params, FMTP_FORMAT_BIT_RATE));
+    let fmtp_format = params.and_then(|params| fmtp_param::<u64>(params, FMTP_FORMAT_BIT_RATE));
     let fmtp_transport =
         params.and_then(|params| fmtp_param::<u64>(params, FMTP_TRANSPORT_BIT_RATE));
     let b_as = as_bandwidth_from_media(m);
@@ -567,8 +556,8 @@ pub(crate) fn bit_rates_from_media(m: &SDPMediaRef) -> BitRates {
 
 /// Parse bit rates from the first `m=` block of a configuring SDP.
 pub(crate) fn bit_rates_from_sdp_text(text: &str) -> Result<BitRates, SdpError> {
-    let msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
     let media = msg.media(0).ok_or(SdpError::NoMedia)?;
     Ok(bit_rates_from_media(media))
 }
@@ -634,15 +623,15 @@ pub(crate) fn is_media_inactive(media: &SDPMediaRef) -> bool {
 
 /// Number of `m=` blocks in an SDP transport file.
 pub(crate) fn sdp_media_block_count(text: &str) -> Result<usize, SdpError> {
-    let msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
     Ok(msg.medias_len() as usize)
 }
 
 /// Count `m=` blocks that are not `a=inactive` (IS-05 `rtp_enabled: true`).
 pub(crate) fn count_active_sdp_legs(text: &str) -> Result<u8, SdpError> {
-    let msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
     let num = msg.medias_len();
     if num == 0 {
         return Err(SdpError::NoMedia);
@@ -677,7 +666,10 @@ pub(crate) fn validate_dual_leg_sdp(msg: &SDPMessage) -> Result<(), SdpError> {
 }
 
 /// Derive RTP + raw essence caps from one SDP `m=` block.
-fn parse_media_essence(msg: &SDPMessage, media: &SDPMediaRef) -> Result<ParsedMediaEssence, SdpError> {
+fn parse_media_essence(
+    msg: &SDPMessage,
+    media: &SDPMediaRef,
+) -> Result<ParsedMediaEssence, SdpError> {
     let pt_str = media.format(0).ok_or(SdpError::MissingPt)?;
     let pt: i32 = pt_str.parse().map_err(|_| SdpError::MissingPt)?;
 
@@ -729,9 +721,9 @@ fn parse_media_essence(msg: &SDPMessage, media: &SDPMediaRef) -> Result<ParsedMe
         FlowFormat::Video => caps_from_rtp_video(&rtp_caps)?,
         FlowFormat::Audio => caps_from_rtp_audio(&rtp_caps)?,
         FlowFormat::Data => caps_from_rtp_data(&rtp_caps)?,
-        FlowFormat::Unspecified => unreachable!(
-            "format dispatch above never produces FlowFormat::Unspecified"
-        ),
+        FlowFormat::Unspecified => {
+            unreachable!("format dispatch above never produces FlowFormat::Unspecified")
+        }
     };
     let caps = crate::essence_caps::caps_from(&parsed_caps, Some(&rtp_caps));
 
@@ -793,10 +785,7 @@ fn dual_leg_essence_equivalent(a: &ParsedMediaEssence, b: &ParsedMediaEssence) -
 /// [`UdpMedia::secondary`]. Inactive legs are skipped. When no leg is
 /// active, the first `m=` block is still stored on `primary` so essence
 /// caps remain available; chain gating treats zero active legs as fake.
-fn active_legs_to_udp_media(
-    essence: ParsedMediaEssence,
-    legs: [(UdpLeg, bool); 2],
-) -> UdpMedia {
+fn active_legs_to_udp_media(essence: ParsedMediaEssence, legs: [(UdpLeg, bool); 2]) -> UdpMedia {
     let leg0_fallback = legs[0].0.clone();
     let active: Vec<UdpLeg> = legs
         .into_iter()
@@ -824,8 +813,8 @@ fn active_legs_to_udp_media(
 /// legs are omitted from [`UdpMedia::secondary`]. Three or more `m=`
 /// lines, or mixed essence (e.g. video + audio), return typed errors.
 pub(crate) fn parse_sdp(text: &str) -> Result<UdpMedia, SdpError> {
-    let msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
 
     let num_medias = msg.medias_len() as usize;
     if num_medias == 0 {
@@ -889,20 +878,15 @@ pub(crate) fn normalise_to_single_active_leg(text: &str) -> Result<String, SdpEr
         return Err(SdpError::NotExactlyOneActiveLeg);
     }
     let media = parse_sdp(text)?;
-    let msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
     let origin = msg.origin();
     let origin_address = origin
         .and_then(|o| o.addr())
         .unwrap_or(defaults::UNSPECIFIED_ADDRESS);
-    let origin_session_id = origin
-        .and_then(|o| o.sess_id())
-        .unwrap_or("0");
+    let origin_session_id = origin.and_then(|o| o.sess_id()).unwrap_or("0");
     let session_name = msg.session_name().unwrap_or("nvnmos session");
-    let active_idx = (0..2).find(|&idx| {
-        msg.media(idx)
-            .is_some_and(|m| !is_media_inactive(m))
-    });
+    let active_idx = (0..2).find(|&idx| msg.media(idx).is_some_and(|m| !is_media_inactive(m)));
     let emit_ptp_ts_refclk = active_idx
         .and_then(|idx| msg.media(idx))
         .and_then(|m| m.attribute_val("ts-refclk"))
@@ -930,8 +914,8 @@ fn session_attribute_value<'a>(msg: &'a SDPMessage, key: &str) -> Option<&'a str
 
 /// Session-level `a=x-nvnmos-name` from configuring SDP text.
 pub(crate) fn resource_name_from_transport(text: &str) -> Result<Option<String>, SdpError> {
-    let msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
     Ok(session_attribute_value(&msg, "x-nvnmos-name")
         .filter(|name| !name.is_empty())
         .map(str::to_owned))
@@ -1122,7 +1106,8 @@ pub(crate) fn build_sdp(media: &UdpMedia, session: SdpSession<'_>) -> Result<Str
 
     msg.add_media(m);
 
-    msg.as_text().map_err(|e| SdpError::Serialise(e.to_string()))
+    msg.as_text()
+        .map_err(|e| SdpError::Serialise(e.to_string()))
 }
 
 /// Canonical SDP spellings for ST 2110 `a=fmtp:` keys.
@@ -1131,11 +1116,22 @@ pub(crate) fn build_sdp(media: &UdpMedia, session: SdpSession<'_>) -> Result<Str
 static ST_2110_UPPERCASE_FMTP_KEYS: LazyLock<HashSet<Ascii<&'static str>>> = LazyLock::new(|| {
     [
         // ST 2110-20 §7.2 / §7.3
-        "PM", "SSN", "TCS", "RANGE", "PAR",
+        "PM",
+        "SSN",
+        "TCS",
+        "RANGE",
+        "PAR",
         // ST 2110-21 §8.1 / §8.2 (also -40 for TROFF, TSMODE, TSDELAY)
-        "TP", "TROFF", "CMAX", "MAXUDP", "TSMODE", "TSDELAY",
+        "TP",
+        "TROFF",
+        "CMAX",
+        "MAXUDP",
+        "TSMODE",
+        "TSDELAY",
         // ST 2110-40 §6
-        "DID_SDID", "VPID_Code", "TM",
+        "DID_SDID",
+        "VPID_Code",
+        "TM",
     ]
     .into_iter()
     .map(Ascii::new)
@@ -1146,17 +1142,17 @@ static ST_2110_UPPERCASE_FMTP_KEYS: LazyLock<HashSet<Ascii<&'static str>>> = Laz
 /// encoding-names. `gstreamer-sdp` upper-cases the encoding-name
 /// on the SDP → caps direction; `nmos-cpp`'s `get_format`
 /// expects the canonical case.
-static ST_2110_LOWERCASE_RTPMAP_NAMES: LazyLock<HashSet<Ascii<&'static str>>> = LazyLock::new(|| {
-    [
-        "raw",      // RFC 4175 / ST 2110-20
-        "jxsv",     // RFC 9134 / ST 2110-22
-        "smpte291", // RFC 8331 / ST 2110-40
-    ]
-    .into_iter()
-    .map(Ascii::new)
-    .collect()
-});
-
+static ST_2110_LOWERCASE_RTPMAP_NAMES: LazyLock<HashSet<Ascii<&'static str>>> =
+    LazyLock::new(|| {
+        [
+            "raw",      // RFC 4175 / ST 2110-20
+            "jxsv",     // RFC 9134 / ST 2110-22
+            "smpte291", // RFC 8331 / ST 2110-40
+        ]
+        .into_iter()
+        .map(Ascii::new)
+        .collect()
+    });
 
 /// Rewrite the `rtpmap` and `fmtp` attributes that
 /// `set_media_from_caps` just populated on `m` into the canonical
@@ -1283,8 +1279,13 @@ fn canonicalise_fmtp_value(value: &str) -> Option<String> {
     let fixed = rest
         .split(';')
         .map(|kv| {
-            let Some((key, val)) = kv.split_once('=') else { return kv.to_owned() };
-            match ST_2110_UPPERCASE_FMTP_KEYS.get(&Ascii::new(key)).map(|m| **m) {
+            let Some((key, val)) = kv.split_once('=') else {
+                return kv.to_owned();
+            };
+            match ST_2110_UPPERCASE_FMTP_KEYS
+                .get(&Ascii::new(key))
+                .map(|m| **m)
+            {
                 Some(canonical) if canonical != key => {
                     changed = true;
                     format!("{canonical}={val}")
@@ -1413,9 +1414,7 @@ pub(crate) struct SdpOverrides<'a> {
     pub bit_rates: BitRates,
 }
 
-pub(crate) use crate::sdp_passthrough::{
-    passthrough_with_overrides, DualLegPassthroughPolicy,
-};
+pub(crate) use crate::sdp_passthrough::{DualLegPassthroughPolicy, passthrough_with_overrides};
 
 /// Cross-check the parsed [`UdpMedia`] (post-splice) against
 /// the user-supplied `caps` (essence shape) and
@@ -1536,7 +1535,10 @@ fn cross_check_essence_caps(media: &UdpMedia, caps: &gst::Caps) -> Result<(), Sd
     Ok(())
 }
 
-fn cross_check_transport_caps(media: &UdpMedia, transport_caps: &gst::Caps) -> Result<(), SdpError> {
+fn cross_check_transport_caps(
+    media: &UdpMedia,
+    transport_caps: &gst::Caps,
+) -> Result<(), SdpError> {
     // Strip always-override fields from both sides so the
     // intersect only sees cross-check fields. The audio-only
     // `clock-rate` override is implicit: passthrough has already
@@ -1685,9 +1687,8 @@ pub(crate) struct SdpBuildInput<'a> {
 /// [`SdpError::InvalidPayloadType`] when `transport_caps` carries
 /// a payload-type outside RFC 3551's dynamic range.
 pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
-    let format = essence_caps_format(input.caps).ok_or_else(|| {
-        SdpError::UnsupportedEssence(format!("essence caps `{}`", input.caps))
-    })?;
+    let format = essence_caps_format(input.caps)
+        .ok_or_else(|| SdpError::UnsupportedEssence(format!("essence caps `{}`", input.caps)))?;
 
     let payload_type = resolve_payload_type(format, input.transport_caps)?;
 
@@ -1700,17 +1701,9 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
                 .structure(0)
                 .is_some_and(|s| matches!(s.name().as_str(), "image/x-jxsc" | "video/x-jxsv"));
             if is_jxsv {
-                rtp_caps_from_video_jxsv(
-                    input.caps,
-                    payload_type,
-                    input.narrow_traffic_profile,
-                )?
+                rtp_caps_from_video_jxsv(input.caps, payload_type, input.narrow_traffic_profile)?
             } else {
-                rtp_caps_from_video(
-                    input.caps,
-                    payload_type,
-                    input.narrow_traffic_profile,
-                )?
+                rtp_caps_from_video(input.caps, payload_type, input.narrow_traffic_profile)?
             }
         }
         FlowFormat::Audio => {
@@ -1778,8 +1771,7 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
     };
 
     let origin_session_id = stable_origin_session_id(input.node_seed, input.side, input.name);
-    let emit_ptp_ts_refclk =
-        input.narrow_traffic_profile && input.side == Side::Sender;
+    let emit_ptp_ts_refclk = input.narrow_traffic_profile && input.side == Side::Sender;
     let session = SdpSession {
         origin_address,
         origin_session_id: &origin_session_id,
@@ -2088,7 +2080,9 @@ fn caps_colorimetry_from_sdp(sdp: &str, depth: u32, tcs: Option<&str>) -> Option
 /// presets return `None`, leaving the SDP without explicit
 /// `colorimetry=` / `TCS=` parameters; standards-compliant
 /// receivers then fall back to ST 2110-20's "unspecified" entry.
-fn sdp_colorimetry_from_caps(caps_colorimetry: &str) -> Option<(&'static str, Option<&'static str>)> {
+fn sdp_colorimetry_from_caps(
+    caps_colorimetry: &str,
+) -> Option<(&'static str, Option<&'static str>)> {
     match caps_colorimetry {
         "bt601" => Some(("BT601", None)),
         "bt709" => Some(("BT709", None)),
@@ -2201,13 +2195,14 @@ fn caps_from_rtp_video(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
         .unwrap_or("")
         .parse()
         .map_err(|_| SdpError::UnsupportedEssence("missing or non-integer width".to_owned()))?;
-    let height: i32 = s
-        .get::<&str>("height")
-        .unwrap_or("")
-        .parse()
-        .map_err(|_| SdpError::UnsupportedEssence("missing or non-integer height".to_owned()))?;
+    let height: i32 =
+        s.get::<&str>("height").unwrap_or("").parse().map_err(|_| {
+            SdpError::UnsupportedEssence("missing or non-integer height".to_owned())
+        })?;
     let (fr_num, fr_den) = parse_exact_framerate(s.get::<&str>("exactframerate").unwrap_or(""))
-        .ok_or_else(|| SdpError::UnsupportedEssence("missing or unparseable exactframerate".to_owned()))?;
+        .ok_or_else(|| {
+            SdpError::UnsupportedEssence("missing or unparseable exactframerate".to_owned())
+        })?;
     // RFC 4175 §6.1's `interlace` flag is a value-less fmtp token;
     // `gst_sdp_media_get_caps_from_media` translates value-less
     // params into `<param>=(string)"1"` on the caps, so a missing
@@ -2280,9 +2275,9 @@ fn caps_from_rtp_audio(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
             )));
         }
     };
-    let rate: i32 = s.get::<i32>("clock-rate").map_err(|_| {
-        SdpError::UnsupportedEssence("audio caps missing clock-rate".to_owned())
-    })?;
+    let rate: i32 = s
+        .get::<i32>("clock-rate")
+        .map_err(|_| SdpError::UnsupportedEssence("audio caps missing clock-rate".to_owned()))?;
     let channels: i32 = s
         .get::<&str>("encoding-params")
         .ok()
@@ -2457,9 +2452,7 @@ fn rtp_caps_from_video(
     let (fr_num, fr_den) = s
         .get::<gst::Fraction>("framerate")
         .map(|f| (f.numer() as u32, f.denom() as u32))
-        .map_err(|_| {
-            SdpError::UnsupportedEssence("raw video caps missing framerate".to_owned())
-        })?;
+        .map_err(|_| SdpError::UnsupportedEssence("raw video caps missing framerate".to_owned()))?;
     let exactframerate = format_exact_framerate(fr_num, fr_den);
     let interlace_mode = s.get::<&str>("interlace-mode").unwrap_or("progressive");
     let colorimetry_caps = s.get::<&str>("colorimetry").ok();
@@ -2502,8 +2495,7 @@ fn rtp_caps_from_video(
     // a Flow has no colorimetry tag set and the value our test
     // SDP fixtures use. Callers wanting BT2020 / BT2100 etc.
     // need to set `colorimetry=` upstream of the `nmossink`.
-    let (colorimetry, tcs) =
-        colorimetry_sdp.unwrap_or((defaults::ST2110_20_COLORIMETRY, None));
+    let (colorimetry, tcs) = colorimetry_sdp.unwrap_or((defaults::ST2110_20_COLORIMETRY, None));
     caps_text.push_str(&format!(",colorimetry=(string){colorimetry}"));
     if let Some(tcs_value) = tcs {
         caps_text.push_str(&format!(",tcs=(string){tcs_value}"));
@@ -2631,9 +2623,7 @@ fn rtp_caps_from_video_jxsv(
     let (fr_num, fr_den) = s
         .get::<gst::Fraction>("framerate")
         .map(|f| (f.numer() as u32, f.denom() as u32))
-        .map_err(|_| {
-            SdpError::UnsupportedEssence("JPEG XS caps missing framerate".to_owned())
-        })?;
+        .map_err(|_| SdpError::UnsupportedEssence("JPEG XS caps missing framerate".to_owned()))?;
     let exactframerate = format_exact_framerate(fr_num, fr_den);
 
     // RFC 9134 §7 fmtp: `packetmode=0` (codestream) is the only
@@ -2807,7 +2797,7 @@ fn rtp_caps_from_data(caps: &gst::Caps, payload_type: u8) -> Result<gst::Caps, S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sdp_passthrough::{reject_unsupported_multi_media, DualLegPassthroughPolicy};
+    use crate::sdp_passthrough::{DualLegPassthroughPolicy, reject_unsupported_multi_media};
     use crate::test_support::init_gst;
 
     #[test]
@@ -2902,7 +2892,7 @@ mod tests {
     fn gst_sdp_strips_ttl_for_unicast_c_lines() {
         init_gst();
         for (addr, expect_suffix) in [
-            ("239.1.1.1", true), // multicast — TTL required
+            ("239.1.1.1", true),   // multicast — TTL required
             ("192.0.2.10", false), // unicast — TTL must be omitted
         ] {
             let mut msg = SDPMessage::new();
@@ -3007,10 +2997,8 @@ mod tests {
     #[test]
     fn source_filter_absent_yields_none_source_ip() {
         init_gst();
-        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace(
-            "a=source-filter: incl IN IP4 239.1.1.1 192.0.2.20\r\n",
-            "",
-        );
+        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
+            .replace("a=source-filter: incl IN IP4 239.1.1.1 192.0.2.20\r\n", "");
         let media = parse_sdp(&sdp).expect("parse");
         assert_eq!(media.primary.source_ip, None);
     }
@@ -3029,7 +3017,8 @@ mod tests {
     #[test]
     fn x_nvnmos_iface_ip_absent_yields_none_interface_ip() {
         init_gst();
-        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("a=x-nvnmos-iface-ip:192.0.2.11\r\n", "");
+        let sdp =
+            VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("a=x-nvnmos-iface-ip:192.0.2.11\r\n", "");
         let media = parse_sdp(&sdp).expect("parse");
         assert_eq!(media.primary.interface_ip, None);
     }
@@ -3037,10 +3026,8 @@ mod tests {
     #[test]
     fn resource_name_from_transport_reads_session_attribute() {
         init_gst();
-        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace(
-            "t=0 0\r\n",
-            "t=0 0\r\na=x-nvnmos-name:cam-a\r\n",
-        );
+        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
+            .replace("t=0 0\r\n", "t=0 0\r\na=x-nvnmos-name:cam-a\r\n");
         assert_eq!(
             resource_name_from_transport(&sdp).expect("parse"),
             Some("cam-a".to_owned()),
@@ -3067,7 +3054,8 @@ mod tests {
     #[test]
     fn fractional_framerate_is_supported() {
         init_gst();
-        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("exactframerate=50;", "exactframerate=30000/1001;");
+        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
+            .replace("exactframerate=50;", "exactframerate=30000/1001;");
         let media = parse_sdp(&sdp).expect("parse");
         let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
@@ -3079,12 +3067,19 @@ mod tests {
     /// Round-trip the colorimetry mapping through `parse_sdp` rather
     /// than calling `caps_colorimetry_from_sdp` directly; this keeps the
     /// fmtp-key-name plumbing (`colorimetry` vs `tcs`) covered too.
-    fn colorimetry_via_parse(sdp_colorimetry: &str, depth: u32, tcs: Option<&str>) -> Option<String> {
+    fn colorimetry_via_parse(
+        sdp_colorimetry: &str,
+        depth: u32,
+        tcs: Option<&str>,
+    ) -> Option<String> {
         init_gst();
         let depth_str = depth.to_string();
         let mut sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
             .replace("depth=10;", &format!("depth={depth_str};"))
-            .replace("colorimetry=BT709;", &format!("colorimetry={sdp_colorimetry};"));
+            .replace(
+                "colorimetry=BT709;",
+                &format!("colorimetry={sdp_colorimetry};"),
+            );
         // The fixture's `TCS=SDR;` lives just before `colorimetry=`,
         // so rewrite the TCS value too (or drop it).
         sdp = match tcs {
@@ -3249,12 +3244,10 @@ mod tests {
     #[test]
     fn dual_leg_both_inactive_parses_with_primary_from_first_m_block() {
         init_gst();
-        let sdp = dual_leg_video_sdp()
-            .replace(
-                "m=video 5004 RTP/AVP 96\r\n",
-                "m=video 5004 RTP/AVP 96\r\na=inactive\r\n",
-            )
-            + "a=inactive\r\n";
+        let sdp = dual_leg_video_sdp().replace(
+            "m=video 5004 RTP/AVP 96\r\n",
+            "m=video 5004 RTP/AVP 96\r\na=inactive\r\n",
+        ) + "a=inactive\r\n";
         let media = parse_sdp(&sdp).expect("parse");
         assert_eq!(media.primary.destination_ip, "239.1.1.1");
         assert!(media.secondary.is_none());
@@ -3296,12 +3289,9 @@ mod tests {
             destination_ip: Some("239.9.9.9"),
             ..Default::default()
         };
-        let out = passthrough_with_overrides(
-            &sdp,
-            &overrides,
-            DualLegPassthroughPolicy::AllowDualLeg,
-        )
-        .expect("splice");
+        let out =
+            passthrough_with_overrides(&sdp, &overrides, DualLegPassthroughPolicy::AllowDualLeg)
+                .expect("splice");
         assert!(
             !out.contains("a=inactive"),
             "leg 0 inactive must be cleared when destination-ip is set: {out}",
@@ -3333,12 +3323,10 @@ mod tests {
             count_active_sdp_legs(VIDEO_YCBCR_422_10BIT_1080P50_SDP).expect("count"),
             1
         );
-        let both_inactive = dual_leg_video_sdp()
-            .replace(
-                "m=video 5004 RTP/AVP 96\r\n",
-                "m=video 5004 RTP/AVP 96\r\na=inactive\r\n",
-            )
-            + "a=inactive\r\n";
+        let both_inactive = dual_leg_video_sdp().replace(
+            "m=video 5004 RTP/AVP 96\r\n",
+            "m=video 5004 RTP/AVP 96\r\na=inactive\r\n",
+        ) + "a=inactive\r\n";
         assert_eq!(count_active_sdp_legs(&both_inactive).expect("count"), 0);
     }
 
@@ -3546,9 +3534,7 @@ mod tests {
     #[test]
     fn extract_source_ip_from_filter_multi_source_returns_none() {
         assert_eq!(
-            extract_source_ip_from_filter(
-                "incl IN IP4 239.1.1.1 192.0.2.20 192.0.2.21"
-            ),
+            extract_source_ip_from_filter("incl IN IP4 239.1.1.1 192.0.2.20 192.0.2.21"),
             None,
         );
     }
@@ -3592,9 +3578,15 @@ mod tests {
             round_tripped.primary.destination_port,
             original.primary.destination_port,
         );
-        assert_eq!(round_tripped.primary.interface_ip, original.primary.interface_ip);
+        assert_eq!(
+            round_tripped.primary.interface_ip,
+            original.primary.interface_ip
+        );
         assert_eq!(round_tripped.primary.source_ip, original.primary.source_ip);
-        assert_eq!(round_tripped.primary.source_port, original.primary.source_port);
+        assert_eq!(
+            round_tripped.primary.source_port,
+            original.primary.source_port
+        );
 
         let orig_raw = original.caps.structure(0).unwrap();
         let rt_raw = round_tripped.caps.structure(0).unwrap();
@@ -3627,15 +3619,24 @@ mod tests {
             round_tripped.primary.destination_port,
             original.primary.destination_port,
         );
-        assert_eq!(round_tripped.primary.interface_ip, original.primary.interface_ip);
+        assert_eq!(
+            round_tripped.primary.interface_ip,
+            original.primary.interface_ip
+        );
         assert_eq!(round_tripped.primary.source_ip, original.primary.source_ip);
-        assert_eq!(round_tripped.primary.source_port, original.primary.source_port);
+        assert_eq!(
+            round_tripped.primary.source_port,
+            original.primary.source_port
+        );
 
         let orig_raw = original.caps.structure(0).unwrap();
         let rt_raw = round_tripped.caps.structure(0).unwrap();
         assert_eq!(rt_raw.get::<&str>("format"), orig_raw.get::<&str>("format"));
         assert_eq!(rt_raw.get::<i32>("rate"), orig_raw.get::<i32>("rate"));
-        assert_eq!(rt_raw.get::<i32>("channels"), orig_raw.get::<i32>("channels"));
+        assert_eq!(
+            rt_raw.get::<i32>("channels"),
+            orig_raw.get::<i32>("channels")
+        );
     }
 
     #[test]
@@ -3657,10 +3658,8 @@ mod tests {
     #[test]
     fn build_sdp_omits_source_filter_when_source_ip_absent() {
         init_gst();
-        let stripped = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace(
-            "a=source-filter: incl IN IP4 239.1.1.1 192.0.2.20\r\n",
-            "",
-        );
+        let stripped = VIDEO_YCBCR_422_10BIT_1080P50_SDP
+            .replace("a=source-filter: incl IN IP4 239.1.1.1 192.0.2.20\r\n", "");
         let media = parse_sdp(&stripped).expect("parse");
         assert!(media.primary.source_ip.is_none());
         let text = build_sdp(&media, test_session()).expect("build");
@@ -3850,8 +3849,8 @@ mod tests {
     #[test]
     fn reject_unsupported_multi_media_accepts_single_block() {
         init_gst();
-        let msg = SDPMessage::parse_buffer(VIDEO_YCBCR_422_10BIT_1080P50_SDP.as_bytes())
-            .expect("parse");
+        let msg =
+            SDPMessage::parse_buffer(VIDEO_YCBCR_422_10BIT_1080P50_SDP.as_bytes()).expect("parse");
         reject_unsupported_multi_media(&msg, DualLegPassthroughPolicy::RejectDualLeg)
             .expect("single media ok");
     }
@@ -3927,12 +3926,14 @@ mod tests {
     #[test]
     fn passthrough_preserves_unknown_fmtp_keys() {
         init_gst();
-        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace(
-            "PM=2110GPM;",
-            "PM=2110GPM; SomeFutureKey=Value;",
-        );
-        let out =
-            passthrough_with_overrides(&sdp, &SdpOverrides::default(), DualLegPassthroughPolicy::RejectDualLeg).expect("passthrough");
+        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
+            .replace("PM=2110GPM;", "PM=2110GPM; SomeFutureKey=Value;");
+        let out = passthrough_with_overrides(
+            &sdp,
+            &SdpOverrides::default(),
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("passthrough");
         assert!(
             out.contains("SomeFutureKey=Value"),
             "vendor/future fmtp keys must survive passthrough:\n{out}",
@@ -3942,9 +3943,14 @@ mod tests {
     #[test]
     fn passthrough_preserves_information_line() {
         init_gst();
-        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP.replace("s=Example\r\n", "s=Example\r\ni=Studio A\r\n");
-        let out =
-            passthrough_with_overrides(&sdp, &SdpOverrides::default(), DualLegPassthroughPolicy::RejectDualLeg).expect("passthrough");
+        let sdp = VIDEO_YCBCR_422_10BIT_1080P50_SDP
+            .replace("s=Example\r\n", "s=Example\r\ni=Studio A\r\n");
+        let out = passthrough_with_overrides(
+            &sdp,
+            &SdpOverrides::default(),
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("passthrough");
         assert!(out.contains("i=Studio A"));
     }
 
@@ -3953,7 +3959,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { label: Some("new label"), ..Default::default() },
+            &SdpOverrides {
+                label: Some("new label"),
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -3991,7 +4000,10 @@ mod tests {
         //      regression that earlier emitted it at media level.
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { name: Some("Camera 1"), ..Default::default() },
+            &SdpOverrides {
+                name: Some("Camera 1"),
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4004,9 +4016,7 @@ mod tests {
         let name_pos = spliced
             .find("a=x-nvnmos-name:")
             .expect("a=x-nvnmos-name: line must be present");
-        let media_pos = spliced
-            .find("\r\nm=")
-            .expect("m= line must be present");
+        let media_pos = spliced.find("\r\nm=").expect("m= line must be present");
         assert!(
             name_pos < media_pos,
             "a=x-nvnmos-name (offset {name_pos}) must appear before first m= (offset {media_pos}); \
@@ -4019,7 +4029,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { group_hint: Some("SDI 1:Video"), ..Default::default() },
+            &SdpOverrides {
+                group_hint: Some("SDI 1:Video"),
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4039,13 +4052,19 @@ mod tests {
         // splice an unrelated override and assert the hint survives.
         let with_hint = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { group_hint: Some("orig:Video"), ..Default::default() },
+            &SdpOverrides {
+                group_hint: Some("orig:Video"),
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("seed");
         let spliced = passthrough_with_overrides(
             &with_hint,
-            &SdpOverrides { label: Some("new label"), ..Default::default() },
+            &SdpOverrides {
+                label: Some("new label"),
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4088,12 +4107,18 @@ mod tests {
     fn passthrough_all_none_preserves_input_legs() {
         init_gst();
         let original = parse_sdp(VIDEO_YCBCR_422_10BIT_1080P50_SDP).expect("parse");
-        let spliced =
-            passthrough_with_overrides(VIDEO_YCBCR_422_10BIT_1080P50_SDP, &SdpOverrides::default(), DualLegPassthroughPolicy::RejectDualLeg)
-                .expect("splice");
+        let spliced = passthrough_with_overrides(
+            VIDEO_YCBCR_422_10BIT_1080P50_SDP,
+            &SdpOverrides::default(),
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("splice");
         let after = parse_sdp(&spliced).expect("re-parse");
         // Leg fields must round-trip unchanged.
-        assert_eq!(after.primary.destination_ip, original.primary.destination_ip);
+        assert_eq!(
+            after.primary.destination_ip,
+            original.primary.destination_ip
+        );
         assert_eq!(
             after.primary.destination_port,
             original.primary.destination_port
@@ -4114,9 +4139,12 @@ mod tests {
         // leg overrides, the splice must keep the same `o=`
         // address and session-id (the daemon may rely on these
         // being stable across the configuring-SDP lifecycle).
-        let spliced =
-            passthrough_with_overrides(VIDEO_YCBCR_422_10BIT_1080P50_SDP, &SdpOverrides::default(), DualLegPassthroughPolicy::RejectDualLeg)
-                .expect("splice");
+        let spliced = passthrough_with_overrides(
+            VIDEO_YCBCR_422_10BIT_1080P50_SDP,
+            &SdpOverrides::default(),
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("splice");
         let msg = SDPMessage::parse_buffer(spliced.as_bytes()).expect("re-parse");
         let origin = msg.origin().expect("origin");
         assert_eq!(origin.addr().unwrap(), "192.0.2.10");
@@ -4126,8 +4154,12 @@ mod tests {
     #[test]
     fn passthrough_invalid_input_propagates_parse_error() {
         init_gst();
-        let err = passthrough_with_overrides("not an SDP at all", &SdpOverrides::default(), DualLegPassthroughPolicy::RejectDualLeg)
-            .expect_err("must error");
+        let err = passthrough_with_overrides(
+            "not an SDP at all",
+            &SdpOverrides::default(),
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect_err("must error");
         assert!(matches!(err, SdpError::Parse(_) | SdpError::NoMedia));
     }
 
@@ -4149,15 +4181,24 @@ mod tests {
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
-        assert!(spliced.contains("m=audio 5004 RTP/AVP 99"),
-            "m= must carry new pt 99; got: {spliced}");
-        assert!(spliced.contains("a=rtpmap:99 L24/48000/2"),
-            "a=rtpmap must carry new pt 99; got: {spliced}");
-        assert!(spliced.contains("a=fmtp:99"),
-            "a=fmtp must be re-keyed to new pt 99; got: {spliced}");
+        assert!(
+            spliced.contains("m=audio 5004 RTP/AVP 99"),
+            "m= must carry new pt 99; got: {spliced}"
+        );
+        assert!(
+            spliced.contains("a=rtpmap:99 L24/48000/2"),
+            "a=rtpmap must carry new pt 99; got: {spliced}"
+        );
+        assert!(
+            spliced.contains("a=fmtp:99"),
+            "a=fmtp must be re-keyed to new pt 99; got: {spliced}"
+        );
         // Re-parse to confirm the model round-trips.
         let m = parse_sdp(&spliced).expect("re-parse");
-        let pt = m.rtp_caps.structure(0).and_then(|s| s.get::<i32>("payload").ok());
+        let pt = m
+            .rtp_caps
+            .structure(0)
+            .and_then(|s| s.get::<i32>("payload").ok());
         assert_eq!(pt, Some(99));
     }
 
@@ -4175,10 +4216,14 @@ mod tests {
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
-        assert!(spliced.contains("a=rtpmap:97 L24/96000/2"),
-            "a=rtpmap clock-rate must be 96000; got: {spliced}");
-        assert!(!spliced.contains("L24/48000/"),
-            "old 48000 must be gone; got: {spliced}");
+        assert!(
+            spliced.contains("a=rtpmap:97 L24/96000/2"),
+            "a=rtpmap clock-rate must be 96000; got: {spliced}"
+        );
+        assert!(
+            !spliced.contains("L24/48000/"),
+            "old 48000 must be gone; got: {spliced}"
+        );
     }
 
     /// Audio ptime + maxptime override: GStreamer convention
@@ -4198,12 +4243,18 @@ mod tests {
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
-        assert!(spliced.contains("a=ptime:1\r\n"),
-            "a=ptime must be 1ms; got: {spliced}");
-        assert!(spliced.contains("a=maxptime:2\r\n"),
-            "a=maxptime must be 2ms; got: {spliced}");
-        assert!(!spliced.contains("a=ptime:0.125"),
-            "old 0.125 ms ptime must be gone; got: {spliced}");
+        assert!(
+            spliced.contains("a=ptime:1\r\n"),
+            "a=ptime must be 1ms; got: {spliced}"
+        );
+        assert!(
+            spliced.contains("a=maxptime:2\r\n"),
+            "a=maxptime must be 2ms; got: {spliced}"
+        );
+        assert!(
+            !spliced.contains("a=ptime:0.125"),
+            "old 0.125 ms ptime must be gone; got: {spliced}"
+        );
     }
 
     /// Audio-only slots silently no-op for video raw essence
@@ -4229,12 +4280,13 @@ mod tests {
         // `caps_from_media` upper-cases the rtpmap
         // encoding-name; match both forms.
         assert!(
-            spliced.contains("a=rtpmap:96 RAW/90000")
-                || spliced.contains("a=rtpmap:96 raw/90000"),
+            spliced.contains("a=rtpmap:96 RAW/90000") || spliced.contains("a=rtpmap:96 raw/90000"),
             "video clock-rate must stay 90000 (audio_clock_rate ignored); got: {spliced}",
         );
-        assert!(!spliced.contains("a=ptime:"),
-            "video must have no a=ptime (audio-only slot ignored); got: {spliced}");
+        assert!(
+            !spliced.contains("a=ptime:"),
+            "video must have no a=ptime (audio-only slot ignored); got: {spliced}"
+        );
     }
 
     /// Video pt override: `m=video … 96` → `… 100`. Pt
@@ -4252,8 +4304,10 @@ mod tests {
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
-        assert!(spliced.contains("m=video 5004 RTP/AVP 100"),
-            "m= must carry new pt 100; got: {spliced}");
+        assert!(
+            spliced.contains("m=video 5004 RTP/AVP 100"),
+            "m= must carry new pt 100; got: {spliced}"
+        );
         // `caps_from_media` upper-cases the rtpmap
         // encoding-name via `g_ascii_strup`; the round-trip
         // through caps therefore emits `RAW`, not `raw`. Match
@@ -4313,13 +4367,8 @@ mod tests {
         init_gst();
         let media = parse_sdp(VIDEO_YCBCR_422_10BIT_1080P50_SDP).expect("parse");
         let audio_caps = gst::Caps::builder("audio/x-raw").build();
-        let err = cross_check_essence(
-            &media,
-            Some(&audio_caps),
-            None,
-            EssenceCrossCheckMode::Full,
-        )
-        .expect_err("format-family mismatch must error");
+        let err = cross_check_essence(&media, Some(&audio_caps), None, EssenceCrossCheckMode::Full)
+            .expect_err("format-family mismatch must error");
         match err {
             SdpError::FormatMismatch { caps, sdp } => {
                 assert_eq!(caps, FlowFormat::Audio);
@@ -4340,15 +4389,12 @@ mod tests {
             .field("width", 1280i32)
             .field("height", 720i32)
             .build();
-        let err = cross_check_essence(
-            &media,
-            Some(&caps),
-            None,
-            EssenceCrossCheckMode::Full,
-        )
-        .expect_err("shape mismatch must error");
-        assert!(matches!(err, SdpError::EssenceShapeMismatch { .. }),
-            "got: {err:?}");
+        let err = cross_check_essence(&media, Some(&caps), None, EssenceCrossCheckMode::Full)
+            .expect_err("shape mismatch must error");
+        assert!(
+            matches!(err, SdpError::EssenceShapeMismatch { .. }),
+            "got: {err:?}"
+        );
     }
 
     /// Transport-caps mismatch on a cross-check field
@@ -4360,15 +4406,12 @@ mod tests {
         let transport = gst::Caps::builder("application/x-rtp")
             .field("encoding-name", "L24")
             .build();
-        let err = cross_check_essence(
-            &media,
-            None,
-            Some(&transport),
-            EssenceCrossCheckMode::Full,
-        )
-        .expect_err("encoding-name mismatch must error");
-        assert!(matches!(err, SdpError::TransportCapsMismatch { .. }),
-            "got: {err:?}");
+        let err = cross_check_essence(&media, None, Some(&transport), EssenceCrossCheckMode::Full)
+            .expect_err("encoding-name mismatch must error");
+        assert!(
+            matches!(err, SdpError::TransportCapsMismatch { .. }),
+            "got: {err:?}"
+        );
     }
 
     /// Video clock-rate is cross-check (not override): a
@@ -4381,15 +4424,12 @@ mod tests {
         let transport = gst::Caps::builder("application/x-rtp")
             .field("clock-rate", 48_000i32)
             .build();
-        let err = cross_check_essence(
-            &media,
-            None,
-            Some(&transport),
-            EssenceCrossCheckMode::Full,
-        )
-        .expect_err("video clock-rate mismatch must error");
-        assert!(matches!(err, SdpError::TransportCapsMismatch { .. }),
-            "got: {err:?}");
+        let err = cross_check_essence(&media, None, Some(&transport), EssenceCrossCheckMode::Full)
+            .expect_err("video clock-rate mismatch must error");
+        assert!(
+            matches!(err, SdpError::TransportCapsMismatch { .. }),
+            "got: {err:?}"
+        );
     }
 
     /// Always-override fields (`payload`, `a-ptime`,
@@ -4412,13 +4452,8 @@ mod tests {
             .field("encoding-name", "RAW")
             .field("clock-rate", 90_000i32)
             .build();
-        cross_check_essence(
-            &media,
-            None,
-            Some(&transport),
-            EssenceCrossCheckMode::Full,
-        )
-        .expect("override-only disagreement must pass");
+        cross_check_essence(&media, None, Some(&transport), EssenceCrossCheckMode::Full)
+            .expect("override-only disagreement must pass");
     }
 
     /// Audio essence: the splice has already copied a user-
@@ -4445,13 +4480,8 @@ mod tests {
         let media = parse_sdp(&spliced).expect("re-parse");
         // 2. Cross-check matches because both now agree on
         //    clock-rate=96000.
-        cross_check_essence(
-            &media,
-            None,
-            Some(&transport),
-            EssenceCrossCheckMode::Full,
-        )
-        .expect("audio override + cross-check → pass");
+        cross_check_essence(&media, None, Some(&transport), EssenceCrossCheckMode::Full)
+            .expect("audio override + cross-check → pass");
     }
 
     /// Wide receiver activation: essence shape mismatch is
@@ -4487,7 +4517,10 @@ mod tests {
             EssenceCrossCheckMode::FormatFamilyOnly,
         )
         .expect_err("format-family mismatch must error");
-        assert!(matches!(err, SdpError::FormatMismatch { .. }), "got: {err:?}");
+        assert!(
+            matches!(err, SdpError::FormatMismatch { .. }),
+            "got: {err:?}"
+        );
     }
 
     /// Format-family-only mode ignores transport-caps disagreements.
@@ -4523,7 +4556,7 @@ mod tests {
                     ..Default::default()
                 },
                 DualLegPassthroughPolicy::RejectDualLeg,
-        )
+            )
             .expect_err(&format!("pt={pt} must be rejected"));
             match err {
                 SdpError::InvalidPayloadType(p) => {
@@ -4541,7 +4574,7 @@ mod tests {
                     ..Default::default()
                 },
                 DualLegPassthroughPolicy::RejectDualLeg,
-        )
+            )
             .unwrap_or_else(|e| panic!("pt={pt} must be valid: {e}"));
         }
     }
@@ -4631,7 +4664,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { caps_mode: CapsMode::Auto, ..Default::default() },
+            &SdpOverrides {
+                caps_mode: CapsMode::Auto,
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4646,7 +4682,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_WIDE_SDP,
-            &SdpOverrides { caps_mode: CapsMode::Auto, ..Default::default() },
+            &SdpOverrides {
+                caps_mode: CapsMode::Auto,
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4661,7 +4700,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_WIDE_SDP,
-            &SdpOverrides { caps_mode: CapsMode::Narrow, ..Default::default() },
+            &SdpOverrides {
+                caps_mode: CapsMode::Narrow,
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4676,7 +4718,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { caps_mode: CapsMode::Narrow, ..Default::default() },
+            &SdpOverrides {
+                caps_mode: CapsMode::Narrow,
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4691,7 +4736,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_SDP,
-            &SdpOverrides { caps_mode: CapsMode::Wide, ..Default::default() },
+            &SdpOverrides {
+                caps_mode: CapsMode::Wide,
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4712,7 +4760,10 @@ mod tests {
         init_gst();
         let spliced = passthrough_with_overrides(
             VIDEO_YCBCR_422_10BIT_1080P50_WIDE_SDP,
-            &SdpOverrides { caps_mode: CapsMode::Wide, ..Default::default() },
+            &SdpOverrides {
+                caps_mode: CapsMode::Wide,
+                ..Default::default()
+            },
             DualLegPassthroughPolicy::RejectDualLeg,
         )
         .expect("splice");
@@ -4806,7 +4857,8 @@ mod tests {
     #[test]
     fn anc_smpte291_fractional_exactframerate() {
         init_gst();
-        let sdp = ANC_SMPTE291_1080P60_SDP.replace("exactframerate=60;", "exactframerate=30000/1001;");
+        let sdp =
+            ANC_SMPTE291_1080P60_SDP.replace("exactframerate=60;", "exactframerate=30000/1001;");
         let media = parse_sdp(&sdp).expect("parse");
         let raw_s = media.caps.structure(0).expect("raw caps");
         assert_eq!(
@@ -4822,8 +4874,8 @@ mod tests {
         // Drop the fmtp line entirely — ANC SDPs in the wild often
         // don't carry it because the rate is implicit from the
         // paired video flow.
-        let sdp = ANC_SMPTE291_1080P60_SDP
-            .replace("a=fmtp:100 exactframerate=60; VPID_Code=132\r\n", "");
+        let sdp =
+            ANC_SMPTE291_1080P60_SDP.replace("a=fmtp:100 exactframerate=60; VPID_Code=132\r\n", "");
         let media = parse_sdp(&sdp).expect("parse");
         let raw_s = media.caps.structure(0).expect("raw caps");
         assert!(
@@ -4859,8 +4911,7 @@ mod tests {
         let rt_raw = round_tripped.caps.structure(0).unwrap();
         assert_eq!(rt_raw.name(), orig_raw.name());
         assert!(
-            orig_raw.get::<&str>("alignment").is_err()
-                && rt_raw.get::<&str>("alignment").is_err(),
+            orig_raw.get::<&str>("alignment").is_err() && rt_raw.get::<&str>("alignment").is_err(),
             "ANC raw caps carry no `alignment` on either side of the round-trip",
         );
         assert_eq!(
@@ -4873,7 +4924,10 @@ mod tests {
     fn parse_exact_framerate_integer_and_fraction() {
         assert_eq!(parse_exact_framerate("50"), Some((50, 1)));
         assert_eq!(parse_exact_framerate("30000/1001"), Some((30_000, 1_001)));
-        assert_eq!(parse_exact_framerate("  60000 / 1001 "), Some((60_000, 1_001)));
+        assert_eq!(
+            parse_exact_framerate("  60000 / 1001 "),
+            Some((60_000, 1_001))
+        );
     }
 
     #[test]
@@ -4903,7 +4957,11 @@ mod tests {
     fn format_exact_framerate_round_trips_parse_exact_framerate() {
         for (num, den) in [(25_u32, 1_u32), (50, 1), (30_000, 1_001), (60_000, 1_001)] {
             let s = format_exact_framerate(num, den);
-            assert_eq!(parse_exact_framerate(&s), Some((num, den)), "round-trip {s}");
+            assert_eq!(
+                parse_exact_framerate(&s),
+                Some((num, den)),
+                "round-trip {s}"
+            );
         }
     }
 
@@ -4929,14 +4987,8 @@ mod tests {
 
     #[test]
     fn sdp_colorimetry_from_caps_pins_each_preset() {
-        assert_eq!(
-            sdp_colorimetry_from_caps("bt601"),
-            Some(("BT601", None)),
-        );
-        assert_eq!(
-            sdp_colorimetry_from_caps("bt709"),
-            Some(("BT709", None)),
-        );
+        assert_eq!(sdp_colorimetry_from_caps("bt601"), Some(("BT601", None)),);
+        assert_eq!(sdp_colorimetry_from_caps("bt709"), Some(("BT709", None)),);
         assert_eq!(
             sdp_colorimetry_from_caps("smpte240m"),
             Some(("SMPTE240M", None)),
@@ -4945,10 +4997,7 @@ mod tests {
 
     #[test]
     fn sdp_colorimetry_from_caps_collapses_bt2020_depth_variants_to_one_sdp_value() {
-        assert_eq!(
-            sdp_colorimetry_from_caps("bt2020"),
-            Some(("BT2020", None)),
-        );
+        assert_eq!(sdp_colorimetry_from_caps("bt2020"), Some(("BT2020", None)),);
         assert_eq!(
             sdp_colorimetry_from_caps("bt2020-10"),
             Some(("BT2020", None)),
@@ -5019,7 +5068,10 @@ mod tests {
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.name().as_str(), "application/x-rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
-        assert_eq!(s.get::<i32>("clock-rate").unwrap(), defaults::VIDEO_CLOCK_RATE);
+        assert_eq!(
+            s.get::<i32>("clock-rate").unwrap(),
+            defaults::VIDEO_CLOCK_RATE
+        );
         // Canonical SDP-form case: RFC 4175 lower-case
         // `raw`, ST 2110-20 upper-case `PM` / `SSN`. See
         // the comment on the caps-text builder in
@@ -5049,13 +5101,7 @@ mod tests {
     #[test]
     fn rtp_caps_from_video_emits_fractional_exactframerate() {
         init_gst();
-        let raw = raw_video_caps(
-            "UYVP",
-            1920,
-            1080,
-            gst::Fraction::new(30_000, 1_001),
-            None,
-        );
+        let raw = raw_video_caps("UYVP", 1920, 1080, gst::Fraction::new(30_000, 1_001), None);
         let rtp = rtp_caps_from_video(&raw, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "30000/1001");
@@ -5202,10 +5248,7 @@ mod tests {
         // (depth carries the bit-depth distinction) and then
         // expands back to bt2020-10 on the parse side because
         // depth=10 is in the RTP caps.
-        assert_eq!(
-            rt.get::<&str>("colorimetry").unwrap(),
-            "bt2020-10",
-        );
+        assert_eq!(rt.get::<&str>("colorimetry").unwrap(), "bt2020-10",);
     }
 
     // -- rtp_caps_from_audio
@@ -5264,9 +5307,8 @@ mod tests {
     fn rtp_caps_from_audio_emits_a_maxptime_when_supplied() {
         init_gst();
         let raw = raw_audio_caps("S24BE", 48_000, 2);
-        let rtp =
-            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, Some(4_000_000), None)
-                .expect("synth");
+        let rtp = rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, Some(4_000_000), None)
+            .expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("a-maxptime").unwrap(), "4");
     }
@@ -5275,8 +5317,8 @@ mod tests {
     fn rtp_caps_from_audio_rejects_unsupported_format() {
         init_gst();
         let raw = raw_audio_caps("S32LE", 48_000, 2);
-        let err =
-            rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect_err("reject");
+        let err = rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None)
+            .expect_err("reject");
         assert!(matches!(err, SdpError::UnsupportedEssence(ref m) if m.contains("S32LE")));
     }
 
@@ -5284,9 +5326,8 @@ mod tests {
     fn rtp_caps_from_audio_round_trips_through_caps_from_rtp_audio() {
         init_gst();
         let original = raw_audio_caps("S24BE", 48_000, 2);
-        let rtp =
-            rtp_caps_from_audio(&original, 97, defaults::AUDIO_PTIME_NS, None, None)
-                .expect("synth");
+        let rtp = rtp_caps_from_audio(&original, 97, defaults::AUDIO_PTIME_NS, None, None)
+            .expect("synth");
         let round_tripped = crate::essence_caps::caps_from(
             &caps_from_rtp_audio(&rtp).expect("parse back"),
             Some(&rtp),
@@ -5310,10 +5351,7 @@ mod tests {
         let rtp =
             rtp_caps_from_audio(&raw, 97, defaults::AUDIO_PTIME_NS, None, None).expect("synth");
         let s = rtp.structure(0).expect("rtp");
-        assert_eq!(
-            s.get::<&str>("channel-order").unwrap(),
-            "SMPTE2110.(U06)",
-        );
+        assert_eq!(s.get::<&str>("channel-order").unwrap(), "SMPTE2110.(U06)",);
     }
 
     // -- rtp_caps_from_data
@@ -5326,7 +5364,10 @@ mod tests {
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "SMPTE291");
-        assert_eq!(s.get::<i32>("clock-rate").unwrap(), defaults::ANC_CLOCK_RATE);
+        assert_eq!(
+            s.get::<i32>("clock-rate").unwrap(),
+            defaults::ANC_CLOCK_RATE
+        );
         assert_eq!(s.get::<i32>("payload").unwrap(), 100);
         assert!(
             s.get::<&str>("exactframerate").is_err(),
@@ -5337,16 +5378,13 @@ mod tests {
     #[test]
     fn rtp_caps_from_data_propagates_framerate() {
         init_gst();
-        let raw = gst::Caps::from_str("meta/x-st-2038,framerate=25/1")
-            .expect("data caps");
+        let raw = gst::Caps::from_str("meta/x-st-2038,framerate=25/1").expect("data caps");
         let rtp = rtp_caps_from_data(&raw, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "25");
 
-        let fractional = gst::Caps::from_str(
-            "meta/x-st-2038,framerate=30000/1001",
-        )
-        .expect("data caps");
+        let fractional =
+            gst::Caps::from_str("meta/x-st-2038,framerate=30000/1001").expect("data caps");
         let rtp = rtp_caps_from_data(&fractional, 100).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "30000/1001");
@@ -5363,10 +5401,7 @@ mod tests {
     #[test]
     fn rtp_caps_from_data_round_trips_through_caps_from_rtp_data() {
         init_gst();
-        let original = gst::Caps::from_str(
-            "meta/x-st-2038,framerate=25/1",
-        )
-        .expect("data caps");
+        let original = gst::Caps::from_str("meta/x-st-2038,framerate=25/1").expect("data caps");
         let rtp = rtp_caps_from_data(&original, 100).expect("synth");
         let round_tripped = caps_from_rtp_data(&rtp).expect("parse back");
         let rt = round_tripped.structure(0).expect("rt raw");
@@ -5457,7 +5492,10 @@ mod tests {
     fn resolve_payload_type_honours_transport_caps_override() {
         init_gst();
         let tc = gst::Caps::from_str("application/x-rtp,payload=(int)110").unwrap();
-        assert_eq!(resolve_payload_type(FlowFormat::Video, Some(&tc)).unwrap(), 110);
+        assert_eq!(
+            resolve_payload_type(FlowFormat::Video, Some(&tc)).unwrap(),
+            110
+        );
     }
 
     #[test]
@@ -5477,7 +5515,11 @@ mod tests {
     fn parse_ptime_ms_as_ns_round_trips_format_ptime_ns_as_ms() {
         for ns in [125_000_u64, 250_000, 1_000_000, 4_000_000, 20_000_000] {
             let s = format_ptime_ns_as_ms(ns);
-            assert_eq!(parse_ptime_ms_as_ns(&s), Some(ns), "round-trip {ns}ns -> {s}");
+            assert_eq!(
+                parse_ptime_ms_as_ns(&s),
+                Some(ns),
+                "round-trip {ns}ns -> {s}"
+            );
         }
     }
 
@@ -5498,10 +5540,9 @@ mod tests {
     #[test]
     fn resolve_audio_ptime_reads_override_strings() {
         init_gst();
-        let tc = gst::Caps::from_str(
-            "application/x-rtp,a-ptime=(string)0.125,a-maxptime=(string)4",
-        )
-        .unwrap();
+        let tc =
+            gst::Caps::from_str("application/x-rtp,a-ptime=(string)0.125,a-maxptime=(string)4")
+                .unwrap();
         let (p, m) = resolve_audio_ptime(Some(&tc));
         assert_eq!(p, 125_000);
         assert_eq!(m, Some(4_000_000));
@@ -5596,7 +5637,10 @@ mod tests {
             text.contains("a=ts-refclk:ptp=IEEE1588-2008:traceable"),
             "nvdsudp sender synthesis must emit PTP ts-refclk:\n{text}",
         );
-        assert!(text.contains("TP=2110TPN"), "narrow traffic profile:\n{text}");
+        assert!(
+            text.contains("TP=2110TPN"),
+            "narrow traffic profile:\n{text}"
+        );
     }
 
     #[test]
@@ -5609,7 +5653,10 @@ mod tests {
             !text.contains("a=ts-refclk:"),
             "udp sender synthesis must omit ts-refclk:\n{text}",
         );
-        assert!(!text.contains("TP=2110TPN"), "udp sender must not indicate narrow profile:\n{text}");
+        assert!(
+            !text.contains("TP=2110TPN"),
+            "udp sender must not indicate narrow profile:\n{text}"
+        );
     }
 
     #[test]
@@ -5626,7 +5673,10 @@ mod tests {
         let text = from_caps(&input).expect("synth");
 
         assert!(text.contains("s=test-label"), "s= carries label:\n{text}");
-        assert!(text.contains("i=test-description"), "i= carries description");
+        assert!(
+            text.contains("i=test-description"),
+            "i= carries description"
+        );
         assert!(
             text.contains("a=x-nvnmos-name:test-name"),
             "session-level a=x-nvnmos-name carries the resource name",
@@ -5641,7 +5691,10 @@ mod tests {
             "rtpmap encoding-name + clock-rate (lower-case per \
              RFC 4175 §6.7 BNF; nmos-cpp matches it case-sensitively):\n{text}",
         );
-        assert!(text.contains("sampling=YCbCr-4:2:2"), "fmtp sampling:\n{text}");
+        assert!(
+            text.contains("sampling=YCbCr-4:2:2"),
+            "fmtp sampling:\n{text}"
+        );
         assert!(text.contains("depth=10"), "fmtp depth=10 for UYVP:\n{text}");
         assert!(text.contains("width=1920"));
         assert!(text.contains("height=1080"));
@@ -5657,7 +5710,10 @@ mod tests {
         // compat story (lower-case `raw` + upper-case `PM` /
         // `SSN` is what libnvnmos accepts).
         assert!(text.contains("PM=2110GPM"), "ST 2110-20 PM:\n{text}");
-        assert!(text.contains("SSN=ST2110-20:2017"), "ST 2110-20 SSN:\n{text}");
+        assert!(
+            text.contains("SSN=ST2110-20:2017"),
+            "ST 2110-20 SSN:\n{text}"
+        );
         assert!(
             text.contains("a=source-filter: incl IN IP4 239.0.0.1 192.0.2.10"),
             "Sender source-filter:\n{text}",
@@ -5700,7 +5756,10 @@ mod tests {
         let s = rtp.structure(0).expect("rtp");
         assert_eq!(s.name().as_str(), "application/x-rtp");
         assert_eq!(s.get::<&str>("media").unwrap(), "video");
-        assert_eq!(s.get::<i32>("clock-rate").unwrap(), defaults::VIDEO_CLOCK_RATE);
+        assert_eq!(
+            s.get::<i32>("clock-rate").unwrap(),
+            defaults::VIDEO_CLOCK_RATE
+        );
         assert_eq!(s.get::<&str>("encoding-name").unwrap(), "jxsv");
         assert_eq!(s.get::<i32>("payload").unwrap(), 96);
         assert_eq!(s.get::<&str>("packetmode").unwrap(), "0");
@@ -5725,7 +5784,10 @@ mod tests {
             s.get::<&str>("colorimetry").is_err(),
             "colorimetry omitted when absent:\n{s:?}",
         );
-        assert!(s.get::<&str>("sampling").is_err(), "sampling omitted:\n{s:?}");
+        assert!(
+            s.get::<&str>("sampling").is_err(),
+            "sampling omitted:\n{s:?}"
+        );
         assert!(s.get::<&str>("depth").is_err(), "depth omitted:\n{s:?}");
         assert!(s.get::<&str>("profile").is_err(), "profile omitted:\n{s:?}");
         assert!(s.get::<&str>("TP").is_err(), "TP omitted when wide:\n{s:?}");
@@ -5801,10 +5863,9 @@ mod tests {
     #[test]
     fn caps_from_rtp_video_jxsv_rejects_non_jxsv_encoding() {
         init_gst();
-        let rtp = gst::Caps::from_str(
-            "application/x-rtp,media=(string)video,encoding-name=(string)raw",
-        )
-        .unwrap();
+        let rtp =
+            gst::Caps::from_str("application/x-rtp,media=(string)video,encoding-name=(string)raw")
+                .unwrap();
         assert!(caps_from_rtp_video_jxsv(&rtp).is_err());
     }
 
@@ -5867,10 +5928,7 @@ mod tests {
         };
         let property = bit_rates_from_properties(120_000, 0);
         let err = cross_check_bit_rates(property, file).unwrap_err();
-        assert!(
-            err.to_string().contains("bit-rate mismatch"),
-            "{err}"
-        );
+        assert!(err.to_string().contains("bit-rate mismatch"), "{err}");
     }
 
     #[test]
@@ -5890,12 +5948,9 @@ mod tests {
             bit_rates: bit_rates_from_properties(110_000, 0),
             ..Default::default()
         };
-        let out = passthrough_with_overrides(
-            sdp,
-            &overrides,
-            DualLegPassthroughPolicy::RejectDualLeg,
-        )
-        .expect("splice");
+        let out =
+            passthrough_with_overrides(sdp, &overrides, DualLegPassthroughPolicy::RejectDualLeg)
+                .expect("splice");
         assert!(out.contains("b=AS:116000"), "bandwidth:\n{out}");
         assert!(
             out.contains("x-nvnmos-format-bit-rate=110000"),
@@ -5920,13 +5975,7 @@ mod tests {
     #[test]
     fn from_caps_jxsv_emits_bitrate_fields_from_format_bit_rate() {
         init_gst();
-        let essence = jxsv_caps(
-            "image/x-jxsc",
-            1920,
-            1080,
-            gst::Fraction::new(50, 1),
-            None,
-        );
+        let essence = jxsv_caps("image/x-jxsc", 1920, 1080, gst::Fraction::new(50, 1), None);
         let mut input = build_input(&essence, Side::Sender, None);
         input.format_bit_rate = 110_000;
         let text = from_caps(&input).expect("synth");
@@ -6078,7 +6127,10 @@ mod tests {
         .unwrap();
         let input = build_input(&essence, Side::Sender, Some(&tc));
         let text = from_caps(&input).expect("synth");
-        assert!(text.contains("m=audio 5004 RTP/AVP 98"), "pt override:\n{text}");
+        assert!(
+            text.contains("m=audio 5004 RTP/AVP 98"),
+            "pt override:\n{text}"
+        );
         assert!(
             text.contains("a=rtpmap:98 L24/96000/2"),
             "audio clock-rate override:\n{text}",
@@ -6090,13 +6142,13 @@ mod tests {
     #[test]
     fn from_caps_data_synthesises_st2110_40_sdp() {
         init_gst();
-        let essence = gst::Caps::from_str(
-            "meta/x-st-2038,framerate=25/1",
-        )
-        .unwrap();
+        let essence = gst::Caps::from_str("meta/x-st-2038,framerate=25/1").unwrap();
         let input = build_input(&essence, Side::Sender, None);
         let text = from_caps(&input).expect("synth");
-        assert!(text.contains("m=video 5004 RTP/AVP 100"), "ANC pt=100:\n{text}");
+        assert!(
+            text.contains("m=video 5004 RTP/AVP 100"),
+            "ANC pt=100:\n{text}"
+        );
         // RFC 8331 §5.1 / SMPTE ST 2110-40 §6 spell the encoding
         // name lower-case (`smpte291`); `nmos-cpp`'s
         // `media_types::video_smpte291` (`U("video/smpte291")`)
@@ -6193,10 +6245,7 @@ mod tests {
     #[test]
     fn from_caps_round_trips_through_parse_sdp_for_data() {
         init_gst();
-        let essence = gst::Caps::from_str(
-            "meta/x-st-2038,framerate=25/1",
-        )
-        .unwrap();
+        let essence = gst::Caps::from_str("meta/x-st-2038,framerate=25/1").unwrap();
         let input = build_input(&essence, Side::Sender, None);
         let text = from_caps(&input).expect("synth");
         let media = parse_sdp(&text).expect("round-trip parse");
@@ -6404,8 +6453,12 @@ mod tests {
             DID_SDID={0x41,0x01};\
             VPID_Code=133;\
             TM=Async\r\n";
-        let spliced =
-            passthrough_with_overrides(raw_sdp, &SdpOverrides::default(), DualLegPassthroughPolicy::RejectDualLeg).expect("splice no-op");
+        let spliced = passthrough_with_overrides(
+            raw_sdp,
+            &SdpOverrides::default(),
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("splice no-op");
         // rtpmap encoding-name must round-trip lower-case.
         assert!(
             spliced.contains("a=rtpmap:96 raw/90000"),
@@ -6428,9 +6481,20 @@ mod tests {
         // and `tp=` are too short for a `!spliced.contains`
         // check (they'd match `BPM=`, `2110TPW`, etc.), so pin
         // them with explicit leading-`;` / leading-` ` anchors.
-        for &canonical in &["PM", "SSN", "TCS", "RANGE", "PAR", "MAXUDP", "TSMODE",
-                             "TSDELAY", "TROFF", "CMAX", "DID_SDID", "VPID_Code"]
-        {
+        for &canonical in &[
+            "PM",
+            "SSN",
+            "TCS",
+            "RANGE",
+            "PAR",
+            "MAXUDP",
+            "TSMODE",
+            "TSDELAY",
+            "TROFF",
+            "CMAX",
+            "DID_SDID",
+            "VPID_Code",
+        ] {
             let lower = canonical.to_ascii_lowercase();
             let needle = format!(";{lower}=");
             assert!(

--- a/rust/gst-nmos-rs/src/sdp_passthrough.rs
+++ b/rust/gst-nmos-rs/src/sdp_passthrough.rs
@@ -9,10 +9,10 @@
 //! vendor and spec-extension attributes the model does not represent survive
 //! verbatim to `libnvnmos`.
 
-use gstreamer_sdp::{SDPAttribute, SDPMediaRef, SDPConnection, SDPMessage};
+use gstreamer_sdp::{SDPAttribute, SDPConnection, SDPMediaRef, SDPMessage};
 
 use crate::iface;
-use crate::sdp::{self, defaults, BitRates, SdpError, SdpOverrides};
+use crate::sdp::{self, BitRates, SdpError, SdpOverrides, defaults};
 use crate::types::CapsMode;
 
 /// Whether the configuring passthrough path may carry a dual-`m=` ST 2022-7 SDP.
@@ -96,8 +96,8 @@ pub(crate) fn passthrough_with_overrides(
     overrides: &SdpOverrides<'_>,
     policy: DualLegPassthroughPolicy,
 ) -> Result<String, SdpError> {
-    let mut msg = SDPMessage::parse_buffer(text.as_bytes())
-        .map_err(|e| SdpError::Parse(e.to_string()))?;
+    let mut msg =
+        SDPMessage::parse_buffer(text.as_bytes()).map_err(|e| SdpError::Parse(e.to_string()))?;
     reject_unsupported_multi_media(&msg, policy)?;
     apply_session_overrides_in_place(&mut msg, overrides)?;
     apply_media_overrides_in_place(&mut msg, overrides)?;
@@ -117,7 +117,9 @@ fn apply_primary_leg_transport_overrides(
     m: &mut SDPMediaRef,
     overrides: &SdpOverrides<'_>,
 ) -> Result<(), SdpError> {
-    let is_audio = m.media().is_some_and(|kind| kind.eq_ignore_ascii_case("audio"));
+    let is_audio = m
+        .media()
+        .is_some_and(|kind| kind.eq_ignore_ascii_case("audio"));
 
     if let Some(port) = overrides.destination_port {
         let num_ports = m.num_ports();
@@ -202,14 +204,15 @@ fn rewrite_payload_type(m: &mut SDPMediaRef, new_pt: u8) -> Result<(), SdpError>
     let old_prefix = format!("{old_pt} ");
     let mut rewrites: Vec<(u32, String, String)> = Vec::new();
     for idx in 0..m.attributes_len() {
-        let Some(attr) = m.attribute(idx) else { continue };
+        let Some(attr) = m.attribute(idx) else {
+            continue;
+        };
         let key = attr.key().to_owned();
         let Some(value) = attr.value() else { continue };
         if let Some(new_value) = match key.as_str() {
-            "rtpmap" | "fmtp" if value.starts_with(&old_prefix) => Some(format!(
-                "{new_pt_str} {}",
-                &value[old_prefix.len()..]
-            )),
+            "rtpmap" | "fmtp" if value.starts_with(&old_prefix) => {
+                Some(format!("{new_pt_str} {}", &value[old_prefix.len()..]))
+            }
             "x-nvnmos-caps" if value == old_pt => Some(new_pt_str.clone()),
             _ => None,
         } {
@@ -224,7 +227,9 @@ fn rewrite_payload_type(m: &mut SDPMediaRef, new_pt: u8) -> Result<(), SdpError>
 
 fn rewrite_audio_clock_rate(m: &mut SDPMediaRef, new_rate: u32) -> Result<(), SdpError> {
     for idx in 0..m.attributes_len() {
-        let Some(attr) = m.attribute(idx) else { continue };
+        let Some(attr) = m.attribute(idx) else {
+            continue;
+        };
         if attr.key() != "rtpmap" {
             continue;
         }
@@ -267,13 +272,7 @@ fn replace_connection_address(m: &mut SDPMediaRef, address: &str) -> Result<(), 
     } else {
         conn.ttl()
     };
-    let new_conn = SDPConnection::new(
-        nettype,
-        addrtype,
-        address,
-        ttl,
-        conn.addr_number(),
-    );
+    let new_conn = SDPConnection::new(nettype, addrtype, address, ttl, conn.addr_number());
     m.replace_connection(0, new_conn)
         .map_err(|e| SdpError::Parse(e.to_string()))
 }
@@ -288,7 +287,9 @@ fn is_multicast_address(address: &str) -> bool {
 
 fn update_source_filter_destination(m: &mut SDPMediaRef, dest: &str) {
     for idx in 0..m.attributes_len() {
-        let Some(attr) = m.attribute(idx) else { continue };
+        let Some(attr) = m.attribute(idx) else {
+            continue;
+        };
         if attr.key() != "source-filter" {
             continue;
         }
@@ -323,18 +324,10 @@ fn upsert_session_attribute(msg: &mut SDPMessage, key: &str, value: Option<&str>
 }
 
 fn find_session_attribute_index(msg: &SDPMessage, key: &str) -> Option<u32> {
-    (0..msg.attributes_len()).find(|&idx| {
-        msg.attribute(idx)
-            .is_some_and(|attr| attr.key() == key)
-    })
+    (0..msg.attributes_len()).find(|&idx| msg.attribute(idx).is_some_and(|attr| attr.key() == key))
 }
 
-fn upsert_media_attribute(
-    m: &mut SDPMediaRef,
-    key: &str,
-    value: Option<&str>,
-    canonicalise: bool,
-) {
+fn upsert_media_attribute(m: &mut SDPMediaRef, key: &str, value: Option<&str>, canonicalise: bool) {
     if let Some(idx) = find_media_attribute_index(m, key) {
         upsert_media_attribute_at(m, idx, key, value, canonicalise);
     } else {
@@ -360,9 +353,7 @@ fn upsert_media_attribute_at(
 }
 
 fn find_media_attribute_index(m: &SDPMediaRef, key: &str) -> Option<u32> {
-    (0..m.attributes_len()).find(|&idx| {
-        m.attribute(idx).is_some_and(|attr| attr.key() == key)
-    })
+    (0..m.attributes_len()).find(|&idx| m.attribute(idx).is_some_and(|attr| attr.key() == key))
 }
 
 fn remove_media_attributes_by_key(m: &mut SDPMediaRef, key: &str) {
@@ -413,7 +404,12 @@ mod tests {
             interface_ip: Some(&ip_str),
             ..Default::default()
         };
-        let out = passthrough_with_overrides(VIDEO_WITH_STALE_IFACE, &overrides, DualLegPassthroughPolicy::RejectDualLeg).expect("splice");
+        let out = passthrough_with_overrides(
+            VIDEO_WITH_STALE_IFACE,
+            &overrides,
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("splice");
         assert!(
             out.contains(&format!("a=x-nvnmos-iface-ip:{ip}")),
             "iface-ip must be overridden: {out}",
@@ -437,8 +433,12 @@ mod tests {
             interface_ip: Some("192.0.2.254"),
             ..Default::default()
         };
-        let out =
-            passthrough_with_overrides(VIDEO_WITH_STALE_IFACE, &overrides, DualLegPassthroughPolicy::RejectDualLeg).expect("splice");
+        let out = passthrough_with_overrides(
+            VIDEO_WITH_STALE_IFACE,
+            &overrides,
+            DualLegPassthroughPolicy::RejectDualLeg,
+        )
+        .expect("splice");
         assert!(
             out.contains("a=x-nvnmos-iface-ip:192.0.2.254"),
             "iface-ip override: {out}",
@@ -448,5 +448,4 @@ mod tests {
             "unresolvable override must drop stale iface: {out}",
         );
     }
-
 }

--- a/rust/gst-nmos-rs/src/session/channel_mapping.rs
+++ b/rust/gst-nmos-rs/src/session/channel_mapping.rs
@@ -6,12 +6,10 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use gstreamer as gst;
 
-use crate::channel_mapping_session::{
-    ChannelMappingActivationHandler, ChannelMappingSession,
-};
+use crate::channel_mapping_session::{ChannelMappingActivationHandler, ChannelMappingSession};
 use crate::runtime::SHARED_RUNTIME;
 use crate::types::DEFAULT_DAEMON_URI;
 
@@ -19,13 +17,11 @@ use super::NodeSettings;
 
 const OPEN_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub(crate) const CHANNELMAPPING_NAME_BLURB: &str =
-    "Caller-chosen name for this channel mapping within the Node. Unique per \
+pub(crate) const CHANNELMAPPING_NAME_BLURB: &str = "Caller-chosen name for this channel mapping within the Node. Unique per \
      Node; identifies the Input/Output bundle added at NULL→READY. Not an IS-08 \
      Input or Output id.";
 
-pub(crate) const RESTRICT_ROUTABLE_INPUTS_BLURB: &str =
-    "When true, each Output's IS-08 /caps routable_inputs lists only this \
+pub(crate) const RESTRICT_ROUTABLE_INPUTS_BLURB: &str = "When true, each Output's IS-08 /caps routable_inputs lists only this \
      element's Input ids. When false (default), routable inputs are \
      unrestricted on the IS-08 Output /caps endpoint.";
 
@@ -70,7 +66,12 @@ pub(crate) fn validate_and_open(
             )
             .await
         })
-        .with_context(|| format!("{element}: OpenSession against {} timed out", settings.daemon_uri))?
+        .with_context(|| {
+            format!(
+                "{element}: OpenSession against {} timed out",
+                settings.daemon_uri
+            )
+        })?
         .with_context(|| format!("{element}: OpenSession against {}", settings.daemon_uri))?;
 
     gst::info!(

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -59,16 +59,13 @@ pub(crate) fn transport_to_proto(t: Transport) -> ProtoTransport {
 // `label`, `description`, `mxl-flow-id`, `caps`) keep their text
 // inline in the respective `imp.rs`.
 
-pub(crate) const DAEMON_URI_BLURB: &str =
-    "gRPC endpoint for nvnmosd. Only `unix:/path/to/sock` URIs are \
+pub(crate) const DAEMON_URI_BLURB: &str = "gRPC endpoint for nvnmosd. Only `unix:/path/to/sock` URIs are \
      currently supported.";
 
-pub(crate) const NODE_SEED_BLURB: &str =
-    "NvNmos Node seed (node_config.seed). Required. Sessions sharing \
+pub(crate) const NODE_SEED_BLURB: &str = "NvNmos Node seed (node_config.seed). Required. Sessions sharing \
      this seed contribute to the same NMOS Node.";
 
-pub(crate) const HTTP_PORT_BLURB: &str =
-    "TCP port libnvnmos serves the NMOS HTTP APIs on \
+pub(crate) const HTTP_PORT_BLURB: &str = "TCP port libnvnmos serves the NMOS HTTP APIs on \
      (node_config.http_port). 0 (the default) asks nvnmosd to allocate \
      from NVNMOSD_HTTP_PORT_MIN..NVNMOSD_HTTP_PORT_MAX. Non-zero selects \
      an explicit port (rejected when unavailable). Honoured only by the \
@@ -77,37 +74,32 @@ pub(crate) const HTTP_PORT_BLURB: &str =
      the same node-seed) this property is ignored. The effective port is \
      returned in OpenSessionResponse.http_port.";
 
-pub(crate) const HOST_NAME_BLURB: &str =
-    "NMOS Node host name (`node_config.host_name`). Empty (the \
+pub(crate) const HOST_NAME_BLURB: &str = "NMOS Node host name (`node_config.host_name`). Empty (the \
      default) leaves libnvnmos to autodetect. Honoured only by the \
      OpenSession that actually creates the Node; ignored when \
      attaching to a pre-existing Node with the same `node-seed`.";
 
-pub(crate) const DOMAIN_BLURB: &str =
-    "DNS domain for NMOS network services (`network_services.domain`). \
+pub(crate) const DOMAIN_BLURB: &str = "DNS domain for NMOS network services (`network_services.domain`). \
      Use `local` to force mDNS. Empty (the default) leaves libnvnmos \
      on automatic discovery. Not to be confused with `mxl-domain-id` \
      / `mxl-domain-path`, which identify an MXL shared-memory Domain. \
      Honoured only by the OpenSession that creates the Node.";
 
-pub(crate) const REGISTRATION_URL_BLURB: &str =
-    "Fixed IS-04 Registration API URL. Format: \
+pub(crate) const REGISTRATION_URL_BLURB: &str = "Fixed IS-04 Registration API URL. Format: \
      `http://host[:port]/x-nmos/registration/v<X.Y>[/]`. Parsed into \
      `network_services.registration_*`; invalid URLs are logged and \
      ignored. Empty (the default) leaves libnvnmos on DNS-SD discovery \
      based on `host-name`. Honoured only by the OpenSession that \
      creates the Node.";
 
-pub(crate) const SYSTEM_URL_BLURB: &str =
-    "Fixed IS-09 System API URL. Format: \
+pub(crate) const SYSTEM_URL_BLURB: &str = "Fixed IS-09 System API URL. Format: \
      `http://host[:port]/x-nmos/system/v<X.Y>[/]`. Parsed into \
      `network_services.system_*`; invalid URLs are logged and ignored. \
      Honoured only when `registration-url` is also set (libnvnmos \
      ignores a standalone System API). Honoured only by the OpenSession \
      that creates the Node.";
 
-pub(crate) const TRANSPORT_BLURB: &str =
-    "Inner data path family. \
+pub(crate) const TRANSPORT_BLURB: &str = "Inner data path family. \
      `mxl`: MXL shared-memory transport (`mxlsrc` / `mxlsink`). \
      `udp`: ST 2110 over RTP/UDP via gst-plugins-good (`udpsrc` / \
      `udpsink` + the `rtpvrawpay` / `rtpL24pay` / `rtpsmpte291pay` \
@@ -119,8 +111,7 @@ pub(crate) const TRANSPORT_BLURB: &str =
      (Rivermax kernel-bypass, built-in RTP (de)payload, Mode 3). \
      Requires ConnectX-5+ and the Rivermax SDK.";
 
-pub(crate) const MXL_DOMAIN_ID_BLURB: &str =
-    "MXL Domain identifier (UUID) included as \
+pub(crate) const MXL_DOMAIN_ID_BLURB: &str = "MXL Domain identifier (UUID) included as \
      `urn:x-nvnmos:tag:mxl-domain-id` in the transport file. \
      Required when transport=mxl, but may be omitted if \
      `mxl-domain-path` points at a directory containing a \
@@ -131,8 +122,7 @@ pub(crate) const MXL_DOMAIN_ID_BLURB: &str =
      NULL\u{2192}READY; on `nmossink` it may also be set in READY \
      for deferred AddSender.";
 
-pub(crate) const SENDER_NAME_BLURB: &str =
-    "Name for this Sender within the Node (becomes the \
+pub(crate) const SENDER_NAME_BLURB: &str = "Name for this Sender within the Node (becomes the \
      `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` \
      flow-def tag in the transport file). Unique across Senders on the \
      Node; a Receiver on the same Node may share the same name (the \
@@ -141,8 +131,7 @@ pub(crate) const SENDER_NAME_BLURB: &str =
      when both are supplied. The Sender's IS-04 id is derived from the \
      name and the element's `node-seed`.";
 
-pub(crate) const RECEIVER_NAME_BLURB: &str =
-    "Name for this Receiver within the Node (becomes the \
+pub(crate) const RECEIVER_NAME_BLURB: &str = "Name for this Receiver within the Node (becomes the \
      `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` \
      flow-def tag in the transport file). Unique across Receivers on the \
      Node; a Sender on the same Node may share the same name (the \
@@ -151,47 +140,39 @@ pub(crate) const RECEIVER_NAME_BLURB: &str =
      when both are supplied. The Receiver's IS-04 id is derived from the \
      name and the element's `node-seed`.";
 
-pub(crate) const LABEL_BLURB_SENDER: &str =
-    "NMOS label for the Sender. Optional. Overrides the transport \
+pub(crate) const LABEL_BLURB_SENDER: &str = "NMOS label for the Sender. Optional. Overrides the transport \
      file when both are supplied (top-level `label` in an MXL \
      `flow_def`; SDP `s=` line for RTP/UDP).";
 
-pub(crate) const LABEL_BLURB_RECEIVER: &str =
-    "NMOS label for the Receiver. Optional. Overrides the transport \
+pub(crate) const LABEL_BLURB_RECEIVER: &str = "NMOS label for the Receiver. Optional. Overrides the transport \
      file when both are supplied (top-level `label` in an MXL \
      `flow_def`; SDP `s=` line for RTP/UDP).";
 
-pub(crate) const DESCRIPTION_BLURB_SENDER: &str =
-    "NMOS description for the Sender. Optional. Overrides the \
+pub(crate) const DESCRIPTION_BLURB_SENDER: &str = "NMOS description for the Sender. Optional. Overrides the \
      transport file when both are supplied (top-level `description` \
      in an MXL `flow_def`; SDP `i=` line for RTP/UDP).";
 
-pub(crate) const DESCRIPTION_BLURB_RECEIVER: &str =
-    "NMOS description for the Receiver. Optional. Overrides the \
+pub(crate) const DESCRIPTION_BLURB_RECEIVER: &str = "NMOS description for the Receiver. Optional. Overrides the \
      transport file when both are supplied (top-level `description` \
      in an MXL `flow_def`; SDP `i=` line for RTP/UDP).";
 
-pub(crate) const GROUP_HINT_BLURB_SENDER: &str =
-    "NMOS group hint for the Sender (the \
+pub(crate) const GROUP_HINT_BLURB_SENDER: &str = "NMOS group hint for the Sender (the \
      `urn:x-nmos:tag:grouphint/v1.0` tag), e.g. `\"SDI 1:Video\"`. \
      Becomes the `x-nvnmos-group-hint` session-level SDP attribute on \
      RTP/UDP or the grouphint tag in an MXL `flow_def`. Overrides the \
      transport file when both are supplied. Optional. Omitted when unset.";
 
-pub(crate) const GROUP_HINT_BLURB_RECEIVER: &str =
-    "NMOS group hint for the Receiver (the \
+pub(crate) const GROUP_HINT_BLURB_RECEIVER: &str = "NMOS group hint for the Receiver (the \
      `urn:x-nmos:tag:grouphint/v1.0` tag), e.g. `\"SDI 1:Video\"`. \
      Becomes the `x-nvnmos-group-hint` session-level SDP attribute on \
      RTP/UDP or the grouphint tag in an MXL `flow_def`. Overrides the \
      transport file when both are supplied. Optional. Omitted when unset.";
 
-pub(crate) const TRANSPORT_FILE_PATH_BLURB: &str =
-    "Filesystem path read at NULL\u{2192}READY into `transport-file`. \
+pub(crate) const TRANSPORT_FILE_PATH_BLURB: &str = "Filesystem path read at NULL\u{2192}READY into `transport-file`. \
      Convenience for gst-launch; mutually exclusive with \
      `transport-file`.";
 
-pub(crate) const TRANSPORT_FILE_BLURB_SENDER: &str =
-    "Literal contents of the NvNmos transport file: MXL `flow_def` JSON \
+pub(crate) const TRANSPORT_FILE_BLURB_SENDER: &str = "Literal contents of the NvNmos transport file: MXL `flow_def` JSON \
      for `transport=mxl`, SDP text for `transport=udp` / `udp2` / \
      `nvdsudp`. The daemon adds the Sender via AddSender and \
      re-publishes the transport file on IS-05 activation. Pass the \
@@ -201,8 +182,7 @@ pub(crate) const TRANSPORT_FILE_BLURB_SENDER: &str =
      element synthesises a configuring transport file from the essence \
      caps (MXL `flow_def` or SDP, depending on `transport`).";
 
-pub(crate) const TRANSPORT_FILE_BLURB_RECEIVER: &str =
-    "Literal contents of the NvNmos transport file: MXL `flow_def` JSON \
+pub(crate) const TRANSPORT_FILE_BLURB_RECEIVER: &str = "Literal contents of the NvNmos transport file: MXL `flow_def` JSON \
      for `transport=mxl`, SDP text for `transport=udp` / `udp2` / \
      `nvdsudp`. The daemon adds the Receiver via AddReceiver and \
      re-publishes the transport file on IS-05 activation. Pass the \
@@ -210,8 +190,7 @@ pub(crate) const TRANSPORT_FILE_BLURB_RECEIVER: &str =
      gst-launch use `transport-file-path` instead. Mutually exclusive \
      with `transport-file-path`. Required unless `caps` is provided.";
 
-pub(crate) const CAPS_BLURB_SENDER: &str =
-    "Essence caps for this Sender. Synthesises the configuring transport \
+pub(crate) const CAPS_BLURB_SENDER: &str = "Essence caps for this Sender. Synthesises the configuring transport \
      file when `transport-file*` is unset (MXL `flow_def` or SDP depending \
      on `transport`). On `transport=mxl`, requires `mxl-flow-id`; supported \
      shapes: v210 video, F32LE audio, `meta/x-st-2038` data. On RTP \
@@ -219,8 +198,7 @@ pub(crate) const CAPS_BLURB_SENDER: &str =
      `transport-file*` is also set, the file wins and `caps` are \
      cross-checked against it — mismatch is a hard error.";
 
-pub(crate) const CAPS_BLURB_RECEIVER: &str =
-    "Essence caps for this Receiver. Required when `transport-file*` is \
+pub(crate) const CAPS_BLURB_RECEIVER: &str = "Essence caps for this Receiver. Required when `transport-file*` is \
      unset; synthesises the configuring transport file (MXL `flow_def` or \
      SDP depending on `transport`). On `transport=mxl`, requires \
      `mxl-flow-id` (media-type structure name picks the matching `mxlsrc` \
@@ -232,8 +210,7 @@ pub(crate) const CAPS_BLURB_RECEIVER: &str =
 pub(crate) const TRANSPORT_CAPS_BLURB: &str =
     "Per-transport overrides (SDP fmtp-style). Typically empty for MXL.";
 
-pub(crate) const FORMAT_BIT_RATE_BLURB: &str =
-    "Coded essence (Flow) bit rate in kilobits per second (1000 bits/s), \
+pub(crate) const FORMAT_BIT_RATE_BLURB: &str = "Coded essence (Flow) bit rate in kilobits per second (1000 bits/s), \
      matching NMOS Flow `bit_rate` and SDP fmtp `x-nvnmos-format-bit-rate`. \
      On JPEG XS RTP transports, synthesises the configuring SDP \
      `a=fmtp:… x-nvnmos-format-bit-rate=` attribute and `b=AS:` (via the \
@@ -246,8 +223,7 @@ pub(crate) const FORMAT_BIT_RATE_BLURB: &str =
      sides declare a rate and splices when the file omits it. Ignored on \
      `transport=mxl`.";
 
-pub(crate) const TRANSPORT_BIT_RATE_BLURB: &str =
-    "Transport (Sender) bit rate in kilobits per second (1000 bits/s), \
+pub(crate) const TRANSPORT_BIT_RATE_BLURB: &str = "Transport (Sender) bit rate in kilobits per second (1000 bits/s), \
      including RTP/UDP/IP overhead, matching NMOS Sender `bit_rate`, SDP \
      `b=AS:`, and fmtp `x-nvnmos-transport-bit-rate`. On JPEG XS RTP \
      transports, synthesises the configuring SDP `b=AS:` bandwidth line and \
@@ -257,8 +233,7 @@ pub(crate) const TRANSPORT_BIT_RATE_BLURB: &str =
      With a supplied `transport-file*`, cross-checks when both sides declare \
      a rate and splices when the file omits it. Ignored on `transport=mxl`.";
 
-pub(crate) const TRANSPORT_PROPERTIES_BLURB: &str =
-    "Overrides applied to the inner source or sink (`udpsrc`, `udpsink`, \
+pub(crate) const TRANSPORT_PROPERTIES_BLURB: &str = "Overrides applied to the inner source or sink (`udpsrc`, `udpsink`, \
      `nvdsudpsrc`, `nvdsudpsink`, `mxlsrc`, or `mxlsink`) every time the \
      data-path chain is built. \
      Pass a `GstStructure` whose fields are GObject property names on that \
@@ -266,20 +241,17 @@ pub(crate) const TRANSPORT_PROPERTIES_BLURB: &str =
      The structure name is not interpreted. Takes effect on the next chain \
      build, not immediately on the one currently in the chain.";
 
-pub(crate) const PAY_PROPERTIES_BLURB: &str =
-    "Overrides applied to the inner RTP payloader every time the UDP sender \
+pub(crate) const PAY_PROPERTIES_BLURB: &str = "Overrides applied to the inner RTP payloader every time the UDP sender \
      chain is built. Same `GstStructure` syntax as `transport-properties`; \
      ignored on non-UDP transports (a warning is logged if non-empty). Takes \
      effect on the next chain build.";
 
-pub(crate) const DEPAY_PROPERTIES_BLURB: &str =
-    "Overrides applied to the inner RTP depayloader every time the UDP \
+pub(crate) const DEPAY_PROPERTIES_BLURB: &str = "Overrides applied to the inner RTP depayloader every time the UDP \
      receiver chain is built. Same `GstStructure` syntax as \
      `transport-properties`; ignored on non-UDP transports (a warning is \
      logged if non-empty). Takes effect on the next chain build.";
 
-pub(crate) const AUTO_ACTIVATE_BLURB: &str =
-    "When `true`, swap in the real transport sink or source (instead of the \
+pub(crate) const AUTO_ACTIVATE_BLURB: &str = "When `true`, swap in the real transport sink or source (instead of the \
      fake chain) once the configuring transport file has been resolved at \
      NULL\u{2192}READY (or READY\u{2192}PAUSED for deferred senders), and call \
      `SyncResourceState` so IS-04/IS-05 show active without an IS-05 PATCH. \
@@ -562,7 +534,10 @@ pub(crate) fn caps_from_flow_def(
     let parsed_caps = crate::flow_def::caps_from(text)
         .map_err(|e| anyhow::anyhow!("caps from flow-def transport file: {e}"))?;
     let caps = crate::essence_caps::caps_from(&parsed_caps, None);
-    gst::info!(gst::CAT_DEFAULT, "{element}: caps `{caps}` from transport file");
+    gst::info!(
+        gst::CAT_DEFAULT,
+        "{element}: caps `{caps}` from transport file"
+    );
     Ok(Some(caps))
 }
 
@@ -823,7 +798,9 @@ pub(crate) fn resolve_resource_name(
         );
     };
     let from_file = match settings.transport {
-        Transport::Mxl => mxl::resource_name_from_transport_file(text).map_err(anyhow::Error::from)?,
+        Transport::Mxl => {
+            mxl::resource_name_from_transport_file(text).map_err(anyhow::Error::from)?
+        }
         Transport::Udp | Transport::Udp2 | Transport::NvDsUdp => {
             udp::resource_name_from_transport_file(text).map_err(anyhow::Error::from)?
         }
@@ -902,7 +879,12 @@ pub(crate) fn validate_and_open(
             )
             .await
         })
-        .with_context(|| format!("{element}: OpenSession against {} timed out", settings.daemon_uri))?
+        .with_context(|| {
+            format!(
+                "{element}: OpenSession against {} timed out",
+                settings.daemon_uri
+            )
+        })?
         .with_context(|| format!("{element}: OpenSession against {}", settings.daemon_uri))?;
 
     let resource_summary = match new_session.resource_id() {
@@ -914,8 +896,15 @@ pub(crate) fn validate_and_open(
     // session-level identifier — the network params live on
     // `UdpMedia` and are summarised below.
     let inner_summary = match &inner {
-        InnerConfig::Real(TransportConfig::Mxl { domain_path, flow_id, format, .. }) => {
-            format!("inner data path: mxl (domain_path={domain_path:?}, flow_id={flow_id}, format={format:?})")
+        InnerConfig::Real(TransportConfig::Mxl {
+            domain_path,
+            flow_id,
+            format,
+            ..
+        }) => {
+            format!(
+                "inner data path: mxl (domain_path={domain_path:?}, flow_id={flow_id}, format={format:?})"
+            )
         }
         InnerConfig::Real(TransportConfig::Udp { variant, media, .. }) => {
             udp_inner_summary("udp", Some(*variant), media)
@@ -1010,7 +999,11 @@ pub(super) fn apply_auto_activate_policy(
     // diagnostics.
     let eager_candidate = matches!(
         inner,
-        InnerConfig::Real(_) | InnerConfig::Fake { kind: FakeKind::NotActive, .. }
+        InnerConfig::Real(_)
+            | InnerConfig::Fake {
+                kind: FakeKind::NotActive,
+                ..
+            }
     );
     if !eager_candidate {
         return inner;
@@ -1184,9 +1177,11 @@ pub(crate) fn sync_active(
     session: &Mutex<Option<Session>>,
     transport_file: Option<&str>,
 ) -> Result<(), anyhow::Error> {
-    let mut taken = session.lock().unwrap().take().ok_or_else(|| {
-        anyhow::anyhow!("{element}: SyncResourceState but no open session")
-    })?;
+    let mut taken = session
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("{element}: SyncResourceState but no open session"))?;
     let rpc_result = SHARED_RUNTIME.block_on(async {
         tokio::time::timeout(OPEN_TIMEOUT, taken.sync_resource_state(transport_file)).await
     });
@@ -1326,10 +1321,12 @@ pub(crate) fn make_activation_plan(
     };
 
     let inner = match settings.transport {
-        Transport::Mxl => match resolve_activation_inner_mxl(cat, element, settings, transport_file) {
-            Ok(inner) => inner,
-            Err(plan) => return *plan,
-        },
+        Transport::Mxl => {
+            match resolve_activation_inner_mxl(cat, element, settings, transport_file) {
+                Ok(inner) => inner,
+                Err(plan) => return *plan,
+            }
+        }
         Transport::Udp => match decide_inner_config_udp(
             element,
             settings,
@@ -1408,9 +1405,7 @@ pub(crate) fn make_activation_plan(
                 detail.clone()
             };
             ActivationAck::Failure {
-                reason: format!(
-                    "{element}: activation cannot bring up inner data path: {msg}"
-                ),
+                reason: format!("{element}: activation cannot bring up inner data path: {msg}"),
             }
         }
     };
@@ -1478,10 +1473,8 @@ mod support {
     pub fn video_caps() -> gst::Caps {
         use std::str::FromStr;
         init_gst();
-        gst::Caps::from_str(
-            "video/x-raw,format=v210,width=1920,height=1080,framerate=50/1",
-        )
-        .expect("static caps parse")
+        gst::Caps::from_str("video/x-raw,format=v210,width=1920,height=1080,framerate=50/1")
+            .expect("static caps parse")
     }
 
     pub fn video_flow_def(id: &str) -> String {
@@ -1528,7 +1521,12 @@ mod tests {
 
     #[test]
     fn deactivation_is_fake_success() {
-        let plan = make_activation_plan(&cat(), "nmossink", &settings(Side::Sender), &req(Side::Sender, None));
+        let plan = make_activation_plan(
+            &cat(),
+            "nmossink",
+            &settings(Side::Sender),
+            &req(Side::Sender, None),
+        );
         assert!(matches!(plan.inner, InnerConfig::Fake { .. }));
         assert!(matches!(plan.ack, ActivationAck::Success));
     }
@@ -1574,7 +1572,9 @@ mod tests {
         fn gate_passes_real_through_when_auto_activate_true() {
             let after = super::super::apply_auto_activate_gate(real_inner(), true);
             match after {
-                InnerConfig::Real(TransportConfig::Mxl { flow_id, format, .. }) => {
+                InnerConfig::Real(TransportConfig::Mxl {
+                    flow_id, format, ..
+                }) => {
                     assert_eq!(flow_id, FLOW_ID_A);
                     assert_eq!(format, FlowFormat::Video);
                 }
@@ -1730,13 +1730,8 @@ mod tests {
                 auto_activate: false,
                 ..settings(Side::Sender)
             };
-            let after = super::super::apply_auto_activate_policy(
-                &cat(),
-                "nmossink",
-                &s,
-                real_mxl(),
-                None,
-            );
+            let after =
+                super::super::apply_auto_activate_policy(&cat(), "nmossink", &s, real_mxl(), None);
             match after {
                 InnerConfig::Fake { kind, .. } => assert_eq!(kind, FakeKind::NotActive),
                 InnerConfig::Real(_) => panic!("auto-activate=false must defer a real chain"),
@@ -1749,13 +1744,8 @@ mod tests {
                 auto_activate: true,
                 ..settings(Side::Sender)
             };
-            let after = super::super::apply_auto_activate_policy(
-                &cat(),
-                "nmossink",
-                &s,
-                real_mxl(),
-                None,
-            );
+            let after =
+                super::super::apply_auto_activate_policy(&cat(), "nmossink", &s, real_mxl(), None);
             assert!(matches!(after, InnerConfig::Real(_)));
         }
 
@@ -1877,8 +1867,8 @@ mod tests {
             let mut s = settings(Side::Receiver);
             s.transport = Transport::Udp;
             s.name.clear();
-            let name = super::resolve_resource_name("nmossrc", &s, Some(SDP_WITH_NAME))
-                .expect("SDP name");
+            let name =
+                super::resolve_resource_name("nmossrc", &s, Some(SDP_WITH_NAME)).expect("SDP name");
             assert_eq!(name, "from-file");
         }
 
@@ -1886,10 +1876,8 @@ mod tests {
         fn mxl_reads_name_from_transport_file() {
             let mut s = settings(Side::Sender);
             s.name.clear();
-            let name =
-                super::resolve_resource_name("nmossink", &s, Some(FLOW_DEF_WITH_NAME)).expect(
-                    "flow_def name",
-                );
+            let name = super::resolve_resource_name("nmossink", &s, Some(FLOW_DEF_WITH_NAME))
+                .expect("flow_def name");
             assert_eq!(name, "from-file");
         }
 

--- a/rust/gst-nmos-rs/src/session/mxl.rs
+++ b/rust/gst-nmos-rs/src/session/mxl.rs
@@ -6,11 +6,11 @@
 use anyhow::{Context, bail};
 use gstreamer as gst;
 
+use super::types::Side;
 use super::{
     ActivationAck, ActivationPlan, CommonSettings, FakeKind, InnerConfig, TransportConfig,
     caps_format,
 };
-use super::types::Side;
 use crate::domain::{self, DomainIdOrigin};
 use crate::flow_def::{self, FlowDefBuildInput, FlowDefOverrides, ValueOrigin};
 use crate::types::FlowFormat;
@@ -109,9 +109,7 @@ pub(super) fn synthesise_deferred_sender_mxl(
         FlowFormat::from_caps(fixated),
         Some(&json),
     )
-    .with_context(|| {
-        format!("{element}: resolving MXL flow id / format for deferred AddSender")
-    })?;
+    .with_context(|| format!("{element}: resolving MXL flow id / format for deferred AddSender"))?;
     let inner = super::apply_auto_activate_policy(
         &crate::CAT,
         element,
@@ -142,7 +140,9 @@ pub(crate) fn property_overrides_mxl<'a>(
 
 pub(super) fn log_flow_origin(cat: &gst::DebugCategory, field: &str, origin: ValueOrigin) {
     match origin {
-        ValueOrigin::Property => gst::debug!(cat, "{field} from property; no transport file constraint"),
+        ValueOrigin::Property => {
+            gst::debug!(cat, "{field} from property; no transport file constraint")
+        }
         ValueOrigin::File => gst::info!(cat, "{field} taken from transport file"),
         ValueOrigin::Both => gst::debug!(cat, "{field} cross-checked against transport file"),
         ValueOrigin::None => gst::debug!(cat, "{field} not supplied by either source"),
@@ -173,8 +173,9 @@ pub(crate) fn decide_inner_config_mxl(
         if transport_file.is_some() {
             return InnerConfig::Fake {
                 kind: FakeKind::NotActive,
-                detail: "`mxl-flow-id` unset; waiting for IS-05 activation to supply the MXL flow id"
-                    .into(),
+                detail:
+                    "`mxl-flow-id` unset; waiting for IS-05 activation to supply the MXL flow id"
+                        .into(),
             };
         }
         return InnerConfig::Fake {
@@ -246,8 +247,13 @@ pub(super) fn resolve_inner_config_mxl(
     // shape and a mismatch is a real error.
     let transport_file = match transport_file {
         Some(text) => Some(
-            flow_def::splice_overrides(&text, &property_overrides_mxl(settings, &domain_resolution.id))
-                .with_context(|| format!("{element}: splicing property overrides into transport file"))?,
+            flow_def::splice_overrides(
+                &text,
+                &property_overrides_mxl(settings, &domain_resolution.id),
+            )
+            .with_context(|| {
+                format!("{element}: splicing property overrides into transport file")
+            })?,
         ),
         None => None,
     };
@@ -343,29 +349,30 @@ pub(super) fn resolve_activation_inner_mxl(
     // cross-check stays because a v210 video activation arriving at
     // an `nmossrc` configured for audio is a real misconfiguration
     // the element must ack-fail.
-    let flow = match flow_def::resolve_mxl_flow_meta(
-        "",
-        caps_format(settings),
-        Some(transport_file),
-    ) {
-        Ok(r) => r,
-        Err(e) => {
-            return Err(Box::new(ActivationPlan {
-                inner: InnerConfig::Fake {
-                    kind: FakeKind::Misconfigured,
-                    detail: "flow_def resolution failed".into(),
-                },
-                ack: ActivationAck::Failure {
-                    reason: format!(
-                        "{element}: resolving MXL flow id / format from activation \
+    let flow =
+        match flow_def::resolve_mxl_flow_meta("", caps_format(settings), Some(transport_file)) {
+            Ok(r) => r,
+            Err(e) => {
+                return Err(Box::new(ActivationPlan {
+                    inner: InnerConfig::Fake {
+                        kind: FakeKind::Misconfigured,
+                        detail: "flow_def resolution failed".into(),
+                    },
+                    ack: ActivationAck::Failure {
+                        reason: format!(
+                            "{element}: resolving MXL flow id / format from activation \
                          transport file: {e:#}"
-                    ),
-                },
-            }));
-        }
-    };
+                        ),
+                    },
+                }));
+            }
+        };
 
-    Ok(decide_inner_config_mxl(settings, &flow, Some(transport_file)))
+    Ok(decide_inner_config_mxl(
+        settings,
+        &flow,
+        Some(transport_file),
+    ))
 }
 
 #[cfg(test)]
@@ -408,8 +415,7 @@ mod tests {
             ..settings(Side::Sender)
         };
         let overrides = super::property_overrides_mxl(&s, DOMAIN_ID);
-        let spliced =
-            flow_def::splice_overrides(&video_flow_def(FLOW_ID_A), &overrides).unwrap();
+        let spliced = flow_def::splice_overrides(&video_flow_def(FLOW_ID_A), &overrides).unwrap();
         let v: serde_json::Value = serde_json::from_str(&spliced).unwrap();
         assert_eq!(v["id"], FLOW_ID_B);
         // Subsequent resolve_mxl_flow_meta with property==B and
@@ -424,7 +430,12 @@ mod tests {
 
     #[test]
     fn deactivation_is_fake_success() {
-        let plan = make_activation_plan(&cat(), "nmossink", &settings(Side::Sender), &req(Side::Sender, None));
+        let plan = make_activation_plan(
+            &cat(),
+            "nmossink",
+            &settings(Side::Sender),
+            &req(Side::Sender, None),
+        );
         assert!(matches!(plan.inner, InnerConfig::Fake { .. }));
         assert!(matches!(plan.ack, ActivationAck::Success));
     }
@@ -451,8 +462,7 @@ mod tests {
     fn nmossrc_caps_st2038_drives_data_format() {
         use std::str::FromStr;
         init_gst();
-        let caps = gst::Caps::from_str("meta/x-st-2038,framerate=30/1")
-            .expect("static caps parse");
+        let caps = gst::Caps::from_str("meta/x-st-2038,framerate=30/1").expect("static caps parse");
         let s = CommonSettings {
             mxl_flow_id: FLOW_ID_A.to_owned(),
             caps: Some(caps),
@@ -464,7 +474,9 @@ mod tests {
             &s,
             &req(
                 Side::Receiver,
-                Some(r#"{"id":"00000000-0000-0000-0000-000000000001","format":"urn:x-nmos:format:data"}"#),
+                Some(
+                    r#"{"id":"00000000-0000-0000-0000-000000000001","format":"urn:x-nmos:format:data"}"#,
+                ),
             ),
         );
         match plan.inner {
@@ -526,7 +538,10 @@ mod tests {
         );
         match plan.inner {
             InnerConfig::Real(TransportConfig::Mxl {
-                domain_path, flow_id, format, transport_file,
+                domain_path,
+                flow_id,
+                format,
+                transport_file,
             }) => {
                 assert_eq!(domain_path, "/var/lib/mxl/domain-a");
                 assert_eq!(flow_id, FLOW_ID_A);
@@ -639,12 +654,8 @@ mod tests {
             mxl_flow_id: FLOW_ID_A.to_owned(),
             ..settings(Side::Sender)
         };
-        let plan = make_activation_plan(
-            &cat(),
-            "nmossink",
-            &s,
-            &req(Side::Sender, Some("not json")),
-        );
+        let plan =
+            make_activation_plan(&cat(), "nmossink", &s, &req(Side::Sender, Some("not json")));
         assert!(matches!(plan.inner, InnerConfig::Fake { .. }));
         assert!(matches!(plan.ack, ActivationAck::Failure { .. }));
     }
@@ -765,7 +776,8 @@ mod tests {
             init_gst();
             let caps = gst::Caps::from_str("video/x-raw,format=I420,width=1920,height=1080")
                 .expect("static caps parse");
-            let res = add_deferred_sender(&cat(), "nmossink", &sender_settings(), &no_session(), caps);
+            let res =
+                add_deferred_sender(&cat(), "nmossink", &sender_settings(), &no_session(), caps);
             let err = res.expect_err("unsupported caps must be rejected");
             // exact message is owned by from_caps; we just want
             // the synthesis-context wrapper to be present.
@@ -818,7 +830,8 @@ mod tests {
             };
             let out = super::synthesise_or_passthrough_mxl(&cat(), "nmossrc", &s, DOMAIN_ID, None)
                 .expect("synthesis must succeed");
-            let text = out.expect("Receiver synthesis must yield Some(json) when caps + flow id are set");
+            let text =
+                out.expect("Receiver synthesis must yield Some(json) when caps + flow id are set");
             let v = parse(&text);
             assert_eq!(v["id"], FLOW_ID_A);
             assert_eq!(v["format"], "urn:x-nmos:format:video");
@@ -854,10 +867,12 @@ mod tests {
                 caps: Some(video_caps()),
                 ..settings(Side::Receiver)
             };
-            let synth = super::synthesise_or_passthrough_mxl(&cat(), "nmossrc", &s, DOMAIN_ID, None)
-                .expect("synthesis")
-                .expect("some json");
-            let flow = flow_def::resolve_mxl_flow_meta("", FlowFormat::Video, Some(&synth)).unwrap();
+            let synth =
+                super::synthesise_or_passthrough_mxl(&cat(), "nmossrc", &s, DOMAIN_ID, None)
+                    .expect("synthesis")
+                    .expect("some json");
+            let flow =
+                flow_def::resolve_mxl_flow_meta("", FlowFormat::Video, Some(&synth)).unwrap();
             let inner = super::decide_inner_config_mxl(&s, &flow, Some(&synth));
             match inner {
                 InnerConfig::Fake { kind, .. } => assert_eq!(kind, FakeKind::NotActive),
@@ -893,8 +908,14 @@ mod tests {
                 ..settings(Side::Receiver)
             };
             let resolved = Some(video_flow_def(FLOW_ID_A));
-            let out = super::synthesise_or_passthrough_mxl(&cat(), "nmossrc", &s, DOMAIN_ID, resolved.clone())
-                .expect("passthrough must succeed");
+            let out = super::synthesise_or_passthrough_mxl(
+                &cat(),
+                "nmossrc",
+                &s,
+                DOMAIN_ID,
+                resolved.clone(),
+            )
+            .expect("passthrough must succeed");
             assert_eq!(
                 out.as_deref(),
                 resolved.as_deref(),

--- a/rust/gst-nmos-rs/src/session/node.rs
+++ b/rust/gst-nmos-rs/src/session/node.rs
@@ -7,8 +7,8 @@
 use gstreamer as gst;
 use nvnmos_rpc::v1::{NetworkServicesConfig, NodeConfig};
 
-use crate::network_services::parse_nmos_url;
 use crate::CAT;
+use crate::network_services::parse_nmos_url;
 
 /// Snapshot of element properties that map to proto `NodeConfig`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -8,8 +8,8 @@ pub(crate) mod types;
 use anyhow::{Context, bail};
 use gstreamer as gst;
 
-use super::{CommonSettings, FakeKind, InnerConfig, TransportConfig};
 use super::types::Side;
+use super::{CommonSettings, FakeKind, InnerConfig, TransportConfig};
 use crate::sdp::{self, DualLegPassthroughPolicy, SdpOverrides};
 use crate::types::{CapsMode, Transport};
 
@@ -17,7 +17,9 @@ use crate::types::{CapsMode, Transport};
 ///
 /// Used when the element already has a `transport-file` at NULL→READY.
 /// Caps-only synthesis and deferred AddSender still require the name property.
-pub(super) fn resource_name_from_transport_file(text: &str) -> Result<Option<String>, sdp::SdpError> {
+pub(super) fn resource_name_from_transport_file(
+    text: &str,
+) -> Result<Option<String>, sdp::SdpError> {
     sdp::resource_name_from_transport(text)
 }
 
@@ -69,9 +71,7 @@ pub(super) fn validate_rtp_configuring_minimum(
 ) -> Result<(), anyhow::Error> {
     match settings.side {
         Side::Sender if settings.source_ip.is_empty() => {
-            bail!(
-                "{element}: `source-ip` is required to synthesise configuring SDP for AddSender"
-            );
+            bail!("{element}: `source-ip` is required to synthesise configuring SDP for AddSender");
         }
         Side::Receiver if settings.interface_ip.is_empty() => {
             bail!(
@@ -338,9 +338,7 @@ fn finish_udp_inner_config(
         return Err(anyhow::Error::new(sdp::SdpError::DualLegNotSupported));
     }
     let mut media = sdp::parse_sdp(text).with_context(|| {
-        format!(
-            "{element}: parsing SDP transport file for transport={transport:?}"
-        )
+        format!("{element}: parsing SDP transport file for transport={transport:?}")
     })?;
     sdp::cross_check_essence(
         &media,
@@ -431,7 +429,8 @@ fn passthrough_user_transport_file(
 ) -> Result<String, anyhow::Error> {
     let file = sdp::bit_rates_from_sdp_text(text)
         .with_context(|| format!("{element}: parsing bit rates from transport-file SDP"))?;
-    let property = sdp::bit_rates_from_properties(settings.format_bit_rate, settings.transport_bit_rate);
+    let property =
+        sdp::bit_rates_from_properties(settings.format_bit_rate, settings.transport_bit_rate);
     sdp::cross_check_bit_rates(property, file)
         .with_context(|| format!("{element}: cross-checking bit rates against transport-file"))?;
 
@@ -440,9 +439,8 @@ fn passthrough_user_transport_file(
         overrides.bit_rates = property;
     }
 
-    sdp::passthrough_with_overrides(text, &overrides, policy).with_context(|| {
-        format!("{element}: applying property overrides to transport-file SDP")
-    })
+    sdp::passthrough_with_overrides(text, &overrides, policy)
+        .with_context(|| format!("{element}: applying property overrides to transport-file SDP"))
 }
 
 pub(super) fn resolve_inner_config_nvdsudp(
@@ -547,8 +545,8 @@ pub(super) fn resolve_inner_config_udp(
 mod tests {
     use super::super::support::*;
     use super::super::*;
-    use super::*;
     use super::types::{UdpLeg, UdpMedia};
+    use super::*;
     use crate::sdp;
     use crate::types::FlowFormat;
     use std::str::FromStr;
@@ -714,15 +712,14 @@ mod tests {
         #[test]
         fn decide_udp_v1_with_valid_sdp_is_real() {
             let s = udp_settings(Side::Receiver, Transport::Udp);
-            let inner =
-                decide_inner_config_udp(
-                    "nmossrc",
-                    &s,
-                    UdpVariant::V1,
-                    Some(VIDEO_UDP_SDP),
-                    sdp::EssenceCrossCheckMode::Full,
-                )
-                .expect("valid SDP parses");
+            let inner = decide_inner_config_udp(
+                "nmossrc",
+                &s,
+                UdpVariant::V1,
+                Some(VIDEO_UDP_SDP),
+                sdp::EssenceCrossCheckMode::Full,
+            )
+            .expect("valid SDP parses");
             match inner {
                 InnerConfig::Real(TransportConfig::Udp {
                     variant,
@@ -746,15 +743,14 @@ mod tests {
         #[test]
         fn decide_udp_v2_picks_udp2_variant() {
             let s = udp_settings(Side::Sender, Transport::Udp2);
-            let inner =
-                decide_inner_config_udp(
-                    "nmossink",
-                    &s,
-                    UdpVariant::V2,
-                    Some(VIDEO_UDP_SDP),
-                    sdp::EssenceCrossCheckMode::Full,
-                )
-                .expect("valid SDP parses");
+            let inner = decide_inner_config_udp(
+                "nmossink",
+                &s,
+                UdpVariant::V2,
+                Some(VIDEO_UDP_SDP),
+                sdp::EssenceCrossCheckMode::Full,
+            )
+            .expect("valid SDP parses");
             match inner {
                 InnerConfig::Real(TransportConfig::Udp { variant, .. }) => {
                     assert_eq!(variant, UdpVariant::V2);
@@ -829,12 +825,8 @@ mod tests {
                 "m=video 5004 RTP/AVP 96\r\na=inactive\r\n",
             );
             let s = udp_settings(Side::Receiver, Transport::Udp);
-            let plan = make_activation_plan(
-                &cat(),
-                "nmossrc",
-                &s,
-                &req(Side::Receiver, Some(&sdp)),
-            );
+            let plan =
+                make_activation_plan(&cat(), "nmossrc", &s, &req(Side::Receiver, Some(&sdp)));
             match plan.inner {
                 InnerConfig::Fake { kind, .. } => {
                     assert_eq!(kind, FakeKind::NotActive);
@@ -851,15 +843,14 @@ mod tests {
         fn decide_udp_without_transport_file_is_misconfigured() {
             for side in [Side::Sender, Side::Receiver] {
                 let s = udp_settings(side, Transport::Udp);
-                let inner =
-                    decide_inner_config_udp(
-                        "nmossrc",
-                        &s,
-                        UdpVariant::V1,
-                        None,
-                        sdp::EssenceCrossCheckMode::Full,
-                    )
-                    .expect("None transport_file is not an error");
+                let inner = decide_inner_config_udp(
+                    "nmossrc",
+                    &s,
+                    UdpVariant::V1,
+                    None,
+                    sdp::EssenceCrossCheckMode::Full,
+                )
+                .expect("None transport_file is not an error");
                 match inner {
                     InnerConfig::Fake { kind, detail } => {
                         assert_eq!(kind, FakeKind::Misconfigured);
@@ -876,15 +867,14 @@ mod tests {
         #[test]
         fn decide_udp_with_malformed_sdp_attributes_error() {
             let s = udp_settings(Side::Receiver, Transport::Udp);
-            let err =
-                decide_inner_config_udp(
-                    "nmossrc",
-                    &s,
-                    UdpVariant::V1,
-                    Some("garbage"),
-                    sdp::EssenceCrossCheckMode::Full,
-                )
-                .expect_err("malformed SDP must error");
+            let err = decide_inner_config_udp(
+                "nmossrc",
+                &s,
+                UdpVariant::V1,
+                Some("garbage"),
+                sdp::EssenceCrossCheckMode::Full,
+            )
+            .expect_err("malformed SDP must error");
             let msg = format!("{err:#}");
             assert!(
                 msg.contains("nmossrc"),
@@ -936,12 +926,8 @@ mod tests {
         #[test]
         fn activation_udp_malformed_sdp_is_failure() {
             let s = udp_settings(Side::Receiver, Transport::Udp);
-            let plan = make_activation_plan(
-                &cat(),
-                "nmossrc",
-                &s,
-                &req(Side::Receiver, Some("garbage")),
-            );
+            let plan =
+                make_activation_plan(&cat(), "nmossrc", &s, &req(Side::Receiver, Some("garbage")));
             assert!(matches!(plan.inner, InnerConfig::Fake { .. }));
             match plan.ack {
                 ActivationAck::Failure { reason } => assert!(
@@ -1106,11 +1092,7 @@ mod tests {
                 }
             }
 
-            fn receiver_settings(
-                multicast: bool,
-                interface: bool,
-                source: bool,
-            ) -> CommonSettings {
+            fn receiver_settings(multicast: bool, interface: bool, source: bool) -> CommonSettings {
                 let mut s = udp_settings(Side::Receiver, Transport::Udp);
                 if multicast {
                     s.multicast_ip = PROP_MCAST.to_owned();
@@ -1222,16 +1204,9 @@ mod tests {
                             for source in [false, true] {
                                 let settings = receiver_settings(multicast, interface, source);
                                 let spliced = splice(sdp_kind.sdp(), &settings);
-                                let c = expected_c(
-                                    multicast,
-                                    interface,
-                                    sdp_kind.baseline_c(),
-                                );
+                                let c = expected_c(multicast, interface, sdp_kind.baseline_c());
 
-                                assert_c_contains(
-                                    &spliced,
-                                    c,
-                                );
+                                assert_c_contains(&spliced, c);
 
                                 let sf = if source {
                                     Some((c, PROP_SRC))
@@ -1244,10 +1219,7 @@ mod tests {
                                 };
                                 assert_source_filter(&spliced, sf);
 
-                                assert_iface_attr(
-                                    &spliced,
-                                    interface.then_some(PROP_IFACE),
-                                );
+                                assert_iface_attr(&spliced, interface.then_some(PROP_IFACE));
                             }
                         }
                     }
@@ -1366,23 +1338,39 @@ mod tests {
             // The returned transport_file text carries the
             // overrides.
             let spliced = spliced_text.expect("transport_file must be Some after splice");
-            assert!(spliced.contains("c=IN IP4 232.0.0.1"),
-                "c= must be overridden to multicast_ip 232.0.0.1; got: {spliced}");
-            assert!(spliced.contains("m=video 5008"),
-                "m= port must be overridden to 5008; got: {spliced}");
-            assert!(spliced.contains("s=Spliced label\r\n"),
-                "s= must be overridden to label; got: {spliced}");
-            assert!(spliced.contains("i=Spliced description\r\n"),
-                "i= must be overridden to description; got: {spliced}");
-            assert!(spliced.contains("a=x-nvnmos-name:spliced-name\r\n"),
-                "session-level a=x-nvnmos-name must carry overridden name; got: {spliced}");
-            assert!(spliced.contains("a=x-nvnmos-iface-ip:192.0.2.30"),
-                "a=x-nvnmos-iface-ip must carry receiver's interface_ip; got: {spliced}");
+            assert!(
+                spliced.contains("c=IN IP4 232.0.0.1"),
+                "c= must be overridden to multicast_ip 232.0.0.1; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("m=video 5008"),
+                "m= port must be overridden to 5008; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("s=Spliced label\r\n"),
+                "s= must be overridden to label; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("i=Spliced description\r\n"),
+                "i= must be overridden to description; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("a=x-nvnmos-name:spliced-name\r\n"),
+                "session-level a=x-nvnmos-name must carry overridden name; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("a=x-nvnmos-iface-ip:192.0.2.30"),
+                "a=x-nvnmos-iface-ip must carry receiver's interface_ip; got: {spliced}"
+            );
 
             // The Real(Udp) inner config carries the spliced
             // UdpMedia (same source of truth).
             match inner {
-                InnerConfig::Real(TransportConfig::Udp { media, transport_file, .. }) => {
+                InnerConfig::Real(TransportConfig::Udp {
+                    media,
+                    transport_file,
+                    ..
+                }) => {
                     assert_eq!(media.primary.destination_ip, "232.0.0.1");
                     assert_eq!(media.primary.destination_port, 5008);
                     assert_eq!(media.primary.source_ip.as_deref(), Some("192.0.2.20"));
@@ -1405,14 +1393,9 @@ mod tests {
                 multicast_ip: "232.0.0.1".to_owned(),
                 ..udp_settings(Side::Receiver, Transport::Udp)
             };
-            let (inner, text) = resolve_inner_config_udp(
-                &cat(),
-                "nmossrc",
-                &s,
-                UdpVariant::V1,
-                None,
-            )
-            .expect("no error");
+            let (inner, text) =
+                resolve_inner_config_udp(&cat(), "nmossrc", &s, UdpVariant::V1, None)
+                    .expect("no error");
             assert!(text.is_none(), "no input → no synth, no spliced output");
             match inner {
                 InnerConfig::Fake { kind, .. } => {
@@ -1430,14 +1413,9 @@ mod tests {
                 destination_ip: "239.1.1.1".to_owned(),
                 ..udp_settings(Side::Sender, Transport::Udp)
             };
-            let (inner, text) = resolve_inner_config_udp(
-                &cat(),
-                "nmossink",
-                &s,
-                UdpVariant::V1,
-                None,
-            )
-            .expect("no error");
+            let (inner, text) =
+                resolve_inner_config_udp(&cat(), "nmossink", &s, UdpVariant::V1, None)
+                    .expect("no error");
             assert!(text.is_none());
             match inner {
                 InnerConfig::Fake { kind, .. } => {
@@ -1453,8 +1431,8 @@ mod tests {
                 destination_ip: "239.1.1.1".to_owned(),
                 ..udp_settings(Side::Sender, Transport::NvDsUdp)
             };
-            let (inner, text) = resolve_inner_config_nvdsudp(&cat(), "nmossink", &s, None)
-                .expect("no error");
+            let (inner, text) =
+                resolve_inner_config_nvdsudp(&cat(), "nmossink", &s, None).expect("no error");
             assert!(text.is_none());
             assert!(matches!(
                 inner,
@@ -1481,14 +1459,9 @@ mod tests {
             s.interface_ip = "192.0.2.30".to_owned();
             s.destination_port = 5004;
             s.auto_activate = true;
-            let (inner, text) = resolve_inner_config_udp(
-                &cat(),
-                "nmossrc",
-                &s,
-                UdpVariant::V1,
-                None,
-            )
-            .expect("unicast receiver caps synthesis");
+            let (inner, text) =
+                resolve_inner_config_udp(&cat(), "nmossrc", &s, UdpVariant::V1, None)
+                    .expect("unicast receiver caps synthesis");
             let text = text.expect("synthesised SDP");
             assert!(
                 text.contains("c=IN IP4 192.0.2.30"),
@@ -1523,18 +1496,19 @@ mod tests {
                 auto_activate: true,
                 ..udp_settings(Side::Receiver, Transport::Udp)
             };
-            let (inner, text) = resolve_inner_config_udp(
-                &cat(),
-                "nmossrc",
-                &s,
-                UdpVariant::V1,
-                None,
-            )
-            .expect("synth + splice + decide must succeed");
+            let (inner, text) =
+                resolve_inner_config_udp(&cat(), "nmossrc", &s, UdpVariant::V1, None)
+                    .expect("synth + splice + decide must succeed");
             let text = text.expect("synthesised SDP must be returned");
-            assert!(text.contains("m=audio 5004 RTP/AVP 97"), "synthesised SDP:\n{text}");
+            assert!(
+                text.contains("m=audio 5004 RTP/AVP 97"),
+                "synthesised SDP:\n{text}"
+            );
             assert!(text.contains("a=rtpmap:97 L24/48000/2"), "rtpmap:\n{text}");
-            assert!(text.contains("c=IN IP4 232.99.99.1/"), "multicast c=:\n{text}");
+            assert!(
+                text.contains("c=IN IP4 232.99.99.1/"),
+                "multicast c=:\n{text}"
+            );
             assert!(
                 text.contains("a=x-nvnmos-iface-ip:192.0.2.30"),
                 "Receiver iface-ip:\n{text}",
@@ -1572,16 +1546,14 @@ mod tests {
                 auto_activate: true,
                 ..udp_settings(Side::Sender, Transport::Udp)
             };
-            let (inner, text) = resolve_inner_config_udp(
-                &cat(),
-                "nmossink",
-                &s,
-                UdpVariant::V1,
-                None,
-            )
-            .expect("synth + splice + decide must succeed");
+            let (inner, text) =
+                resolve_inner_config_udp(&cat(), "nmossink", &s, UdpVariant::V1, None)
+                    .expect("synth + splice + decide must succeed");
             let text = text.expect("synthesised SDP");
-            assert!(text.contains("m=video 5008 RTP/AVP 96"), "Sender SDP:\n{text}");
+            assert!(
+                text.contains("m=video 5008 RTP/AVP 96"),
+                "Sender SDP:\n{text}"
+            );
             assert!(text.contains("c=IN IP4 239.99.99.1/"), "Sender c=:\n{text}");
             assert!(
                 text.contains("a=source-filter: incl IN IP4 239.99.99.1 192.0.2.10"),
@@ -1754,14 +1726,22 @@ mod tests {
             .expect("splice + decide must succeed");
             let spliced = spliced.expect("transport_file must round-trip");
 
-            assert!(spliced.contains("m=audio 5004 RTP/AVP 100"),
-                "pt override must hit m= line; got: {spliced}");
-            assert!(spliced.contains("a=rtpmap:100 L24/96000/2"),
-                "pt + clock-rate must land on rtpmap together; got: {spliced}");
-            assert!(spliced.contains("a=ptime:1\r\n"),
-                "a=ptime override; got: {spliced}");
-            assert!(spliced.contains("a=maxptime:1\r\n"),
-                "a=maxptime override; got: {spliced}");
+            assert!(
+                spliced.contains("m=audio 5004 RTP/AVP 100"),
+                "pt override must hit m= line; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("a=rtpmap:100 L24/96000/2"),
+                "pt + clock-rate must land on rtpmap together; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("a=ptime:1\r\n"),
+                "a=ptime override; got: {spliced}"
+            );
+            assert!(
+                spliced.contains("a=maxptime:1\r\n"),
+                "a=maxptime override; got: {spliced}"
+            );
         }
 
         /// An invalid pt in `transport-caps` causes
@@ -1861,8 +1841,7 @@ mod tests {
             .expect_err("audio caps + video SDP must error");
             let chain = format!("{err:#}");
             assert!(
-                chain.contains("essence format mismatch")
-                    && chain.contains("cross-checking SDP"),
+                chain.contains("essence format mismatch") && chain.contains("cross-checking SDP"),
                 "error must attribute to cross-check; got: {chain}",
             );
         }
@@ -2048,7 +2027,11 @@ mod tests {
                 &req(Side::Receiver, Some(VIDEO_UDP_SDP)),
             );
             match plan.inner {
-                InnerConfig::Real(TransportConfig::Udp { media, transport_file, .. }) => {
+                InnerConfig::Real(TransportConfig::Udp {
+                    media,
+                    transport_file,
+                    ..
+                }) => {
                     // Activation address is preserved.
                     assert_eq!(media.primary.destination_ip, "239.1.1.1");
                     assert_eq!(media.primary.destination_port, 5004);
@@ -2127,10 +2110,7 @@ mod tests {
                     InnerConfig::Real(TransportConfig::NvDsUdp { media, .. })
                     | InnerConfig::Real(TransportConfig::Udp { media, .. }) => {
                         assert_eq!(media.format, FlowFormat::Data);
-                        assert_eq!(
-                            media.caps.structure(0).unwrap().name(),
-                            "meta/x-st-2038",
-                        );
+                        assert_eq!(media.caps.structure(0).unwrap().name(), "meta/x-st-2038",);
                     }
                     other => panic!("expected Real for {transport:?} ANC, got {other:?}"),
                 }
@@ -2166,35 +2146,32 @@ mod tests {
 
         fn anc_peer_caps() -> gst::Caps {
             init_gst();
-            gst::Caps::from_str("meta/x-st-2038,framerate=30/1")
-                .expect("anc caps")
+            gst::Caps::from_str("meta/x-st-2038,framerate=30/1").expect("anc caps")
         }
 
         #[test]
         fn synthesise_deferred_sender_udp_video_udp_builds_real_inner() {
             let s = sender_udp_settings(Transport::Udp);
-            let (text, inner) = synthesise_deferred_sender_udp(
-                "nmossink",
-                &s,
-                &video_peer_caps(),
-            )
-            .expect("synth");
+            let (text, inner) =
+                synthesise_deferred_sender_udp("nmossink", &s, &video_peer_caps()).expect("synth");
             assert!(text.contains("m=video 5004 RTP/AVP 96"), "SDP:\n{text}");
             assert!(text.contains("c=IN IP4 239.99.99.1/"));
-            assert!(matches!(inner, InnerConfig::Real(TransportConfig::Udp { .. })));
+            assert!(matches!(
+                inner,
+                InnerConfig::Real(TransportConfig::Udp { .. })
+            ));
         }
 
         #[test]
         fn synthesise_deferred_sender_udp_anc_nvdsudp_builds_real_inner() {
             let s = sender_udp_settings(Transport::NvDsUdp);
-            let (text, inner) = synthesise_deferred_sender_udp(
-                "nmossink",
-                &s,
-                &anc_peer_caps(),
-            )
-            .expect("synth");
+            let (text, inner) =
+                synthesise_deferred_sender_udp("nmossink", &s, &anc_peer_caps()).expect("synth");
             assert!(text.contains("smpte291/90000"), "ANC SDP:\n{text}");
-            assert!(matches!(inner, InnerConfig::Real(TransportConfig::NvDsUdp { .. })));
+            assert!(matches!(
+                inner,
+                InnerConfig::Real(TransportConfig::NvDsUdp { .. })
+            ));
         }
 
         #[test]

--- a/rust/gst-nmos-rs/tests/av_sync.rs
+++ b/rust/gst-nmos-rs/tests/av_sync.rs
@@ -52,10 +52,10 @@
 mod common;
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
+use std::sync::atomic::{AtomicBool, Ordering};
 
-use common::{init, nvnmosd_skip_reason, DaemonGuard};
+use common::{DaemonGuard, init, nvnmosd_skip_reason};
 use gst::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
@@ -649,8 +649,7 @@ fn assert_synchronised(video: &[VideoFrame], pips: &[u64], anc_tol: usize) {
         std::collections::BTreeMap::new();
     for f in video {
         for c in &f.captions {
-            let target = ((f.idx as i64 - anc_tol as i64).max(0)
-                ..=(f.idx as i64 + anc_tol as i64))
+            let target = ((f.idx as i64 - anc_tol as i64).max(0)..=(f.idx as i64 + anc_tol as i64))
                 .find_map(|i| {
                     let i = i as u8;
                     (i != 0
@@ -755,7 +754,7 @@ fn skip_reason(t: Transport) -> Option<String> {
                 "nvdsudp needs the DeepStream/Rivermax + PTP runtime (hardware \
                  timestamping) to co-time the flows; not available here"
                     .into(),
-            )
+            );
         }
         Transport::Mxl => {
             if !cfg!(target_os = "linux") {
@@ -823,8 +822,12 @@ fn run_case(t: Transport) {
     let _teardown = Teardown(producer.clone(), consumer.clone());
 
     // Producer first so all three flows exist before the consumer attaches.
-    producer.set_state(gst::State::Playing).expect("producer Playing");
-    consumer.set_state(gst::State::Playing).expect("consumer Playing");
+    producer
+        .set_state(gst::State::Playing)
+        .expect("producer Playing");
+    consumer
+        .set_state(gst::State::Playing)
+        .expect("consumer Playing");
     let (res, _, _) = consumer.state(gst::ClockTime::from_seconds(10));
     res.expect("consumer reached Playing");
 

--- a/rust/gst-nmos-rs/tests/common/mod.rs
+++ b/rust/gst-nmos-rs/tests/common/mod.rs
@@ -38,7 +38,8 @@ fn ensure_gst_plugin_path() {
         return;
     }
     let target_dir = std::env::var("CARGO_TARGET_DIR").ok().unwrap_or_else(|| {
-        let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
+        let manifest =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
         PathBuf::from(manifest)
             .parent()
             .expect("manifest parent")
@@ -97,7 +98,8 @@ pub fn nvnmosd_bin() -> PathBuf {
         return PathBuf::from(p);
     }
     let target_dir = std::env::var("CARGO_TARGET_DIR").ok().unwrap_or_else(|| {
-        let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
+        let manifest =
+            std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR set by cargo");
         PathBuf::from(manifest)
             .parent()
             .expect("manifest parent")
@@ -117,7 +119,12 @@ pub fn nvnmosd_bin() -> PathBuf {
 pub fn libnvnmos_dir() -> Option<PathBuf> {
     let mut dirs: Vec<PathBuf> = Vec::new();
     if let Ok(paths) = std::env::var("LD_LIBRARY_PATH") {
-        dirs.extend(paths.split(':').filter(|s| !s.is_empty()).map(PathBuf::from));
+        dirs.extend(
+            paths
+                .split(':')
+                .filter(|s| !s.is_empty())
+                .map(PathBuf::from),
+        );
     }
     if let Ok(dir) = std::env::var("NVNMOS_LIB_DIR") {
         dirs.push(PathBuf::from(dir));
@@ -161,7 +168,10 @@ impl DaemonGuard {
         command
             .arg("--uds")
             .arg(&socket)
-            .env("RUST_LOG", std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()))
+            .env(
+                "RUST_LOG",
+                std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
+            )
             .stdout(Stdio::null())
             .stderr(Stdio::inherit());
         // nvnmosd links libnvnmos.so; surface NVNMOS_LIB_DIR to the loader even

--- a/rust/gst-nmos-rs/tests/is08_audio_channelmap.rs
+++ b/rust/gst-nmos-rs/tests/is08_audio_channelmap.rs
@@ -19,11 +19,13 @@ mod common;
 use std::str::FromStr;
 use std::time::Duration;
 
-use common::{init, nvnmosd_skip_reason, perfect_fifth_hz, require_factories, A4_HZ, DaemonGuard, Tone};
-use test_skip::skip;
+use common::{
+    A4_HZ, DaemonGuard, Tone, init, nvnmosd_skip_reason, perfect_fifth_hz, require_factories,
+};
 use gst::prelude::*;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
+use test_skip::skip;
 
 const SAMPLE_RATE: i32 = 48_000;
 const CHANNELS: u32 = 2;
@@ -91,7 +93,8 @@ fn pull_mono_samples(appsink: &gst_app::AppSink, timeout: Duration) -> Vec<f32> 
         if remaining_ms == 0 {
             break;
         }
-        let Some(sample) = appsink.try_pull_sample(gst::ClockTime::from_mseconds(remaining_ms)) else {
+        let Some(sample) = appsink.try_pull_sample(gst::ClockTime::from_mseconds(remaining_ms))
+        else {
             std::thread::sleep(Duration::from_millis(5));
             continue;
         };
@@ -233,11 +236,9 @@ fn run_routing_case(daemon_uri: &str, node_seed: &str, case: &RoutingCase, decla
         .link(&sink1)
         .expect("link cf_high -> map.sink_1");
 
-    src0
-        .link(&out0.static_pad("sink").unwrap())
+    src0.link(&out0.static_pad("sink").unwrap())
         .expect("link map.src_0 -> appsink0");
-    src1
-        .link(&out1.static_pad("sink").unwrap())
+    src1.link(&out1.static_pad("sink").unwrap())
         .expect("link map.src_1 -> appsink1");
 
     set_playing_or_panic(&pipeline);
@@ -245,9 +246,7 @@ fn run_routing_case(daemon_uri: &str, node_seed: &str, case: &RoutingCase, decla
     let samples0 = pull_mono_samples(&out0, Duration::from_secs(3));
     let samples1 = pull_mono_samples(&out1, Duration::from_secs(3));
 
-    pipeline
-        .set_state(gst::State::Null)
-        .expect("NULL");
+    pipeline.set_state(gst::State::Null).expect("NULL");
 
     assert!(
         case.expect_src0.dominant_in(&samples0, SAMPLE_RATE as f32),
@@ -309,11 +308,7 @@ fn is08_audio_channelmap_routes_and_swaps_tones() {
     ];
 
     for (idx, case) in cases.iter().enumerate() {
-        let node_seed = format!(
-            "gst-is08-audio-{}-{}",
-            std::process::id(),
-            idx
-        );
+        let node_seed = format!("gst-is08-audio-{}-{}", std::process::id(), idx);
         run_routing_case(&daemon_uri, &node_seed, case, true);
     }
 }
@@ -378,20 +373,36 @@ fn gst_parse_applies_child_properties_on_request_pads() {
     let map = map.dynamic_cast::<gst::ChildProxy>().expect("ChildProxy");
 
     let sink = map.child_by_name("sink_0").expect("sink_0 pad");
-    assert_eq!(sink.property::<u32>("channels"), 7, "sink channels child prop");
+    assert_eq!(
+        sink.property::<u32>("channels"),
+        7,
+        "sink channels child prop"
+    );
     assert_eq!(
         sink.property::<String>("receiver-name"),
         "rin",
         "sink receiver-name child prop"
     );
-    assert_eq!(sink.property::<String>("label"), "in0", "sink label child prop");
+    assert_eq!(
+        sink.property::<String>("label"),
+        "in0",
+        "sink label child prop"
+    );
 
     let src = map.child_by_name("src_0").expect("src_0 pad");
-    assert_eq!(src.property::<u32>("channels"), 5, "src channels child prop");
+    assert_eq!(
+        src.property::<u32>("channels"),
+        5,
+        "src channels child prop"
+    );
     assert_eq!(
         src.property::<String>("sender-name"),
         "sout",
         "src sender-name child prop"
     );
-    assert_eq!(src.property::<String>("label"), "out0", "src label child prop");
+    assert_eq!(
+        src.property::<String>("label"),
+        "out0",
+        "src label child prop"
+    );
 }

--- a/rust/nvnmos/examples/node.rs
+++ b/rust/nvnmos/examples/node.rs
@@ -57,17 +57,49 @@ struct Resource {
 // (`sink-N` / `mxl-sink-N`) and NMOS receivers are sources
 // (`source-N` / `mxl-source-N`).
 const SENDERS: &[Resource] = &[
-    Resource { name: "sink-0",       transport: Transport::Rtp, media: Media::Video },
-    Resource { name: "sink-1",       transport: Transport::Rtp, media: Media::Audio },
-    Resource { name: "mxl-sink-0",   transport: Transport::Mxl, media: Media::Video },
-    Resource { name: "mxl-sink-1",   transport: Transport::Mxl, media: Media::Audio },
+    Resource {
+        name: "sink-0",
+        transport: Transport::Rtp,
+        media: Media::Video,
+    },
+    Resource {
+        name: "sink-1",
+        transport: Transport::Rtp,
+        media: Media::Audio,
+    },
+    Resource {
+        name: "mxl-sink-0",
+        transport: Transport::Mxl,
+        media: Media::Video,
+    },
+    Resource {
+        name: "mxl-sink-1",
+        transport: Transport::Mxl,
+        media: Media::Audio,
+    },
 ];
 
 const RECEIVERS: &[Resource] = &[
-    Resource { name: "source-0",     transport: Transport::Rtp, media: Media::Video },
-    Resource { name: "source-1",     transport: Transport::Rtp, media: Media::Audio },
-    Resource { name: "mxl-source-0", transport: Transport::Mxl, media: Media::Video },
-    Resource { name: "mxl-source-1", transport: Transport::Mxl, media: Media::Audio },
+    Resource {
+        name: "source-0",
+        transport: Transport::Rtp,
+        media: Media::Video,
+    },
+    Resource {
+        name: "source-1",
+        transport: Transport::Rtp,
+        media: Media::Audio,
+    },
+    Resource {
+        name: "mxl-source-0",
+        transport: Transport::Mxl,
+        media: Media::Video,
+    },
+    Resource {
+        name: "mxl-source-1",
+        transport: Transport::Mxl,
+        media: Media::Audio,
+    },
 ];
 
 // MXL example UUIDs, lifted verbatim from `src/main.c` so this example
@@ -395,10 +427,7 @@ fn main() -> ExitCode {
             Ok(())
         })
         .on_log(|log| {
-            eprintln!(
-                "[nvnmos {} {}] {}",
-                log.level, log.categories, log.message
-            );
+            eprintln!("[nvnmos {} {}] {}", log.level, log.categories, log.message);
         })
         .build()
     {
@@ -481,8 +510,7 @@ fn main() -> ExitCode {
         }
     }
     for (name, cfg) in &receivers {
-        if let Err(e) =
-            server.activate_connection(Side::Receiver, name, Some(&cfg.transport_file))
+        if let Err(e) = server.activate_connection(Side::Receiver, name, Some(&cfg.transport_file))
         {
             eprintln!("activate receiver({name}) failed: {e}");
             return ExitCode::FAILURE;

--- a/rust/nvnmos/src/lib.rs
+++ b/rust/nvnmos/src/lib.rs
@@ -198,8 +198,12 @@ pub enum ChannelMappingParentType {
 impl ChannelMappingParentType {
     fn to_ffi(self) -> sys::NvNmosChannelMappingParentType {
         match self {
-            Self::Receiver => sys::_NvNmosChannelMappingParentType_NVNMOS_CHANNELMAPPING_PARENT_TYPE_RECEIVER,
-            Self::Source => sys::_NvNmosChannelMappingParentType_NVNMOS_CHANNELMAPPING_PARENT_TYPE_SOURCE,
+            Self::Receiver => {
+                sys::_NvNmosChannelMappingParentType_NVNMOS_CHANNELMAPPING_PARENT_TYPE_RECEIVER
+            }
+            Self::Source => {
+                sys::_NvNmosChannelMappingParentType_NVNMOS_CHANNELMAPPING_PARENT_TYPE_SOURCE
+            }
         }
     }
 }
@@ -252,7 +256,10 @@ pub struct ChannelMappingConfig {
     pub outputs: Vec<ChannelMappingOutput>,
 }
 type ChannelMappingActivationCallback = Box<
-    dyn Fn(&ChannelMappingActivation<'_>) -> std::result::Result<(), String> + Send + Sync + 'static,
+    dyn Fn(&ChannelMappingActivation<'_>) -> std::result::Result<(), String>
+        + Send
+        + Sync
+        + 'static,
 >;
 
 /// A single log message from libnvnmos, passed to the callback installed via
@@ -1223,10 +1230,9 @@ impl NodeServer {
             channelmapping_activated: callback_state
                 .as_ref()
                 .filter(|s| s.channelmapping_activation.is_some())
-                .map(
-                    |_| channelmapping_activation_trampoline
-                        as unsafe extern "C" fn(_, _, _, _, _) -> _,
-                ),
+                .map(|_| {
+                    channelmapping_activation_trampoline as unsafe extern "C" fn(_, _, _, _, _) -> _
+                }),
             log_callback: callback_state
                 .as_ref()
                 .filter(|s| s.log.is_some())
@@ -1292,9 +1298,8 @@ impl NodeServer {
     /// Remove a sender by its name.
     pub fn remove_sender(&self, sender_name: &str) -> Result<()> {
         let cname = CString::new(sender_name)?;
-        let ok = unsafe {
-            sys::remove_nmos_sender_from_node_server(self.raw_ptr_mut(), cname.as_ptr())
-        };
+        let ok =
+            unsafe { sys::remove_nmos_sender_from_node_server(self.raw_ptr_mut(), cname.as_ptr()) };
         if !ok {
             return Err(Error::Failed("remove_nmos_sender_from_node_server"));
         }
@@ -1517,7 +1522,11 @@ mod tests {
     fn assert_uuid_shape(id: &str) {
         assert_eq!(id.len(), 36, "expected 36-char UUID, got {id:?}");
         let parts: Vec<usize> = id.split('-').map(str::len).collect();
-        assert_eq!(parts, vec![8, 4, 4, 4, 12], "id {id:?} not in 8-4-4-4-12 form");
+        assert_eq!(
+            parts,
+            vec![8, 4, 4, 4, 12],
+            "id {id:?} not in 8-4-4-4-12 form"
+        );
         assert!(
             id.chars().all(|c| c == '-' || c.is_ascii_hexdigit()),
             "id {id:?} contains non-hex characters",
@@ -1566,7 +1575,10 @@ mod tests {
 
     #[test]
     fn rejects_interior_nul() {
-        assert!(matches!(make_node_id("bad\0seed"), Err(Error::InteriorNul(_))));
+        assert!(matches!(
+            make_node_id("bad\0seed"),
+            Err(Error::InteriorNul(_))
+        ));
         assert!(matches!(
             make_sender_id("seed", "bad\0name"),
             Err(Error::InteriorNul(_))

--- a/rust/nvnmosd-bench/src/main.rs
+++ b/rust/nvnmosd-bench/src/main.rs
@@ -29,7 +29,7 @@ use nvnmos_rpc::v1::{
 use serde::Serialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UnixStream};
-use tokio::sync::{mpsc as tokio_mpsc, Mutex, Semaphore};
+use tokio::sync::{Mutex, Semaphore, mpsc as tokio_mpsc};
 use tokio::task::JoinSet;
 use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
@@ -231,9 +231,7 @@ fn cpu_pct_between(
 fn read_proc_cpu_jiffies(pid: u32) -> anyhow::Result<(u64, u64)> {
     let stat = std::fs::read_to_string(format!("/proc/{pid}/stat"))
         .with_context(|| format!("reading /proc/{pid}/stat"))?;
-    let rparen = stat
-        .rfind(')')
-        .context("parsing /proc/stat comm field")?;
+    let rparen = stat.rfind(')').context("parsing /proc/stat comm field")?;
     let fields: Vec<&str> = stat[rparen + 2..].split_whitespace().collect();
     anyhow::ensure!(
         fields.len() > 12,
@@ -320,11 +318,7 @@ impl CpuPhaseSampler {
     }
 }
 
-fn cpu_sampler_loop(
-    pid: u32,
-    interval: Duration,
-    stop: std::sync::mpsc::Receiver<()>,
-) -> Vec<f64> {
+fn cpu_sampler_loop(pid: u32, interval: Duration, stop: std::sync::mpsc::Receiver<()>) -> Vec<f64> {
     let mut samples = Vec::new();
     let Ok((mut prev_utime, mut prev_stime)) = read_proc_cpu_jiffies(pid) else {
         return samples;
@@ -571,10 +565,7 @@ async fn main() -> anyhow::Result<()> {
         args.remove_receivers,
         args.add_receivers,
     );
-    anyhow::ensure!(
-        args.syncs <= MAX_SYNCS,
-        "syncs must be <= {MAX_SYNCS}"
-    );
+    anyhow::ensure!(args.syncs <= MAX_SYNCS, "syncs must be <= {MAX_SYNCS}");
     anyhow::ensure!(
         args.patches <= MAX_PATCHES,
         "patches must be <= {MAX_PATCHES}"
@@ -597,7 +588,10 @@ async fn main() -> anyhow::Result<()> {
         "sessions must be <= {MAX_SESSIONS}"
     );
     if args.add_senders > 0 || args.add_receivers > 0 {
-        anyhow::ensure!(args.sessions >= 1, "sessions must be >= 1 when creating resources");
+        anyhow::ensure!(
+            args.sessions >= 1,
+            "sessions must be >= 1 when creating resources"
+        );
     }
     anyhow::ensure!(
         u32::from(args.base_http_port) + args.nodes as u32 <= u16::MAX as u32,
@@ -615,9 +609,7 @@ async fn main() -> anyhow::Result<()> {
     };
     let mut cpu = CpuMonitor::new(args.daemon_pid, cpu_sample_interval(args.cpu_sample_ms));
 
-    let node_seeds: Vec<String> = (0..args.nodes)
-        .map(|i| format!("bench-node-{i}"))
-        .collect();
+    let node_seeds: Vec<String> = (0..args.nodes).map(|i| format!("bench-node-{i}")).collect();
 
     // -------- Open sessions (one UDS/gRPC client per session, in parallel) --------
     cpu.begin_phase();
@@ -683,16 +675,12 @@ async fn main() -> anyhow::Result<()> {
             sub_set.spawn(async move {
                 let t0 = Instant::now();
                 let (task, hub) = spawn_auto_ack_task(client, session_handle).await?;
-                Ok::<_, anyhow::Error>((
-                    index,
-                    t0.elapsed().as_micros() as u64,
-                    hub,
-                    task,
-                ))
+                Ok::<_, anyhow::Error>((index, t0.elapsed().as_micros() as u64, hub, task))
             });
         }
         while let Some(res) = sub_set.join_next().await {
-            let (index, sample, hub, task) = res.context("SubscribeActivations task panicked")??;
+            let (index, sample, hub, task) =
+                res.context("SubscribeActivations task panicked")??;
             subscribe_samples.push(sample);
             let ctx = &mut sessions[index];
             ctx.activation_hub = Some(hub);
@@ -714,14 +702,10 @@ async fn main() -> anyhow::Result<()> {
         let session_handle = ctx.slot.session_handle.clone();
         let mut client = ctx.client.clone();
         let sender_indices: Vec<usize> = (0..args.add_senders)
-            .filter(|&i| {
-                session_for_resource(i, args.sessions) == session_index
-            })
+            .filter(|&i| session_for_resource(i, args.sessions) == session_index)
             .collect();
         let receiver_indices: Vec<usize> = (0..args.add_receivers)
-            .filter(|&i| {
-                session_for_resource(args.add_senders + i, args.sessions) == session_index
-            })
+            .filter(|&i| session_for_resource(args.add_senders + i, args.sessions) == session_index)
             .collect();
         if sender_indices.is_empty() && receiver_indices.is_empty() {
             continue;
@@ -932,8 +916,7 @@ async fn main() -> anyhow::Result<()> {
                 let mut deactivate_samples = Vec::with_capacity(1);
 
                 let t0 = Instant::now();
-                let (status, _) =
-                    connection_get(&iface_ip, http_port, &staged_path).await?;
+                let (status, _) = connection_get(&iface_ip, http_port, &staged_path).await?;
                 anyhow::ensure!(status == 200, "GET staged returned HTTP {status}");
                 get_samples.push(t0.elapsed().as_micros() as u64);
 
@@ -948,8 +931,7 @@ async fn main() -> anyhow::Result<()> {
                     .await?;
 
                 let t0 = Instant::now();
-                let (status, _) =
-                    connection_get(&iface_ip, http_port, &staged_path).await?;
+                let (status, _) = connection_get(&iface_ip, http_port, &staged_path).await?;
                 anyhow::ensure!(status == 200, "GET staged returned HTTP {status}");
                 get_samples.push(t0.elapsed().as_micros() as u64);
 
@@ -968,8 +950,7 @@ async fn main() -> anyhow::Result<()> {
         }
 
         while let Some(res) = patch_set.join_next().await {
-            let (gets, activates, deactivates) =
-                res.context("Connection API task panicked")??;
+            let (gets, activates, deactivates) = res.context("Connection API task panicked")??;
             connection_get_samples.extend(gets);
             patch_activate_samples.extend(activates);
             patch_deactivate_samples.extend(deactivates);
@@ -986,13 +967,12 @@ async fn main() -> anyhow::Result<()> {
 
     if args.remove_senders > 0 || args.remove_receivers > 0 {
         cpu.begin_phase();
-        let (sender_removals, receiver_removals) =
-            resources_to_remove(
-                &senders,
-                &receivers,
-                args.remove_senders,
-                args.remove_receivers,
-            );
+        let (sender_removals, receiver_removals) = resources_to_remove(
+            &senders,
+            &receivers,
+            args.remove_senders,
+            args.remove_receivers,
+        );
         let mut remove_set = JoinSet::new();
         for ctx in &mut sessions {
             let session_index = ctx.index;
@@ -1023,10 +1003,7 @@ async fn main() -> anyhow::Result<()> {
                         })
                         .await
                         .with_context(|| {
-                            format!(
-                                "RemoveResource sender resource_id={}",
-                                resource.resource_id
-                            )
+                            format!("RemoveResource sender resource_id={}", resource.resource_id)
                         })?;
                     sender_samples.push(t0.elapsed().as_micros() as u64);
                 }
@@ -1069,9 +1046,7 @@ async fn main() -> anyhow::Result<()> {
         close_set.spawn(async move {
             let t0 = Instant::now();
             client
-                .close_session(CloseSessionRequest {
-                    session_handle,
-                })
+                .close_session(CloseSessionRequest { session_handle })
                 .await
                 .context("CloseSession")?;
             Ok::<_, anyhow::Error>(t0.elapsed().as_micros() as u64)
@@ -1336,7 +1311,10 @@ mod tests {
 
     #[test]
     fn activation_indices_full_coverage() {
-        assert_eq!(sender_activation_indices(10, 10), (0..10).collect::<Vec<_>>());
+        assert_eq!(
+            sender_activation_indices(10, 10),
+            (0..10).collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -1358,7 +1336,7 @@ mod tests {
 
     #[test]
     fn resources_to_remove_respects_per_side_counts() {
-        use super::{resources_to_remove, ResourceSlot};
+        use super::{ResourceSlot, resources_to_remove};
 
         let senders: Vec<ResourceSlot> = (0..4)
             .map(|i| ResourceSlot {
@@ -1377,8 +1355,7 @@ mod tests {
             })
             .collect();
 
-        let (removed_senders, removed_receivers) =
-            resources_to_remove(&senders, &receivers, 2, 1);
+        let (removed_senders, removed_receivers) = resources_to_remove(&senders, &receivers, 2, 1);
         assert_eq!(removed_senders.len(), 2);
         assert_eq!(removed_receivers.len(), 1);
         assert_eq!(removed_senders[0].resource_id, "sender-0");

--- a/rust/nvnmosd-example/src/main.rs
+++ b/rust/nvnmosd-example/src/main.rs
@@ -93,21 +93,22 @@ use clap::Parser;
 use hyper_util::rt::TokioIo;
 use nvnmos_rpc::v1::nvnmos_daemon_client::NvnmosDaemonClient;
 use nvnmos_rpc::v1::{
-    AckActivationRequest, AckChannelMappingActivationRequest, ActivationEvent, AddChannelMappingRequest,
-    AddChannelMappingResponse, AddNodeRequest, AddNodeResponse, AddReceiverRequest,
-    AddResourceResponse, AddSenderRequest, AssetConfig, ChannelMappingActivationEvent,
-    ChannelMappingInput as ProtoChannelMappingInput, ChannelMappingOutput as ProtoChannelMappingOutput,
+    AckActivationRequest, AckChannelMappingActivationRequest, ActivationEvent, ActiveMapEntry,
+    AddChannelMappingRequest, AddChannelMappingResponse, AddNodeRequest, AddNodeResponse,
+    AddReceiverRequest, AddResourceResponse, AddSenderRequest, AssetConfig,
+    ChannelMappingActivationEvent, ChannelMappingInput as ProtoChannelMappingInput,
+    ChannelMappingOutput as ProtoChannelMappingOutput,
     ChannelMappingParentType as ProtoChannelMappingParentType, CloseSessionRequest, NodeConfig,
     OpenSessionRequest, OpenSessionResponse, RemoveChannelMappingRequest, RemoveNodeRequest,
     RemoveResourceRequest, Side as ProtoSide, SubscribeActivationsRequest,
     SubscribeChannelMappingActivationsRequest, SyncChannelMappingStateRequest,
-    SyncResourceStateRequest, ActiveMapEntry, Transport as ProtoTransport,
+    SyncResourceStateRequest, Transport as ProtoTransport,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UnixStream};
 use tokio::sync::mpsc as tokio_mpsc;
-use tonic::transport::{Channel, Endpoint, Uri};
 use tonic::Code;
+use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
 #[derive(Parser, Debug)]
@@ -189,7 +190,13 @@ async fn main() -> anyhow::Result<()> {
     let mut client = NvnmosDaemonClient::new(channel);
 
     // (1) First OpenSession: creates the Node.
-    let a = open(&mut client, &args.node_seed, args.http_port, "first session (creates Node)").await?;
+    let a = open(
+        &mut client,
+        &args.node_seed,
+        args.http_port,
+        "first session (creates Node)",
+    )
+    .await?;
     anyhow::ensure!(
         a.created_node,
         "first OpenSession on a fresh seed should have created_node=true; got {}",
@@ -201,7 +208,13 @@ async fn main() -> anyhow::Result<()> {
     // ignored by the daemon when the Node already exists; we still
     // send a NodeConfig because the wire requires `node_config.seed`
     // to identify which Node to attach to.
-    let b = open(&mut client, &args.node_seed, args.http_port, "second session (refcount bump)").await?;
+    let b = open(
+        &mut client,
+        &args.node_seed,
+        args.http_port,
+        "second session (refcount bump)",
+    )
+    .await?;
     anyhow::ensure!(
         !b.created_node,
         "second OpenSession on the same seed should have created_node=false; got {}",
@@ -221,10 +234,20 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // (3) Close the first session: refcount 2→1, Node remains.
-    close(&mut client, &a.session_handle, "first close (refcount to 1)").await?;
+    close(
+        &mut client,
+        &a.session_handle,
+        "first close (refcount to 1)",
+    )
+    .await?;
 
     // (4) Close the second session: refcount 1→0, Node destroyed.
-    close(&mut client, &b.session_handle, "second close (Node destroyed)").await?;
+    close(
+        &mut client,
+        &b.session_handle,
+        "second close (Node destroyed)",
+    )
+    .await?;
 
     // -------- Persistent Node lifecycle --------
     let persistent_seed = format!("{}-persistent", args.node_seed);
@@ -236,8 +259,20 @@ async fn main() -> anyhow::Result<()> {
     // affecting its lifetime. Both must return the persistent Node's id
     // *and* report `created_node=false` (the persistent Node was
     // created by AddNode in step 5).
-    let c = open(&mut client, &persistent_seed, args.http_port, "first session on persistent Node").await?;
-    let d = open(&mut client, &persistent_seed, args.http_port, "second session on persistent Node").await?;
+    let c = open(
+        &mut client,
+        &persistent_seed,
+        args.http_port,
+        "first session on persistent Node",
+    )
+    .await?;
+    let d = open(
+        &mut client,
+        &persistent_seed,
+        args.http_port,
+        "second session on persistent Node",
+    )
+    .await?;
     anyhow::ensure!(
         c.node_id == added.node_id && d.node_id == added.node_id,
         "OpenSession on the persistent seed returned the wrong node_id: \
@@ -317,8 +352,8 @@ async fn main() -> anyhow::Result<()> {
         &build_video_sdp(sender_name, true, &iface_ip),
     )
     .await?;
-    let expected_sender_id = nvnmos::make_sender_id(&resource_seed, sender_name)
-        .context("make_sender_id")?;
+    let expected_sender_id =
+        nvnmos::make_sender_id(&resource_seed, sender_name).context("make_sender_id")?;
     anyhow::ensure!(
         sender_resp.resource_id == expected_sender_id,
         "AddSender returned resource_id {} but make_sender_id({:?}, {:?}) says {}",
@@ -343,8 +378,7 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
     let expected_receiver_id =
-        nvnmos::make_receiver_id(&resource_seed, receiver_name)
-            .context("make_receiver_id")?;
+        nvnmos::make_receiver_id(&resource_seed, receiver_name).context("make_receiver_id")?;
     anyhow::ensure!(
         receiver_resp.resource_id == expected_receiver_id,
         "AddReceiver returned resource_id {} but make_receiver_id({:?}, {:?}) says {}",
@@ -420,7 +454,9 @@ async fn main() -> anyhow::Result<()> {
         .await
         .context("Connection API PATCH deactivate round-trip")?;
     } else {
-        tracing::info!("--skip-connection set; skipping the in-band Connection API PATCH round-trip");
+        tracing::info!(
+            "--skip-connection set; skipping the in-band Connection API PATCH round-trip"
+        );
     }
 
     // (16) Mismatch: claim name="claimed-id" but build the SDP with a
@@ -652,8 +688,7 @@ async fn spawn_auto_ack_task(
             match stream.message().await {
                 Ok(Some(event)) => {
                     let activated = event.transport_file.is_some();
-                    let side = ProtoSide::try_from(event.side)
-                        .unwrap_or(ProtoSide::Unspecified);
+                    let side = ProtoSide::try_from(event.side).unwrap_or(ProtoSide::Unspecified);
                     tracing::info!(
                         session_handle,
                         resource_handle = %event.resource_handle,
@@ -1098,9 +1133,7 @@ async fn connection_patch(
             .split_whitespace()
             .nth(1)
             .and_then(|s| s.parse().ok())
-            .ok_or_else(|| {
-                anyhow::anyhow!("could not parse HTTP status line: {status_line:?}")
-            })?;
+            .ok_or_else(|| anyhow::anyhow!("could not parse HTTP status line: {status_line:?}"))?;
         Ok((status, resp))
     })
     .await
@@ -1125,16 +1158,18 @@ async fn drive_connection_sender_activation(
         r#"{{"master_enable":{enable},"activation":{{"mode":"activate_immediate"}}}}"#,
         enable = expect_active,
     );
-    let path = format!(
-        "/x-nmos/connection/v1.1/single/senders/{sender_resource_id}/staged"
-    );
+    let path = format!("/x-nmos/connection/v1.1/single/senders/{sender_resource_id}/staged");
     tracing::info!(
         connection_host,
         connection_port,
         sender_resource_id,
         expect_active,
         "IS-05 PATCH (sender {action})",
-        action = if expect_active { "activate" } else { "deactivate" },
+        action = if expect_active {
+            "activate"
+        } else {
+            "deactivate"
+        },
     );
 
     let (status, body_resp) = connection_patch(connection_host, connection_port, &path, &body)

--- a/rust/nvnmosd/src/env_config.rs
+++ b/rust/nvnmosd/src/env_config.rs
@@ -26,13 +26,7 @@ pub(crate) enum EnvDefault {
 
 /// Read `name` from the process environment and parse it with [`parse_env_bool`].
 pub(crate) fn read_env_bool(name: &str, default: EnvDefault) -> bool {
-    parse_env_bool(
-        std::env::var(name)
-            .ok()
-            .as_deref()
-            .map(str::trim),
-        default,
-    )
+    parse_env_bool(std::env::var(name).ok().as_deref().map(str::trim), default)
 }
 
 /// Parse a boolean environment value. `None` means the variable was unset.

--- a/rust/nvnmosd/src/log_bridge.rs
+++ b/rust/nvnmosd/src/log_bridge.rs
@@ -15,9 +15,7 @@
 //! directive equivalent) brings the full firehose into view; the default
 //! `info` filter shows just warnings and errors.
 
-use nvnmos::{
-    LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_VERBOSE, LOG_LEVEL_WARNING, LogMessage,
-};
+use nvnmos::{LOG_LEVEL_ERROR, LOG_LEVEL_INFO, LOG_LEVEL_VERBOSE, LOG_LEVEL_WARNING, LogMessage};
 use tracing::{Level, event};
 
 /// `tracing` target used for every event emitted by the bridge.

--- a/rust/nvnmosd/src/main.rs
+++ b/rust/nvnmosd/src/main.rs
@@ -42,21 +42,18 @@ use nvnmos_rpc::v1::{
     AddChannelMappingRequest, AddChannelMappingResponse, AddNodeRequest, AddNodeResponse,
     AddReceiverRequest, AddResourceResponse, AddSenderRequest, CloseSessionRequest, Empty,
     OpenSessionRequest, OpenSessionResponse, RemoveChannelMappingRequest, RemoveNodeRequest,
-    RemoveResourceRequest, SubscribeActivationsRequest,
-    SubscribeChannelMappingActivationsRequest, SyncChannelMappingStateRequest,
-    SyncResourceStateRequest, Transport as ProtoTransport,
+    RemoveResourceRequest, SubscribeActivationsRequest, SubscribeChannelMappingActivationsRequest,
+    SyncChannelMappingStateRequest, SyncResourceStateRequest, Transport as ProtoTransport,
 };
 use tokio::net::UnixListener;
 use tokio::sync::mpsc as tokio_mpsc;
-use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
 use tokio_stream::Stream;
+use tokio_stream::wrappers::{ReceiverStream, UnixListenerStream};
 use tonic::{Request, Response, Status};
 
 use crate::http_port::read_http_port_range;
 use crate::session_gc::SessionGc;
-use crate::state::{
-    AckOutcome, ActivationDispatch, ChannelMappingActivationDispatch, Side, State,
-};
+use crate::state::{AckOutcome, ActivationDispatch, ChannelMappingActivationDispatch, Side, State};
 
 /// Bound on the per-session activations stream. Small because activations
 /// are rare (one per IS-05 PATCH) and the consumer is expected to ack
@@ -290,8 +287,7 @@ impl NvnmosDaemon for Daemon {
         let req = request.into_inner();
         let outcome = {
             let mut state = self.lock_state();
-            let outcome =
-                state.remove_resource(&req.session_handle, &req.resource_handle)?;
+            let outcome = state.remove_resource(&req.session_handle, &req.resource_handle)?;
             malloc_trim::maybe_after_remove_resource(&state, &outcome.node_seed);
             outcome
         };
@@ -389,12 +385,7 @@ impl NvnmosDaemon for Daemon {
         let req = request.into_inner();
         let outcome = {
             let mut state = self.lock_state();
-            state.add_channelmapping(
-                &req.session_handle,
-                &req.name,
-                &req.inputs,
-                &req.outputs,
-            )?
+            state.add_channelmapping(&req.session_handle, &req.name, &req.inputs, &req.outputs)?
         };
         tracing::info!(
             session_handle = %req.session_handle,
@@ -677,10 +668,7 @@ fn route_activation(
         Ok(outcome) if outcome.success => Ok(()),
         Ok(outcome) => Err(outcome.failure_reason),
         Err(std_mpsc::RecvTimeoutError::Timeout) => {
-            tracing::warn!(
-                activation_handle,
-                "activation ack timed out; NACKing",
-            );
+            tracing::warn!(activation_handle, "activation ack timed out; NACKing",);
             Err("activation ack timed out".to_string())
         }
         Err(std_mpsc::RecvTimeoutError::Disconnected) => {

--- a/rust/nvnmosd/src/malloc_trim.rs
+++ b/rust/nvnmosd/src/malloc_trim.rs
@@ -75,12 +75,7 @@ fn run_impl(via: &str, node_seed: &str) {
         log_malloc_info(via, "after");
     }
 
-    tracing::info!(
-        via,
-        node_seed,
-        released,
-        "malloc_trim"
-    );
+    tracing::info!(via, node_seed, released, "malloc_trim");
 }
 
 #[cfg(target_os = "linux")]
@@ -112,8 +107,5 @@ fn log_malloc_info(via: &str, phase: &str) {
 
 #[cfg(not(target_os = "linux"))]
 fn run_impl(_via: &str, node_seed: &str) {
-    tracing::debug!(
-        node_seed,
-        "malloc_trim skipped (not Linux)"
-    );
+    tracing::debug!(node_seed, "malloc_trim skipped (not Linux)");
 }

--- a/rust/nvnmosd/src/session_gc.rs
+++ b/rust/nvnmosd/src/session_gc.rs
@@ -78,7 +78,11 @@ impl SessionGc {
     }
 
     pub fn cancel_timeout(&self, session_handle: &str) {
-        if let Some(handle) = self.watchdogs.lock().expect("watchdog mutex poisoned").remove(session_handle)
+        if let Some(handle) = self
+            .watchdogs
+            .lock()
+            .expect("watchdog mutex poisoned")
+            .remove(session_handle)
         {
             handle.abort();
         }
@@ -127,7 +131,10 @@ impl SessionGc {
                 implicit = true,
                 "CloseSession",
             );
-            let _ = watchdogs.lock().expect("watchdog mutex poisoned").remove(&handle);
+            let _ = watchdogs
+                .lock()
+                .expect("watchdog mutex poisoned")
+                .remove(&handle);
         });
         self.watchdogs
             .lock()

--- a/rust/nvnmosd/src/state.rs
+++ b/rust/nvnmosd/src/state.rs
@@ -49,9 +49,9 @@ use std::sync::mpsc as std_mpsc;
 use std::time::Duration;
 
 use nvnmos::{
-    ChannelMappingActiveMapEntry, AssetConfig, ChannelMappingConfig, ChannelMappingInput, ChannelMappingOutput,
-    ChannelMappingParentType, NetworkServicesConfig, NodeConfig, NodeServer, ReceiverConfig,
-    SenderConfig, Side as WrapperSide, Transport,
+    AssetConfig, ChannelMappingActiveMapEntry, ChannelMappingConfig, ChannelMappingInput,
+    ChannelMappingOutput, ChannelMappingParentType, NetworkServicesConfig, NodeConfig, NodeServer,
+    ReceiverConfig, SenderConfig, Side as WrapperSide, Transport,
 };
 use nvnmos_rpc::v1::{
     ActivationEvent, ActiveMapEntry as ProtoActiveMapEntry, AssetConfig as ProtoAssetConfig,
@@ -177,11 +177,7 @@ impl Side {
     /// `Ok(None)` when libnvnmos does not have a resource of this side
     /// with the given `name`. Used as the post-add validation
     /// primitive by [`State::add_resource`].
-    fn lookup_id(
-        self,
-        server: &NodeServer,
-        name: &str,
-    ) -> nvnmos::Result<Option<String>> {
+    fn lookup_id(self, server: &NodeServer, name: &str) -> nvnmos::Result<Option<String>> {
         match self {
             Self::Sender => server.sender_id(name),
             Self::Receiver => server.receiver_id(name),
@@ -191,11 +187,7 @@ impl Side {
     /// Dispatch the wrapper's `remove_*` call. Used both by
     /// [`State::remove_resource`] and by [`State::close_session`] when
     /// dropping a session's resources before tearing down the Node.
-    fn remove_from_server(
-        self,
-        server: &NodeServer,
-        name: &str,
-    ) -> nvnmos::Result<()> {
+    fn remove_from_server(self, server: &NodeServer, name: &str) -> nvnmos::Result<()> {
         match self {
             Self::Sender => server.remove_sender(name),
             Self::Receiver => server.remove_receiver(name),
@@ -557,12 +549,7 @@ impl State {
                         http_port,
                     },
                 );
-                (
-                    true,
-                    node_id,
-                    Lifetime::SessionRefcounted,
-                    http_port,
-                )
+                (true, node_id, Lifetime::SessionRefcounted, http_port)
             }
         };
 
@@ -648,8 +635,9 @@ impl State {
                 resource.side,
                 resource.name.clone(),
             ));
-            if let Err(e) =
-                resource.side.remove_from_server(&node.server, &resource.name)
+            if let Err(e) = resource
+                .side
+                .remove_from_server(&node.server, &resource.name)
             {
                 tracing::warn!(
                     %resource_handle,
@@ -702,8 +690,7 @@ impl State {
         let lifetime = entry.lifetime;
         entry.attached_sessions = entry.attached_sessions.saturating_sub(1);
         let remaining_sessions = entry.attached_sessions;
-        let node_destroyed =
-            lifetime == Lifetime::SessionRefcounted && remaining_sessions == 0;
+        let node_destroyed = lifetime == Lifetime::SessionRefcounted && remaining_sessions == 0;
         if node_destroyed {
             self.http_ports.remove(&entry.http_port);
             self.nodes.remove(&seed);
@@ -778,9 +765,10 @@ impl State {
     ///   currently attached (the caller must close them first).
     pub fn remove_node(&mut self, seed: &str) -> Result<RemoveNodeOutcome, Status> {
         require_non_empty_seed(seed)?;
-        let entry = self.nodes.get(seed).ok_or_else(|| {
-            Status::not_found(format!("no Node exists for seed {seed:?}"))
-        })?;
+        let entry = self
+            .nodes
+            .get(seed)
+            .ok_or_else(|| Status::not_found(format!("no Node exists for seed {seed:?}")))?;
         match entry.lifetime {
             Lifetime::Persistent => {}
             Lifetime::SessionRefcounted => {
@@ -1001,8 +989,9 @@ impl State {
         // removal is best-effort — a failure here would leak a resource
         // in libnvnmos's IS-04 model, but our state stays clean.
         if let Some(node) = self.nodes.get(&resource.node_seed) {
-            if let Err(e) =
-                resource.side.remove_from_server(&node.server, &resource.name)
+            if let Err(e) = resource
+                .side
+                .remove_from_server(&node.server, &resource.name)
             {
                 tracing::warn!(
                     resource_handle,
@@ -1338,11 +1327,7 @@ impl State {
     /// Resolve `requested` (`0` = allocate from `port_range`) to an
     /// available TCP port. Skips ports already assigned to another Node
     /// and runs a bind-only host probe before Node creation.
-    fn resolve_http_port(
-        &self,
-        requested: u16,
-        port_range: &PortRange,
-    ) -> Result<u16, Status> {
+    fn resolve_http_port(&self, requested: u16, port_range: &PortRange) -> Result<u16, Status> {
         if requested != 0 {
             if let Some(owner) = self.http_ports.get(&requested) {
                 return Err(Status::already_exists(format!(
@@ -1385,9 +1370,7 @@ impl State {
     }
 
     fn allocate_channelmapping_handle(&self) -> String {
-        let n = self
-            .next_channelmapping_id
-            .fetch_add(1, Ordering::Relaxed);
+        let n = self.next_channelmapping_id.fetch_add(1, Ordering::Relaxed);
         format!("cm-{n}")
     }
 
@@ -1491,16 +1474,11 @@ impl State {
             .values()
             .any(|entry| entry.node_seed == node_seed);
 
-        let effective_input_ids =
-            effective_channelmapping_input_ids(name, inputs, first_on_node);
+        let effective_input_ids = effective_channelmapping_input_ids(name, inputs, first_on_node);
         let effective_output_ids =
             effective_channelmapping_output_ids(name, outputs, first_on_node);
-        let mapping = build_channel_mapping(
-            inputs,
-            outputs,
-            &effective_input_ids,
-            &effective_output_ids,
-        );
+        let mapping =
+            build_channel_mapping(inputs, outputs, &effective_input_ids, &effective_output_ids);
 
         let node = self.nodes.get(&node_seed).ok_or_else(|| {
             Status::internal(format!(
@@ -1509,11 +1487,13 @@ impl State {
             ))
         })?;
 
-        node.server.add_channelmapping(name, &mapping).map_err(|e| {
-            Status::invalid_argument(format!(
-                "libnvnmos add_channelmapping failed (duplicate or invalid geometry): {e}"
-            ))
-        })?;
+        node.server
+            .add_channelmapping(name, &mapping)
+            .map_err(|e| {
+                Status::invalid_argument(format!(
+                    "libnvnmos add_channelmapping failed (duplicate or invalid geometry): {e}"
+                ))
+            })?;
 
         let channelmapping_handle = self.allocate_channelmapping_handle();
         let output_id_set: HashSet<String> = effective_output_ids.iter().cloned().collect();
@@ -1625,12 +1605,15 @@ impl State {
             )));
         }
 
-        let entry = self.channelmappings.get(channelmapping_handle).ok_or_else(|| {
-            Status::internal(format!(
-                "session {session_handle:?} owns channelmapping_handle \
+        let entry = self
+            .channelmappings
+            .get(channelmapping_handle)
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "session {session_handle:?} owns channelmapping_handle \
                  {channelmapping_handle:?} but no entry exists"
-            ))
-        })?;
+                ))
+            })?;
         let node = self.nodes.get(&entry.node_seed).ok_or_else(|| {
             Status::internal(format!(
                 "channelmapping {channelmapping_handle:?} references seed {:?} but no Node \
@@ -1952,9 +1935,7 @@ pub fn translate_config(proto: Option<&ProtoNodeConfig>) -> Result<NodeConfig, S
 /// `INVALID_ARGUMENT`: libnvnmos requires all four fields when asset
 /// tags are present at all, so failing here gives the client a clearer
 /// error than letting the wrapper trip over an empty string later.
-fn translate_asset_tags(
-    proto: Option<&ProtoAssetConfig>,
-) -> Result<Option<AssetConfig>, Status> {
+fn translate_asset_tags(proto: Option<&ProtoAssetConfig>) -> Result<Option<AssetConfig>, Status> {
     let Some(proto) = proto else { return Ok(None) };
     let all_empty = proto.manufacturer.is_empty()
         && proto.product.is_empty()

--- a/rust/nvnmosd/src/uds.rs
+++ b/rust/nvnmosd/src/uds.rs
@@ -37,24 +37,19 @@ pub fn prepare_listen_path(path: &Path) -> anyhow::Result<()> {
         Err(e) if e.kind() == ErrorKind::ConnectionRefused => {
             // Stale socket file with no acceptor.
             if path.exists() {
-                std::fs::remove_file(path).with_context(|| {
-                    format!("removing stale UDS socket at {}", path.display())
-                })?;
+                std::fs::remove_file(path)
+                    .with_context(|| format!("removing stale UDS socket at {}", path.display()))?;
             }
         }
         Err(e) => {
-            anyhow::bail!(
-                "cannot probe UDS socket at {}: {e}",
-                path.display()
-            );
+            anyhow::bail!("cannot probe UDS socket at {}: {e}", path.display());
         }
     }
 
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).with_context(|| {
-                format!("creating parent directory for {}", path.display())
-            })?;
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating parent directory for {}", path.display()))?;
         }
     }
 
@@ -69,10 +64,7 @@ mod tests {
 
     #[test]
     fn rejects_live_listener() {
-        let dir = std::env::temp_dir().join(format!(
-            "nvnmosd-uds-test-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("nvnmosd-uds-test-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         let sock = dir.join("nvnmosd.sock");
 
@@ -81,20 +73,14 @@ mod tests {
 
         let err = prepare_listen_path(&sock).unwrap_err();
         let msg = format!("{err:#}");
-        assert!(
-            msg.contains("already in use"),
-            "unexpected error: {msg}"
-        );
+        assert!(msg.contains("already in use"), "unexpected error: {msg}");
 
         let _ = std::fs::remove_dir_all(dir);
     }
 
     #[test]
     fn probes_even_when_pathname_is_missing() {
-        let dir = std::env::temp_dir().join(format!(
-            "nvnmosd-uds-missing-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("nvnmosd-uds-missing-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         let sock = dir.join("nvnmosd.sock");
 
@@ -106,10 +92,7 @@ mod tests {
 
     #[test]
     fn removes_stale_socket_file() {
-        let dir = std::env::temp_dir().join(format!(
-            "nvnmosd-uds-stale-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("nvnmosd-uds-stale-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         let sock = dir.join("nvnmosd.sock");
         std::fs::write(&sock, b"").expect("create stale socket file");
@@ -123,10 +106,7 @@ mod tests {
 
     #[test]
     fn rejects_while_background_listener_holds_path() {
-        let dir = std::env::temp_dir().join(format!(
-            "nvnmosd-uds-bg-{}",
-            std::process::id()
-        ));
+        let dir = std::env::temp_dir().join(format!("nvnmosd-uds-bg-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
         let sock = dir.join("nvnmosd.sock");
 

--- a/rust/nvnmosd/tests/session_gc.rs
+++ b/rust/nvnmosd/tests/session_gc.rs
@@ -16,8 +16,8 @@ use nvnmos_rpc::v1::{
 };
 use tempfile::TempDir;
 use tokio::net::UnixStream;
-use tonic::transport::{Channel, Endpoint, Uri};
 use tonic::Code;
+use tonic::transport::{Channel, Endpoint, Uri};
 use tower::service_fn;
 
 struct DaemonHarness {
@@ -71,9 +71,7 @@ fn find_libnvnmos_dir() -> String {
     if let Ok(dir) = std::env::var("NVNMOS_LIB_DIR") {
         candidates.push(PathBuf::from(dir));
     }
-    candidates.push(
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../build"),
-    );
+    candidates.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../build"));
     if let Ok(cwd) = std::env::current_dir() {
         candidates.push(cwd.join("../build"));
         candidates.push(cwd.join("build"));
@@ -223,11 +221,7 @@ async fn open_session(client: &mut NvnmosDaemonClient<Channel>, seed: &str) -> S
 }
 
 fn expect_code(err: tonic::Status, expected: Code) {
-    assert_eq!(
-        err.code(),
-        expected,
-        "unexpected gRPC status: {err}"
-    );
+    assert_eq!(err.code(), expected, "unexpected gRPC status: {err}");
 }
 
 /// Case A — subscribe before add.


### PR DESCRIPTION
Add `cargo fmt --all --check` to the Rust CI job (with the rustfmt component) and apply a one-time format pass across the workspace. Keep the existing `edition = "2024"` config (matching gst-plugins-rs); no rule changes needed.