### PR TITLE
nvnmosd: fix state/model lock-ordering deadlock

### DIFF
--- a/doc/designs/nvnmosd/lock-ordering.md
+++ b/doc/designs/nvnmosd/lock-ordering.md
@@ -1,0 +1,229 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# `nvnmosd` — lock ordering and concurrent FFI
+
+The daemon can deadlock, hang its whole gRPC surface, and strand a Node's
+HTTP listener in `LISTEN`, when an in-band IS-05 / IS-08 activation runs
+concurrently with an RPC that called libnvnmos while holding the daemon
+`state` mutex.
+
+Observed symptom: producer/consumer example pipelines run against a shared
+long-lived `nvnmosd`; Ctrl+C one pipeline; the NMOS API becomes
+non-responsive and the Node's `http-port` stays in `LISTEN`, so a relaunch
+cannot bind it.
+
+This document describes the failure mode, the invariant that fixes it, the
+**as-built** orchestration in `rust/nvnmosd`, and what concurrency guarantees
+remain (and do not remain) after releasing `state` around FFI.
+
+## Locks in play
+
+| Lock | Owner | Guards |
+|------|-------|--------|
+| `state` | `nvnmosd` (`Arc<Mutex<State>>`) | Nodes, sessions, resources, channel mappings, subscriptions, pending activations, `http_ports`, `pending_nodes` |
+| `SessionGc.watchdogs` | `nvnmosd` | per-session watchdog abort handles |
+| `model` (read/write) | libnvnmos / nmos-cpp (`node_model`) | the IS-04 / IS-05 / IS-08 resource model |
+
+`model` is not visible to Rust directly; every libnvnmos FFI entry point
+acquires it internally.
+
+## The two lock orders (pre-fix)
+
+### Order A — activation callback: `model` → `state`
+
+nmos-cpp's `connection_activation_thread` (and the IS-08
+`channelmapping_activation_thread`) take `model.write_lock()` for the whole
+processing loop, and invoke the daemon's callback **while still holding it**:
+
+- `nmos-cpp` `connection_activation.cpp` — `auto lock = model.write_lock();`
+- `nmos-cpp` `connection_activation.cpp` — `connection_activated(...)`
+- `nmos-cpp` `channelmapping_activation.cpp` — same shape
+
+The callback lands in `route_activation` (`main.rs`), which takes `state`:
+
+- dispatch: `state.lock()` → `dispatch_activation`
+- then **blocks up to `ACTIVATION_ACK_TIMEOUT` (5 s) on the client ack while
+  the model write-lock is still held by the caller**
+- cleanup: `state.lock()` again → `cleanup_pending_activation`
+
+So this path holds `model`, then wants `state` (twice), and keeps `model`
+for up to 5 s per activation.
+
+### Order B — RPC handler (pre-fix): `state` → `model`
+
+Every mutating RPC handler held `state` across a `State::*` method that
+called libnvnmos FFI; each FFI entry took `model`.
+
+### Deadlock
+
+Order A (`model`→`state`) and Order B (`state`→`model`) are opposite. Run
+concurrently they are a classic AB-BA deadlock. Example:
+
+1. An IS-05 activation is in flight: activation thread holds `model`, is in
+   `route_activation`, blocked on the ack.
+2. `AddSender` arrives: handler takes `state`, calls FFI, blocks on `model`.
+3. The ack arrives: `AckActivation` needs `state` (held by the blocked
+   `AddSender`) — cannot complete → activation cannot be acked.
+4. After 5 s the activation times out and `route_activation` re-takes
+   `state` for cleanup — but `AddSender` still holds `state` waiting on
+   `model`. Neither can proceed. **Permanent deadlock.**
+
+`CloseSession` was the worst case: after `remove_*` it dropped the
+`NodeServer`, whose `destroy_nmos_node_server` sets `model.shutdown` (needs
+`model`) and **joins the activation thread**. If that thread was parked
+needing `state`, the join never returned; the cpprest `http_listener` was
+never closed, so the socket stayed in `LISTEN` and a relaunch could not bind
+the port.
+
+The implicit close via session GC ran the same `close_session` under
+`state` (`session_gc.rs`), so the GC self-heal path had the identical
+deadlock.
+
+## Invariant (post-fix)
+
+**No libnvnmos FFI call while holding `state`.**
+
+Bookkeeping (maps, reservations, session attach/detach) stays under `state`.
+Blocking libnvnmos work runs only after the guard is dropped. Where teardown
+needs a `NodeServer`, an `Arc<NodeServer>` captured under the lock keeps the
+C++ object alive until deferred `*Ffi::run()` completes outside the lock.
+
+`route_activation` already released `state` before the ack wait; both
+`state` sections in that path remain FFI-free.
+
+## As-built orchestration
+
+RPC handlers in `main.rs` delegate to inherent `Daemon` helpers where the
+pattern is non-trivial. `State` in `state.rs` owns the bookkeeping phases
+and the `*Prep` / `*Ffi` / `*Ready` types.
+
+### Three-phase add / create (prepare → run FFI → commit)
+
+Used when daemon maps must be validated or reserved before libnvnmos runs,
+then updated after FFI succeeds.
+
+| RPC | First phase (`state`, locked) | Second phase (no `state` lock) | Third phase (`state`, locked) |
+|-----|-------------------------------|--------------------------------|-------------------------------|
+| `AddNode` | `prepare_add_node` → `CreateNodePrep` | `Daemon::run_ffi` → `CreateNodePrep::run_ffi` | `commit_add_node` |
+| `OpenSession` (new Node) | `prepare_open_session` → `CreateNodePrep` | `Daemon::run_ffi` → `CreateNodePrep::run_ffi` | `commit_open_session` |
+| `OpenSession` (existing Node) | `prepare_open_session` → `Attached` | — (no FFI) | — |
+| `AddSender` / `AddReceiver` | `prepare_add_resource` | `AddResourcePrep::run_ffi` | `commit_add_resource` |
+| `AddChannelMapping` | `prepare_add_channelmapping` | `AddChannelMappingPrep::run_ffi` | `commit_add_channelmapping` |
+
+Node create is special: `CreateNodePrep::run_ffi` builds the
+`NodeServer` (`create_nmos_node_server` + `node_id()`), but activation
+callbacks are supplied by `Daemon::run_ffi` in `main.rs` because they route
+into `route_activation` / `route_channelmapping_activation` and need
+`Arc<Mutex<State>>` — which `State` cannot capture from inside `&mut self`.
+
+On FFI failure during node create, `Daemon::run_ffi` briefly re-locks
+`state` to call `abort_pending_node` (drops the pending seed and port).
+
+### Two-phase remove / close / sync (bookkeeping → deferred FFI)
+
+Used when all daemon map updates can finish under the lock; libnvnmos
+cleanup runs afterwards.
+
+| RPC | Under `state` | Outside `state` |
+|-----|---------------|-----------------|
+| `RemoveNode` | `remove_node` → `RemoveNodeFfi` | `ffi.run()` |
+| `CloseSession` | `close_session` → `CloseSessionFfi` | `ffi.run()` (removals + optional `NodeServer` destroy) |
+| `RemoveResource` | `remove_resource` → `RemoveResourceFfi` | `ffi.run()` |
+| `RemoveChannelMapping` | `remove_channelmapping` → `RemoveChannelMappingFfi` | `ffi.run()` |
+| `SyncResourceState` | `sync_resource_state` → `SyncResourceFfi` | `ffi.run()?` |
+| `SyncChannelMappingState` | `sync_channelmapping_state` → `SyncChannelMappingFfi` | `ffi.run()?` |
+
+`CloseSessionFfi` and `RemoveNodeFfi` hold the last `Arc<NodeServer>`
+until `run()` drops it, running `destroy_nmos_node_server` (shutdown +
+thread-join + listener close) with no `state` lock held.
+
+Session GC (`session_gc.rs`) uses the same close pattern: bookkeeping under
+`state`, then `CloseSessionFfi::run()` outside the lock.
+
+## Concurrency during the unlocked gap
+
+Releasing and re-acquiring `state` does **not** remove all races; it removes
+the AB-BA deadlock with `model`. Bookkeeping mutations remain serialized by
+`state`. The unlocked window only runs blocking libnvnmos work or drops an
+`Arc<NodeServer>` whose lifetime was captured under the lock.
+
+### Protections
+
+| Concern | Mechanism |
+|---------|-----------|
+| Double node create for same `node_seed` | `pending_nodes` + `http_ports` reserved in `prepare_*`; concurrent `OpenSession` / `AddNode` gets `ABORTED` / `ALREADY_EXISTS` |
+| Add resource while session dies | `commit_add_resource` re-checks session exists; returns `NOT_FOUND` if `CloseSession` won the race |
+| `NodeServer` destroyed while FFI uses it | `Arc<NodeServer>` in `*Prep` / `*Ffi` keeps the C++ object alive until `run_ffi` / `run()` completes |
+| Conflicting FFI on one Node | libnvnmos `model` lock serialises internally |
+
+### Accepted overlaps (documented outcomes, not bugs)
+
+These follow directly from releasing `state` around FFI: libnvnmos and the
+daemon maps can be briefly out of step. The daemon prefers a bounded,
+recoverable outcome over holding `state` across blocking C++ work (which
+reintroduces the deadlock).
+
+| Scenario | Outcome |
+|----------|---------|
+| `CloseSession` during `AddSender` / `AddReceiver` / `AddChannelMapping` FFI | libnvnmos accepted the add, but the session is gone before commit. Commit returns `NOT_FOUND`; the daemon does **not** attempt a compensating libnvnmos remove. The object is a **stray** in libnvnmos until the Node is destroyed. The client sees a failed add, not a hung daemon. |
+| Activation for a stray (or between add FFI and commit) | `dispatch_activation` / `dispatch_channelmapping_activation` find no daemon entry → NACK (`NoResource` / `NoChannelMapping`). The daemon does not remove the libnvnmos object on this path. |
+| Node create: server up, not yet committed | No session or resources in daemon maps yet; activations cannot route. A second create for the same seed is blocked by `pending_nodes`. |
+
+### Residual grey area
+
+**HTTP port reuse timing:** `close_session` removes the port from
+`http_ports` under `state`, but the OS socket may stay in `LISTEN` until
+`destroy_nmos_node_server` completes in `ffi.run()`. A concurrent create
+may succeed or fail depending on `is_tcp_port_bindable` and OS teardown
+timing. The deadlock fix allows destroy to finish (activation thread can take
+`state`); it does not formally prove instant port reuse.
+
+## Non-issues (checked)
+
+- **`watchdogs` vs `state`**: never nested in opposite orders.
+  `cancel_timeout` / insert take `watchdogs` alone; the GC task takes `state`
+  and `watchdogs` sequentially (`state` released first). No inversion.
+- **`dispatch_activation` → `tx.try_send`**: non-blocking under `state`.
+- **`complete_activation` → `ack_tx.send`**: capacity-1, single-use channel;
+  will not block.
+- **Log callback**: `log_bridge::forward` is lock-free. Close with no
+  activation in flight only fires log callbacks during `close().wait()`, so
+  thread-joins complete. The deadlock needs an **activation** callback (the
+  only callback that takes `state`) mid-flight.
+
+## Latency
+
+Holding `state` across `node_server->open().wait()`, `close().wait()`, or
+any FFI serialised every RPC behind one Node's blocking C++ work. The
+post-fix split removes that stall.
+
+Note: `AddSender` may still block on `model` while an in-band activation is
+parked on the ack — that is correct serialization, not a deadlock.
+
+## Trigger surface
+
+The dangerous callback is the **in-band** IS-05 / IS-08 activation processed
+by the activation threads — a controller (or smoke test) PATCH of `/staged`
+with an activation. The daemon's own `auto-activate` path uses
+`SyncResourceState` → `activate_connection`, which per the C contract does
+**not** invoke the activation callback (it updates `/active` directly); but
+it still takes `model.write_lock()`, so it remains an Order-B participant
+when FFI ran under `state` (pre-fix).
+
+## Regression coverage
+
+`rust/nvnmosd/tests/lock_ordering_regression.rs` drives an in-band IS-05
+activation (HTTP PATCH of `/staged` on the Node's port) so the activation
+thread is parked on the ack, then concurrently issues `AddSender` and
+`CloseSession` on the same Node. Post-fix:
+
+- both RPCs complete within the test budget (no hang);
+- `AddSender` may wait for the activation ack timeout while `model` is held
+  — expected;
+- `CloseSession` returns promptly and the HTTP port is released after close.
+
+Also run the full `nvnmosd` test suite under default parallelism and
+`--test-threads=1` (`http_port_release_repro`, `session_gc`, etc.).

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1332,6 +1332,7 @@ dependencies = [
  "libc",
  "nvnmos",
  "nvnmos-rpc",
+ "serde_json",
  "socket2 0.5.10",
  "tempfile",
  "tokio",

--- a/rust/nvnmosd/Cargo.toml
+++ b/rust/nvnmosd/Cargo.toml
@@ -40,8 +40,10 @@ libc = "0.2"
 [dev-dependencies]
 hyper-util = { workspace = true }
 nvnmos-rpc = { path = "../nvnmos-rpc" }
+serde_json.workspace = true
 tempfile = { workspace = true }
 tonic.workspace = true
 tokio = { workspace = true, features = ["time"] }
+tokio-stream.workspace = true
 tower.workspace = true
 

--- a/rust/nvnmosd/README.md
+++ b/rust/nvnmosd/README.md
@@ -11,8 +11,11 @@ Linux-first NMOS daemon: one process hosts multiple NMOS **Nodes** (by `node_see
 [`nvnmosd.proto`](../nvnmos-rpc/proto/nvnmosd.proto)).
 
 Architecture, element integration, and historical design rationale live in
-[`doc/designs/nvnmosd/README.md`](../../doc/designs/nvnmosd/README.md). This
-file describes the **as-built** daemon surface for operators and client authors.
+[`doc/designs/nvnmosd/README.md`](../../doc/designs/nvnmosd/README.md).
+Concurrency and the no-FFI-under-`state` invariant are documented in
+[`doc/designs/nvnmosd/lock-ordering.md`](../../doc/designs/nvnmosd/lock-ordering.md).
+This file describes the **as-built** daemon surface for operators and client
+authors.
 
 ## Build and Run
 

--- a/rust/nvnmosd/src/main.rs
+++ b/rust/nvnmosd/src/main.rs
@@ -35,7 +35,7 @@ use std::task::{Context as TaskContext, Poll};
 
 use anyhow::Context;
 use clap::Parser;
-use nvnmos::{Activation, ChannelMappingActivation, NodeServer};
+use nvnmos::{Activation, ChannelMappingActivation, Transport};
 use nvnmos_rpc::v1::nvnmos_daemon_server::{NvnmosDaemon, NvnmosDaemonServer};
 use nvnmos_rpc::v1::{
     AckActivationRequest, AckChannelMappingActivationRequest, ActivationEvent,
@@ -101,6 +101,112 @@ impl Daemon {
         // inconsistency that triggered the original panic.
         self.state.lock().expect("daemon state mutex poisoned")
     }
+
+    /// Second phase of node-creating RPCs (no `state` lock held): wire daemon
+    /// activation callbacks into [`CreateNodePrep::run_ffi`]. On failure,
+    /// abort the pending node ([`State::abort_pending_node`], a brief
+    /// lock). The caller commits via [`State::commit_open_session`] or
+    /// [`State::commit_add_node`].
+    fn run_ffi(&self, prep: state::CreateNodePrep) -> Result<state::CreateNodeReady, Status> {
+        let seed = prep.seed.clone();
+        let http_port = prep.http_port;
+        prep.run_ffi(
+            {
+                let state = self.state.clone();
+                let seed = seed.clone();
+                move |act| route_activation(&state, &seed, act)
+            },
+            {
+                let state = self.state.clone();
+                let seed = seed.clone();
+                move |act| route_channelmapping_activation(&state, &seed, act)
+            },
+        )
+        .inspect_err(|_| {
+            self.lock_state().abort_pending_node(&seed, http_port);
+        })
+    }
+
+    /// `AddNode` orchestration (persistent-Node analogue of
+    /// [`Daemon::add_resource`]): validate daemon bookkeeping under the
+    /// lock, build the [`nvnmos::NodeServer`] with no lock held, then
+    /// commit under the lock.
+    fn add_node(&self, config: nvnmos::NodeConfig) -> Result<state::AddNodeOutcome, Status> {
+        let prep = {
+            let mut state = self.lock_state();
+            state.prepare_add_node(config, &self.http_port_range)?
+        };
+        let ready = self.run_ffi(prep)?;
+        let mut state = self.lock_state();
+        Ok(state.commit_add_node(ready))
+    }
+
+    /// `OpenSession` orchestration (session-refcounted analogue of
+    /// [`Daemon::add_node`]): validate daemon bookkeeping under the lock
+    /// and either attach to an existing Node (no FFI) or, for a new Node,
+    /// build the [`nvnmos::NodeServer`] with no lock held and commit under
+    /// the lock.
+    fn open_session(&self, config: nvnmos::NodeConfig) -> Result<state::OpenOutcome, Status> {
+        // Bookkeeping under the lock; the blocking libnvnmos create (mDNS
+        // / bind / worker spawn) runs afterwards with no lock held.
+        let plan = {
+            let mut state = self.lock_state();
+            state.prepare_open_session(config, &self.http_port_range)?
+        };
+        match plan {
+            state::OpenSessionPlan::Attached(outcome) => Ok(outcome),
+            state::OpenSessionPlan::Create(prep) => {
+                let ready = self.run_ffi(prep)?;
+                Ok(self.lock_state().commit_open_session(ready))
+            }
+        }
+    }
+
+    /// Shared `AddSender` / `AddReceiver` orchestration: validate daemon
+    /// bookkeeping under the lock, run the libnvnmos add + name-match
+    /// lookup with no lock held, then commit under the lock.
+    fn add_resource(
+        &self,
+        side: Side,
+        session_handle: &str,
+        transport: Transport,
+        transport_file: &str,
+        claimed_name: &str,
+    ) -> Result<state::AddResourceOutcome, Status> {
+        let prep = {
+            let mut state = self.lock_state();
+            state.prepare_add_resource(
+                side,
+                session_handle,
+                transport,
+                transport_file,
+                claimed_name,
+            )?
+        };
+        let ready = prep.run_ffi()?;
+        let mut state = self.lock_state();
+        state.commit_add_resource(ready)
+    }
+
+    /// `AddChannelMapping` orchestration (IS-08 analogue of
+    /// [`Daemon::add_resource`]): validate daemon bookkeeping under the
+    /// lock, run the libnvnmos add with no lock held, then commit under
+    /// the lock.
+    fn add_channelmapping(
+        &self,
+        session_handle: &str,
+        name: &str,
+        inputs: &[nvnmos_rpc::v1::ChannelMappingInput],
+        outputs: &[nvnmos_rpc::v1::ChannelMappingOutput],
+    ) -> Result<state::AddChannelMappingOutcome, Status> {
+        let prep = {
+            let mut state = self.lock_state();
+            state.prepare_add_channelmapping(session_handle, name, inputs, outputs)?
+        };
+        let ready = prep.run_ffi()?;
+        let mut state = self.lock_state();
+        state.commit_add_channelmapping(ready)
+    }
 }
 
 #[tonic::async_trait]
@@ -112,15 +218,7 @@ impl NvnmosDaemon for Daemon {
         let req = request.into_inner();
         let config = state::translate_config(req.node_config.as_ref())?;
         let seed = config.seed.clone();
-        let state_for_callback = self.state.clone();
-        let seed_for_callback = seed.clone();
-        let http_port_range = self.http_port_range;
-        let outcome = {
-            let mut state = self.lock_state();
-            state.add_node(config, &http_port_range, |config| {
-                build_node_server(config, state_for_callback, seed_for_callback)
-            })?
-        };
+        let outcome = self.add_node(config)?;
         tracing::info!(
             node_seed = %seed,
             node_id = %outcome.node_id,
@@ -138,12 +236,16 @@ impl NvnmosDaemon for Daemon {
         request: Request<RemoveNodeRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
-        let outcome = {
+        let (outcome, ffi) = {
             let mut state = self.lock_state();
-            let outcome = state.remove_node(&req.node_seed)?;
-            malloc_trim::maybe_after_remove_node(&state, &req.node_seed);
-            outcome
+            state.remove_node(&req.node_seed)?
         };
+        // Drop the NodeServer (destroy + thread-join) outside the lock.
+        ffi.run();
+        {
+            let state = self.lock_state();
+            malloc_trim::maybe_after_remove_node(&state, &req.node_seed);
+        }
         tracing::info!(
             node_seed = %req.node_seed,
             node_id = %outcome.node_id,
@@ -162,20 +264,7 @@ impl NvnmosDaemon for Daemon {
         // (bad port), and there's no reason to hold the lock for it.
         let config = state::translate_config(req.node_config.as_ref())?;
         let seed = config.seed.clone();
-
-        // Hold the state lock only over the state update (and the
-        // libnvnmos create call inside it, which blocks on mDNS / bind /
-        // worker spawn). Acceptable while the daemon is single-client;
-        // revisit when multi-client throughput matters.
-        let state_for_callback = self.state.clone();
-        let seed_for_callback = seed.clone();
-        let http_port_range = self.http_port_range;
-        let outcome = {
-            let mut state = self.lock_state();
-            state.open_session(config, &http_port_range, |config| {
-                build_node_server(config, state_for_callback, seed_for_callback)
-            })?
-        };
+        let outcome = self.open_session(config)?;
         self.session_gc
             .start_subscribe_timeout(&outcome.session_handle);
 
@@ -202,12 +291,19 @@ impl NvnmosDaemon for Daemon {
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
         self.session_gc.cancel_timeout(&req.session_handle);
-        let outcome = {
+        let (outcome, ffi) = {
             let mut state = self.lock_state();
-            let outcome = state.close_session(&req.session_handle)?;
-            malloc_trim::maybe_after_close_session(&state, &outcome);
-            outcome
+            state.close_session(&req.session_handle)?
         };
+        // Remove the session's libnvnmos resources and (if this was the
+        // last session) destroy the NodeServer outside the lock, so a
+        // parked activation thread can take the lock and let the
+        // thread-joins in destroy return.
+        ffi.run();
+        {
+            let state = self.lock_state();
+            malloc_trim::maybe_after_close_session(&state, &outcome);
+        }
         tracing::info!(
             session_handle = %req.session_handle,
             node_seed = %outcome.node_seed,
@@ -226,15 +322,13 @@ impl NvnmosDaemon for Daemon {
     ) -> Result<Response<AddResourceResponse>, Status> {
         let req = request.into_inner();
         let transport = state::translate_transport(decode_proto_transport(req.transport)?)?;
-        let outcome = {
-            let mut state = self.lock_state();
-            state.add_sender(
-                &req.session_handle,
-                transport,
-                &req.transport_file,
-                &req.name,
-            )?
-        };
+        let outcome = self.add_resource(
+            Side::Sender,
+            &req.session_handle,
+            transport,
+            &req.transport_file,
+            &req.name,
+        )?;
         tracing::info!(
             session_handle = %req.session_handle,
             node_seed = %outcome.node_seed,
@@ -256,15 +350,13 @@ impl NvnmosDaemon for Daemon {
     ) -> Result<Response<AddResourceResponse>, Status> {
         let req = request.into_inner();
         let transport = state::translate_transport(decode_proto_transport(req.transport)?)?;
-        let outcome = {
-            let mut state = self.lock_state();
-            state.add_receiver(
-                &req.session_handle,
-                transport,
-                &req.transport_file,
-                &req.name,
-            )?
-        };
+        let outcome = self.add_resource(
+            Side::Receiver,
+            &req.session_handle,
+            transport,
+            &req.transport_file,
+            &req.name,
+        )?;
         tracing::info!(
             session_handle = %req.session_handle,
             node_seed = %outcome.node_seed,
@@ -285,12 +377,16 @@ impl NvnmosDaemon for Daemon {
         request: Request<RemoveResourceRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
-        let outcome = {
+        let (outcome, ffi) = {
             let mut state = self.lock_state();
-            let outcome = state.remove_resource(&req.session_handle, &req.resource_handle)?;
-            malloc_trim::maybe_after_remove_resource(&state, &outcome.node_seed);
-            outcome
+            state.remove_resource(&req.session_handle, &req.resource_handle)?
         };
+        // libnvnmos removal is best-effort and runs outside the lock.
+        ffi.run();
+        {
+            let state = self.lock_state();
+            malloc_trim::maybe_after_remove_resource(&state, &outcome.node_seed);
+        }
         tracing::info!(
             session_handle = %req.session_handle,
             resource_handle = %req.resource_handle,
@@ -358,7 +454,7 @@ impl NvnmosDaemon for Daemon {
         request: Request<SyncResourceStateRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
-        let outcome = {
+        let (outcome, ffi) = {
             let mut state = self.lock_state();
             state.sync_resource_state(
                 &req.session_handle,
@@ -366,6 +462,9 @@ impl NvnmosDaemon for Daemon {
                 req.transport_file.as_deref(),
             )?
         };
+        // The libnvnmos activate/deactivate runs outside the lock; its
+        // result is the RPC result.
+        ffi.run()?;
         tracing::info!(
             session_handle = %req.session_handle,
             resource_handle = %req.resource_handle,
@@ -383,10 +482,8 @@ impl NvnmosDaemon for Daemon {
         request: Request<AddChannelMappingRequest>,
     ) -> Result<Response<AddChannelMappingResponse>, Status> {
         let req = request.into_inner();
-        let outcome = {
-            let mut state = self.lock_state();
-            state.add_channelmapping(&req.session_handle, &req.name, &req.inputs, &req.outputs)?
-        };
+        let outcome =
+            self.add_channelmapping(&req.session_handle, &req.name, &req.inputs, &req.outputs)?;
         tracing::info!(
             session_handle = %req.session_handle,
             name = %req.name,
@@ -406,10 +503,12 @@ impl NvnmosDaemon for Daemon {
         request: Request<RemoveChannelMappingRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
-        let outcome = {
+        let (outcome, ffi) = {
             let mut state = self.lock_state();
             state.remove_channelmapping(&req.session_handle, &req.channelmapping_handle)?
         };
+        // libnvnmos removal is best-effort and runs outside the lock.
+        ffi.run();
         tracing::info!(
             session_handle = %req.session_handle,
             channelmapping_handle = %req.channelmapping_handle,
@@ -425,7 +524,7 @@ impl NvnmosDaemon for Daemon {
         request: Request<SyncChannelMappingStateRequest>,
     ) -> Result<Response<Empty>, Status> {
         let req = request.into_inner();
-        let outcome = {
+        let (outcome, ffi) = {
             let mut state = self.lock_state();
             state.sync_channelmapping_state(
                 &req.session_handle,
@@ -434,6 +533,8 @@ impl NvnmosDaemon for Daemon {
                 &req.active_map,
             )?
         };
+        // The libnvnmos IS-08 activate runs outside the lock.
+        ffi.run()?;
         tracing::info!(
             session_handle = %req.session_handle,
             channelmapping_handle = %req.channelmapping_handle,
@@ -569,32 +670,6 @@ fn decode_proto_transport(raw: i32) -> Result<ProtoTransport, Status> {
     ProtoTransport::try_from(raw).map_err(|_| {
         Status::invalid_argument(format!("unknown Transport value on the wire: {raw}"))
     })
-}
-
-/// Construct the daemon's standard [`NodeServer`]: wraps the wrapper's
-/// builder with the daemon's log bridge and the activation router so
-/// that libnvnmos's IS-05 callbacks are bridged into the right session's
-/// `SubscribeActivations` stream.
-///
-/// Takes the `Arc<Mutex<State>>` and `node_seed` by value because both
-/// have to be captured by the `'static` activation closure. The caller
-/// is expected to `clone()` from the daemon's own state and to forward
-/// the request's `node_seed`.
-fn build_node_server(
-    config: &nvnmos::NodeConfig,
-    state: Arc<Mutex<State>>,
-    node_seed: String,
-) -> Result<NodeServer, Status> {
-    let cm_state = state.clone();
-    let cm_node_seed = node_seed.clone();
-    NodeServer::builder(config)
-        .on_log(log_bridge::forward)
-        .on_activation(move |act| route_activation(&state, &node_seed, act))
-        .on_channelmapping_activation(move |act| {
-            route_channelmapping_activation(&cm_state, &cm_node_seed, act)
-        })
-        .build()
-        .map_err(|e| Status::internal(format!("create_nmos_node_server failed: {e}")))
 }
 
 /// Bridge a single libnvnmos activation callback into the daemon's

--- a/rust/nvnmosd/src/session_gc.rs
+++ b/rust/nvnmosd/src/session_gc.rs
@@ -106,7 +106,7 @@ impl SessionGc {
         let watchdogs = self.watchdogs.clone();
         let join = tokio::spawn(async move {
             tokio::time::sleep(timeout).await;
-            let outcome = {
+            let (outcome, ffi) = {
                 let mut guard = state.lock().expect("daemon state mutex poisoned");
                 if !guard.sessions_contains(&handle) {
                     return;
@@ -114,13 +114,19 @@ impl SessionGc {
                 if guard.has_any_activation_subscription(&handle) {
                     return;
                 }
-                let outcome = match guard.close_session(&handle) {
-                    Ok(outcome) => outcome,
+                match guard.close_session(&handle) {
+                    Ok(outcome_ffi) => outcome_ffi,
                     Err(_) => return,
-                };
-                malloc_trim::maybe_after_close_session(&guard, &outcome);
-                outcome
+                }
             };
+            // Run the libnvnmos removals / NodeServer destroy outside the
+            // lock so a parked activation thread can take `state` and let
+            // the destroy thread-joins return.
+            ffi.run();
+            {
+                let guard = state.lock().expect("daemon state mutex poisoned");
+                malloc_trim::maybe_after_close_session(&guard, &outcome);
+            }
             tracing::info!(
                 session_handle = %handle,
                 node_seed = %outcome.node_seed,

--- a/rust/nvnmosd/src/state.rs
+++ b/rust/nvnmosd/src/state.rs
@@ -4,8 +4,8 @@
 //! Daemon-wide state: Nodes, sessions, resources, and the operations
 //! that mutate them.
 //!
-//! Shape (formalised in the design doc, "Daemon internal state"
-//! section of `doc/designs/nvnmosd/README.md`):
+//! **Shape:** (formalised in the design doc, "Daemon internal state"
+//! section of `doc/designs/nvnmosd/README.md`)
 //!
 //! * **Nodes** are keyed by `node_seed`. The daemon holds at most one
 //!   [`nvnmos::NodeServer`] per seed; multiple sessions may attach to the
@@ -42,16 +42,22 @@
 //!   [`State::add_node`]. Survive every [`State::close_session`]; only
 //!   [`State::remove_node`] tears them down, and only when no sessions
 //!   are currently attached.
+//!
+//! **Locking:** no libnvnmos FFI while `state` is held. Mutations use
+//! prepare / deferred `*Ffi` or `*Prep::run_ffi` / commit phases; see
+//! `doc/designs/nvnmosd/lock-ordering.md`.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::time::Duration;
 
 use nvnmos::{
-    AssetConfig, ChannelMappingActiveMapEntry, ChannelMappingConfig, ChannelMappingInput,
-    ChannelMappingOutput, ChannelMappingParentType, NetworkServicesConfig, NodeConfig, NodeServer,
-    ReceiverConfig, SenderConfig, Side as WrapperSide, Transport,
+    Activation, AssetConfig, ChannelMappingActivation, ChannelMappingActiveMapEntry,
+    ChannelMappingConfig, ChannelMappingInput, ChannelMappingOutput, ChannelMappingParentType,
+    NetworkServicesConfig, NodeConfig, NodeServer, ReceiverConfig, SenderConfig,
+    Side as WrapperSide, Transport,
 };
 use nvnmos_rpc::v1::{
     ActivationEvent, ActiveMapEntry as ProtoActiveMapEntry, AssetConfig as ProtoAssetConfig,
@@ -219,12 +225,11 @@ struct ResourceEntry {
 
 /// A live Node owned by the daemon.
 struct NodeEntry {
-    /// The C node server itself. Dropped when the entry is removed,
-    /// which calls `destroy_nmos_node_server` via the wrapper's `Drop`.
-    /// `#[allow(dead_code)]` because the field is held purely for its
-    /// `Drop` side effect — Rust can't see the FFI-level usage.
-    #[allow(dead_code)]
-    server: NodeServer,
+    /// The C node server itself, behind an [`Arc`] so an RPC handler can
+    /// clone a reference, drop the `state` lock, and then run libnvnmos
+    /// FFI (or the `Drop` that calls `destroy_nmos_node_server`) with no
+    /// daemon lock held. Dropping the last clone tears down the server.
+    server: Arc<NodeServer>,
     /// NMOS `/self` UUID cached at create time so RPC handlers that hold
     /// the state lock don't drop back into FFI for every read. Stable for
     /// the lifetime of the entry — libnvnmos derives it from the seed.
@@ -408,6 +413,9 @@ pub enum ChannelMappingActivationDispatch {
         activation_handle: String,
         ack_rx: std_mpsc::Receiver<AckOutcome>,
     },
+    /// No channel mapping entry exists for `(node_seed, output_id)` —
+    /// stray or not yet committed. The router NACKs; it does not remove
+    /// the libnvnmos mapping.
     NoChannelMapping,
     NoSubscriber,
     SubscriberBusy,
@@ -425,10 +433,10 @@ pub enum ActivationDispatch {
         activation_handle: String,
         ack_rx: std_mpsc::Receiver<AckOutcome>,
     },
-    /// No resource is created for `(node_seed, name)`. Either
-    /// the activation is for a stray (a resource that survived the
-    /// `AddSender`/`AddReceiver` mismatch path) or for one that was
-    /// removed between the IS-05 PATCH arriving and the callback firing.
+    /// No resource entry exists for `(node_seed, side, name)` — either a
+    /// stray (libnvnmos object with no daemon map entry) or a resource
+    /// removed between the IS-05 PATCH and the callback. The router NACKs;
+    /// it does not remove the libnvnmos object.
     NoResource,
     /// The owning session has no `SubscribeActivations` stream attached.
     /// (Either the client never subscribed or its earlier stream was
@@ -440,9 +448,371 @@ pub enum ActivationDispatch {
     SubscriberBusy,
 }
 
+/// Deferred libnvnmos work returned by a `State::*` bookkeeping phase so
+/// the RPC handler can run it **after** dropping the `state` lock.
+///
+/// Every FFI call takes libnvnmos's internal `model` lock, and the
+/// in-band activation callback path takes `model` then `state`; running
+/// FFI while `state` is held would be an AB-BA deadlock. These `*Ffi` /
+/// `*Prep` types are the seam that keeps FFI off the locked path.
+///
+/// This one drops a session's resources (and, when the Node is being
+/// destroyed, the last [`NodeServer`] reference) with no daemon lock
+/// held, so a parked activation thread can take `state`, finish, and let
+/// `destroy_nmos_node_server`'s thread-joins return.
+#[must_use = "close_session FFI must run outside the state lock"]
+pub struct CloseSessionFfi {
+    server: Arc<NodeServer>,
+    resource_removals: Vec<(Side, String)>,
+    channelmapping_removals: Vec<String>,
+    session_handle: String,
+}
+
+impl CloseSessionFfi {
+    pub fn run(self) {
+        for (side, name) in &self.resource_removals {
+            if let Err(e) = side.remove_from_server(&self.server, name) {
+                tracing::warn!(
+                    session_handle = %self.session_handle,
+                    side = side.label(),
+                    name = %name,
+                    error = %e,
+                    "close_session: libnvnmos remove_sender/remove_receiver failed; \
+                     continuing"
+                );
+            }
+        }
+        for name in &self.channelmapping_removals {
+            if let Err(e) = self.server.remove_channelmapping(name) {
+                tracing::warn!(
+                    session_handle = %self.session_handle,
+                    name = %name,
+                    error = %e,
+                    "close_session: libnvnmos remove_channelmapping failed; continuing"
+                );
+            }
+        }
+        // Dropping the last reference runs `destroy_nmos_node_server`
+        // (shutdown + thread-join + listener close) here, outside the
+        // lock. If the entry was retained (sessions remain), this is not
+        // the last reference and only decrements the count.
+        drop(self.server);
+    }
+}
+
+/// Drops the last [`NodeServer`] reference for a torn-down persistent
+/// Node outside the `state` lock. See [`CloseSessionFfi`].
+#[must_use = "remove_node FFI must run outside the state lock"]
+pub struct RemoveNodeFfi {
+    server: Arc<NodeServer>,
+}
+
+impl RemoveNodeFfi {
+    pub fn run(self) {
+        drop(self.server);
+    }
+}
+
+/// Best-effort libnvnmos removal of one resource, run after the daemon
+/// bookkeeping is already consistent. See [`CloseSessionFfi`].
+#[must_use = "remove_resource FFI must run outside the state lock"]
+pub struct RemoveResourceFfi {
+    /// `None` when the Node had already gone (nothing to remove).
+    server: Option<Arc<NodeServer>>,
+    side: Side,
+    name: String,
+}
+
+impl RemoveResourceFfi {
+    pub fn run(self) {
+        let Some(server) = self.server else { return };
+        if let Err(e) = self.side.remove_from_server(&server, &self.name) {
+            tracing::warn!(
+                side = self.side.label(),
+                name = %self.name,
+                error = %e,
+                "remove_resource: libnvnmos remove_sender/remove_receiver failed; \
+                 daemon state already cleared"
+            );
+        }
+    }
+}
+
+/// Pushes a resource (re)activation / deactivation into libnvnmos. Runs
+/// after the `state` lock is dropped; its result is the RPC result. See
+/// [`CloseSessionFfi`].
+#[must_use = "sync_resource_state FFI must run outside the state lock"]
+pub struct SyncResourceFfi {
+    server: Arc<NodeServer>,
+    side: Side,
+    name: String,
+    transport_file: Option<String>,
+}
+
+impl SyncResourceFfi {
+    pub fn run(self) -> Result<(), Status> {
+        self.server
+            .activate_connection(
+                self.side.to_wrapper(),
+                &self.name,
+                self.transport_file.as_deref(),
+            )
+            .map_err(|e| {
+                let verb = if self.transport_file.is_some() {
+                    "activate"
+                } else {
+                    "deactivate"
+                };
+                Status::invalid_argument(format!(
+                    "libnvnmos {verb} for {} {:?} failed (transport_file \
+                     parse error or libnvnmos state mismatch): {e}",
+                    self.side.label(),
+                    self.name,
+                ))
+            })
+    }
+}
+
+/// First phase of `AddSender` / `AddReceiver`: daemon bookkeeping is
+/// validated under `state`, then the lock is dropped and
+/// [`AddResourcePrep::run_ffi`] performs the libnvnmos add + name-match
+/// lookup with no lock held. [`State::commit_add_resource`] finishes the
+/// bookkeeping. See [`CloseSessionFfi`].
+#[must_use = "add_resource must proceed through run_ffi + commit_add_resource"]
+pub struct AddResourcePrep {
+    server: Arc<NodeServer>,
+    side: Side,
+    transport: Transport,
+    transport_file: String,
+    name: String,
+    node_seed: String,
+    session_handle: String,
+}
+
+/// Output of [`AddResourcePrep::run_ffi`], fed to
+/// [`State::commit_add_resource`].
+pub struct AddResourceReady {
+    side: Side,
+    name: String,
+    node_seed: String,
+    session_handle: String,
+    resource_id: String,
+}
+
+impl AddResourcePrep {
+    pub fn run_ffi(self) -> Result<AddResourceReady, Status> {
+        self.side
+            .add_to_server(&self.server, self.transport, &self.transport_file)
+            .map_err(|e| {
+                Status::invalid_argument(format!(
+                    "libnvnmos add_{} failed (transport_file parse error or \
+                     duplicate): {e}",
+                    self.side.label(),
+                ))
+            })?;
+
+        let resource_id = match self.side.lookup_id(&self.server, &self.name) {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                tracing::error!(
+                    side = self.side.label(),
+                    claimed_name = %self.name,
+                    node_seed = %self.node_seed,
+                    "AddSender/AddReceiver: libnvnmos accepted the transport \
+                     file but its embedded name does not match the claimed \
+                     name; left as a stray until the Node is destroyed"
+                );
+                return Err(Status::invalid_argument(format!(
+                    "{}'s transport_file embeds a different name than {:?}",
+                    self.side.label(),
+                    self.name,
+                )));
+            }
+            Err(e) => {
+                return Err(Status::internal(format!(
+                    "querying {} id from libnvnmos failed after add: {e}",
+                    self.side.label(),
+                )));
+            }
+        };
+
+        Ok(AddResourceReady {
+            side: self.side,
+            name: self.name,
+            node_seed: self.node_seed,
+            session_handle: self.session_handle,
+            resource_id,
+        })
+    }
+}
+
+/// Best-effort libnvnmos removal of one channel mapping. See
+/// [`CloseSessionFfi`].
+#[must_use = "remove_channelmapping FFI must run outside the state lock"]
+pub struct RemoveChannelMappingFfi {
+    server: Option<Arc<NodeServer>>,
+    name: String,
+}
+
+impl RemoveChannelMappingFfi {
+    pub fn run(self) {
+        let Some(server) = self.server else { return };
+        if let Err(e) = server.remove_channelmapping(&self.name) {
+            tracing::warn!(
+                name = %self.name,
+                error = %e,
+                "remove_channelmapping: libnvnmos remove failed; daemon state already cleared"
+            );
+        }
+    }
+}
+
+/// Pushes an IS-08 activation into libnvnmos. See [`SyncResourceFfi`].
+#[must_use = "sync_channelmapping_state FFI must run outside the state lock"]
+pub struct SyncChannelMappingFfi {
+    server: Arc<NodeServer>,
+    name: String,
+    output_id: String,
+    active_map: Vec<ChannelMappingActiveMapEntry>,
+}
+
+impl SyncChannelMappingFfi {
+    pub fn run(self) -> Result<(), Status> {
+        self.server
+            .activate_channelmapping(&self.name, &self.output_id, &self.active_map)
+            .map_err(|e| {
+                Status::invalid_argument(format!(
+                    "libnvnmos nmos_channelmapping_activate failed: {e}"
+                ))
+            })
+    }
+}
+
+/// First phase of `AddChannelMapping` (parallel to [`AddResourcePrep`]).
+#[must_use = "add_channelmapping must proceed through run_ffi + commit_add_channelmapping"]
+pub struct AddChannelMappingPrep {
+    server: Arc<NodeServer>,
+    name: String,
+    mapping: ChannelMappingConfig,
+    node_seed: String,
+    session_handle: String,
+    effective_input_ids: Vec<String>,
+    effective_output_ids: Vec<String>,
+}
+
+/// Output of [`AddChannelMappingPrep::run_ffi`], fed to
+/// [`State::commit_add_channelmapping`].
+pub struct AddChannelMappingReady {
+    name: String,
+    node_seed: String,
+    session_handle: String,
+    effective_input_ids: Vec<String>,
+    effective_output_ids: Vec<String>,
+}
+
+impl AddChannelMappingPrep {
+    pub fn run_ffi(self) -> Result<AddChannelMappingReady, Status> {
+        self.server
+            .add_channelmapping(&self.name, &self.mapping)
+            .map_err(|e| {
+                Status::invalid_argument(format!(
+                    "libnvnmos add_channelmapping failed (duplicate or invalid geometry): {e}"
+                ))
+            })?;
+        Ok(AddChannelMappingReady {
+            name: self.name,
+            node_seed: self.node_seed,
+            session_handle: self.session_handle,
+            effective_input_ids: self.effective_input_ids,
+            effective_output_ids: self.effective_output_ids,
+        })
+    }
+}
+
+/// First phase of `OpenSession(Create)` / `AddNode`: a pending node whose
+/// port and seed are recorded in daemon state. The caller must
+/// [`CreateNodePrep::run_ffi`] outside the `state` lock (supplying
+/// daemon-specific activation callbacks), then
+/// [`State::commit_open_session`] / [`State::commit_add_node`] (or
+/// [`State::abort_pending_node`] on build failure).
+#[must_use = "node create must proceed through run_ffi + commit_*"]
+pub struct CreateNodePrep {
+    pub seed: String,
+    pub config: Box<NodeConfig>,
+    pub http_port: u16,
+}
+
+/// Output of [`CreateNodePrep::run_ffi`], fed to
+/// [`State::commit_open_session`] or [`State::commit_add_node`].
+pub struct CreateNodeReady {
+    pub seed: String,
+    pub http_port: u16,
+    pub server: Arc<NodeServer>,
+    pub node_id: String,
+}
+
+impl CreateNodePrep {
+    /// Second phase of `OpenSession(Create)` / `AddNode`: build a
+    /// [`NodeServer`] via `create_nmos_node_server` with no `state` lock
+    /// held, then query its `node_id`. Activation callbacks are supplied
+    /// by the daemon because they route into
+    /// [`State::dispatch_activation`].
+    pub fn run_ffi<A, C>(
+        self,
+        on_activation: A,
+        on_channelmapping_activation: C,
+    ) -> Result<CreateNodeReady, Status>
+    where
+        A: Fn(&Activation<'_>) -> std::result::Result<(), String> + Send + Sync + 'static,
+        C: Fn(&ChannelMappingActivation<'_>) -> std::result::Result<(), String>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let server = NodeServer::builder(self.config.as_ref())
+            .on_log(log_bridge::forward)
+            .on_activation(on_activation)
+            .on_channelmapping_activation(on_channelmapping_activation)
+            .build()
+            .map_err(|e| Status::internal(format!("create_nmos_node_server failed: {e}")))?;
+
+        let node_id = server.node_id().map_err(|e| {
+            Status::internal(format!(
+                "querying node_id from the new NodeServer failed: {e}"
+            ))
+        })?;
+
+        Ok(CreateNodeReady {
+            seed: self.seed,
+            http_port: self.http_port,
+            server: Arc::new(server),
+            node_id,
+        })
+    }
+}
+
+/// Result of [`State::prepare_open_session`].
+pub enum OpenSessionPlan {
+    /// A Node already existed for the seed; the session was allocated and
+    /// attached entirely under `state`. No FFI needed.
+    Attached(OpenOutcome),
+    /// No Node existed: a pending node now owns the HTTP port and seed.
+    /// The handler must [`CreateNodePrep::run_ffi`] outside the `state`
+    /// lock, then call [`State::commit_open_session`] (or
+    /// [`State::abort_pending_node`] on failure).
+    Create(CreateNodePrep),
+}
+
 /// All daemon state. Wrapped in `Arc<Mutex<…>>` by the gRPC service.
 pub struct State {
     nodes: HashMap<String, NodeEntry>,
+    /// Seeds of pending nodes: nodes prepared but not yet committed. The
+    /// port is already in [`State::http_ports`] and the seed is here, but
+    /// the [`NodeEntry`] is not yet in [`State::nodes`] — its
+    /// [`NodeServer`] is being built outside the `state` lock. Guards
+    /// against a second concurrent create for the same seed while the
+    /// first is still pending.
+    pending_nodes: HashSet<String>,
     sessions: HashMap<String, SessionEntry>,
     /// Live resources keyed by daemon-allocated `resource_handle`.
     resources: HashMap<String, ResourceEntry>,
@@ -477,6 +847,7 @@ impl State {
     pub fn new() -> Self {
         Self {
             nodes: HashMap::new(),
+            pending_nodes: HashSet::new(),
             sessions: HashMap::new(),
             resources: HashMap::new(),
             by_name: HashMap::new(),
@@ -496,88 +867,133 @@ impl State {
         }
     }
 
-    /// Open a session, attaching to or creating a Node for `seed`.
+    /// First phase of `OpenSession`: attach to an existing Node or record
+    /// a new pending node for `seed`.
     ///
     /// If a Node already exists for `seed` (either [`Lifetime::Persistent`]
-    /// or [`Lifetime::SessionRefcounted`]), this attaches to it and
-    /// increments its session count; `build_node_server` is *not* invoked
-    /// and any `node_config` the caller supplied is ignored. If no Node
-    /// exists, this constructs a new [`Lifetime::SessionRefcounted`] Node
-    /// via `build_node_server`.
+    /// or [`Lifetime::SessionRefcounted`]), this attaches to it,
+    /// increments its session count, allocates the session, and returns
+    /// [`OpenSessionPlan::Attached`] — no FFI needed, so there is no
+    /// commit phase. If no Node exists, this records a pending node (its
+    /// HTTP port and seed) and returns [`OpenSessionPlan::Create`]; the
+    /// caller must [`CreateNodePrep::run_ffi`] outside the `state` lock
+    /// and then call
+    /// [`State::commit_open_session`] (or [`State::abort_pending_node`]
+    /// on build failure).
     ///
     /// Errors:
     /// * `INVALID_ARGUMENT` if `seed` is empty (the empty seed would
     ///   collapse every "default" session onto the same Node and lose
     ///   determinism of the NMOS UUIDs).
-    /// * Whatever `build_node_server` returns, surfaced verbatim.
-    pub fn open_session(
+    /// * `ABORTED` if a create for the same seed is already pending.
+    /// * Whatever [`State::resolve_http_port`] returns.
+    pub fn prepare_open_session(
         &mut self,
         mut config: NodeConfig,
         port_range: &PortRange,
-        build_node_server: impl FnOnce(&NodeConfig) -> Result<NodeServer, Status>,
-    ) -> Result<OpenOutcome, Status> {
+    ) -> Result<OpenSessionPlan, Status> {
         let seed = config.seed.clone();
         require_non_empty_seed(&seed)?;
 
-        let (created_node, node_id, lifetime, http_port) = match self.nodes.get_mut(&seed) {
-            Some(entry) => {
-                entry.attached_sessions += 1;
-                (
-                    false,
-                    entry.node_id.clone(),
-                    entry.lifetime,
-                    entry.http_port,
-                )
-            }
-            None => {
-                let http_port = self.resolve_http_port(config.http_port, port_range)?;
-                config.http_port = http_port;
-                let server = build_node_server(&config)?;
-                let node_id = server.node_id().map_err(|e| {
-                    Status::internal(format!(
-                        "querying node_id from the new NodeServer failed: {e}"
-                    ))
-                })?;
-                self.http_ports.insert(http_port, seed.clone());
-                self.nodes.insert(
-                    seed.clone(),
-                    NodeEntry {
-                        server,
-                        node_id: node_id.clone(),
-                        lifetime: Lifetime::SessionRefcounted,
-                        attached_sessions: 1,
-                        http_port,
-                    },
-                );
-                (true, node_id, Lifetime::SessionRefcounted, http_port)
-            }
-        };
+        if let Some(entry) = self.nodes.get_mut(&seed) {
+            entry.attached_sessions += 1;
+            let node_id = entry.node_id.clone();
+            let lifetime = entry.lifetime;
+            let http_port = entry.http_port;
+            let session_handle = self.allocate_session_handle();
+            self.sessions.insert(
+                session_handle.clone(),
+                SessionEntry {
+                    node_seed: seed,
+                    resources: HashSet::new(),
+                    channelmappings: HashSet::new(),
+                },
+            );
+            return Ok(OpenSessionPlan::Attached(OpenOutcome {
+                session_handle,
+                node_id,
+                lifetime,
+                created_node: false,
+                http_port,
+            }));
+        }
 
+        if self.pending_nodes.contains(&seed) {
+            return Err(Status::aborted(format!(
+                "a Node for seed {seed:?} is already being created; retry"
+            )));
+        }
+
+        let http_port = self.resolve_http_port(config.http_port, port_range)?;
+        config.http_port = http_port;
+        self.http_ports.insert(http_port, seed.clone());
+        self.pending_nodes.insert(seed.clone());
+        Ok(OpenSessionPlan::Create(CreateNodePrep {
+            seed,
+            config: Box::new(config),
+            http_port,
+        }))
+    }
+
+    /// Third phase of `OpenSession`: commit the pending node built for
+    /// [`OpenSessionPlan::Create`] into a live [`NodeEntry`], and allocate
+    /// the first session attached to it.
+    pub fn commit_open_session(&mut self, ready: CreateNodeReady) -> OpenOutcome {
+        self.pending_nodes.remove(&ready.seed);
+        self.nodes.insert(
+            ready.seed.clone(),
+            NodeEntry {
+                server: ready.server,
+                node_id: ready.node_id.clone(),
+                lifetime: Lifetime::SessionRefcounted,
+                attached_sessions: 1,
+                http_port: ready.http_port,
+            },
+        );
         let session_handle = self.allocate_session_handle();
         self.sessions.insert(
             session_handle.clone(),
             SessionEntry {
-                node_seed: seed,
+                node_seed: ready.seed,
                 resources: HashSet::new(),
                 channelmappings: HashSet::new(),
             },
         );
-        Ok(OpenOutcome {
+        OpenOutcome {
             session_handle,
-            node_id,
-            lifetime,
-            created_node,
-            http_port,
-        })
+            node_id: ready.node_id,
+            lifetime: Lifetime::SessionRefcounted,
+            created_node: true,
+            http_port: ready.http_port,
+        }
     }
 
-    /// Close a session, detaching from the backing Node. Drops every
-    /// resource the session contributed (through libnvnmos) before
-    /// detaching, so a subsequent destroy of the Node never has to
-    /// reckon with stale resources. For [`Lifetime::SessionRefcounted`]
-    /// Nodes, also destroys the Node when the last session detaches.
-    /// [`Lifetime::Persistent`] Nodes are never destroyed by this call.
-    pub fn close_session(&mut self, session_handle: &str) -> Result<CloseOutcome, Status> {
+    /// Abort a pending node ([`OpenSessionPlan::Create`] / [`CreateNodePrep`])
+    /// when the FFI build failed: its seed and its port are removed.
+    pub fn abort_pending_node(&mut self, seed: &str, http_port: u16) {
+        self.pending_nodes.remove(seed);
+        if self.http_ports.get(&http_port).is_some_and(|s| s == seed) {
+            self.http_ports.remove(&http_port);
+        }
+    }
+
+    /// Close a session, detaching from the backing Node.
+    ///
+    /// All daemon bookkeeping (removing the session, its resources and
+    /// channel mappings, its subscriptions, and aborting its in-flight
+    /// activations) happens under the `state` lock. The libnvnmos work —
+    /// removing each resource / channel mapping and, when this was the
+    /// last session on a [`Lifetime::SessionRefcounted`] Node, destroying
+    /// the [`NodeServer`] — is deferred to the returned [`CloseSessionFfi`]
+    /// so it runs with no daemon lock held. That is what lets a parked
+    /// activation thread take `state`, finish, and let
+    /// `destroy_nmos_node_server`'s thread-joins return (otherwise the
+    /// HTTP listener is stranded in `LISTEN`). [`Lifetime::Persistent`]
+    /// Nodes are never destroyed by this call.
+    pub fn close_session(
+        &mut self,
+        session_handle: &str,
+    ) -> Result<(CloseOutcome, CloseSessionFfi), Status> {
         let session = self.sessions.remove(session_handle).ok_or_else(|| {
             Status::not_found(format!(
                 "session_handle {session_handle:?} is not known to this daemon"
@@ -610,17 +1026,22 @@ impl State {
         }
 
         let seed = session.node_seed;
-        let node = self.nodes.get(&seed).ok_or_else(|| {
-            Status::internal(format!(
-                "session {session_handle:?} referenced seed {seed:?} but no Node entry exists"
-            ))
-        })?;
+        let server = self
+            .nodes
+            .get(&seed)
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "session {session_handle:?} referenced seed {seed:?} but no Node entry exists"
+                ))
+            })?
+            .server
+            .clone();
 
-        // Drop the session's resources via libnvnmos before we touch the
-        // Node's lifetime. Errors are logged but not fatal — the session
-        // is going away regardless, and leaking a libnvnmos resource is
-        // less bad than refusing to close. Resources are dropped from
-        // daemon state whether or not libnvnmos's removal succeeded.
+        // Clear the session's resources from daemon state and collect the
+        // libnvnmos removals to run after the lock is dropped. Resources
+        // are dropped from daemon state regardless of the deferred FFI
+        // outcome — the session is going away.
+        let mut resource_removals: Vec<(Side, String)> = Vec::new();
         for resource_handle in session.resources {
             let Some(resource) = self.resources.remove(&resource_handle) else {
                 tracing::warn!(
@@ -635,22 +1056,10 @@ impl State {
                 resource.side,
                 resource.name.clone(),
             ));
-            if let Err(e) = resource
-                .side
-                .remove_from_server(&node.server, &resource.name)
-            {
-                tracing::warn!(
-                    %resource_handle,
-                    session_handle,
-                    side = resource.side.label(),
-                    name = %resource.name,
-                    error = %e,
-                    "close_session: libnvnmos remove_sender/remove_receiver failed; \
-                     continuing"
-                );
-            }
+            resource_removals.push((resource.side, resource.name));
         }
 
+        let mut channelmapping_removals: Vec<String> = Vec::new();
         for channelmapping_handle in session.channelmappings {
             if let Some(entry) = self.channelmappings.remove(&channelmapping_handle) {
                 self.channelmappings_by_name
@@ -659,15 +1068,7 @@ impl State {
                     self.outputs_by_id
                         .remove(&(entry.node_seed.clone(), output_id.clone()));
                 }
-                if let Err(e) = node.server.remove_channelmapping(&entry.name) {
-                    tracing::warn!(
-                        %channelmapping_handle,
-                        session_handle,
-                        name = %entry.name,
-                        error = %e,
-                        "close_session: libnvnmos remove_channelmapping failed; continuing"
-                    );
-                }
+                channelmapping_removals.push(entry.name);
             }
         }
 
@@ -695,13 +1096,20 @@ impl State {
             self.http_ports.remove(&entry.http_port);
             self.nodes.remove(&seed);
         }
-        Ok(CloseOutcome {
+        let outcome = CloseOutcome {
             node_seed: seed,
             node_id,
             lifetime,
             remaining_sessions,
             node_destroyed,
-        })
+        };
+        let ffi = CloseSessionFfi {
+            server,
+            resource_removals,
+            channelmapping_removals,
+            session_handle: session_handle.to_string(),
+        };
+        Ok((outcome, ffi))
     }
 
     /// Count live senders/receivers created on `node_seed`.
@@ -712,19 +1120,23 @@ impl State {
             .count()
     }
 
-    /// Create a persistent Node for `seed`.
+    /// First phase of `AddNode`: record a pending node (its HTTP port and
+    /// seed) for a persistent Node and return a [`CreateNodePrep`]. The
+    /// caller must [`CreateNodePrep::run_ffi`] outside the `state` lock
+    /// and then call
+    /// [`State::commit_add_node`] (or [`State::abort_pending_node`] on
+    /// build failure).
     ///
     /// Errors:
     /// * `INVALID_ARGUMENT` if `seed` is empty.
     /// * `ALREADY_EXISTS` if any Node (persistent or session-refcounted)
-    ///   currently exists for `seed`.
-    /// * Whatever `build_node_server` returns, surfaced verbatim.
-    pub fn add_node(
+    ///   currently exists for `seed`, or a create for it is already pending.
+    /// * Whatever [`State::resolve_http_port`] returns.
+    pub fn prepare_add_node(
         &mut self,
         mut config: NodeConfig,
         port_range: &PortRange,
-        build_node_server: impl FnOnce(&NodeConfig) -> Result<NodeServer, Status>,
-    ) -> Result<AddNodeOutcome, Status> {
+    ) -> Result<CreateNodePrep, Status> {
         let seed = config.seed.clone();
         require_non_empty_seed(&seed)?;
         if let Some(entry) = self.nodes.get(&seed) {
@@ -733,26 +1145,40 @@ impl State {
                 entry.lifetime.label(),
             )));
         }
+        if self.pending_nodes.contains(&seed) {
+            return Err(Status::already_exists(format!(
+                "a Node for seed {seed:?} is already being created"
+            )));
+        }
         let http_port = self.resolve_http_port(config.http_port, port_range)?;
         config.http_port = http_port;
-        let server = build_node_server(&config)?;
-        let node_id = server.node_id().map_err(|e| {
-            Status::internal(format!(
-                "querying node_id from the new NodeServer failed: {e}"
-            ))
-        })?;
         self.http_ports.insert(http_port, seed.clone());
-        self.nodes.insert(
+        self.pending_nodes.insert(seed.clone());
+        Ok(CreateNodePrep {
             seed,
+            config: Box::new(config),
+            http_port,
+        })
+    }
+
+    /// Third phase of `AddNode`: commit the pending node built for a
+    /// [`CreateNodePrep`] into a live persistent [`NodeEntry`].
+    pub fn commit_add_node(&mut self, ready: CreateNodeReady) -> AddNodeOutcome {
+        self.pending_nodes.remove(&ready.seed);
+        self.nodes.insert(
+            ready.seed,
             NodeEntry {
-                server,
-                node_id: node_id.clone(),
+                server: ready.server,
+                node_id: ready.node_id.clone(),
                 lifetime: Lifetime::Persistent,
                 attached_sessions: 0,
-                http_port,
+                http_port: ready.http_port,
             },
         );
-        Ok(AddNodeOutcome { node_id, http_port })
+        AddNodeOutcome {
+            node_id: ready.node_id,
+            http_port: ready.http_port,
+        }
     }
 
     /// Tear down a persistent Node.
@@ -763,7 +1189,10 @@ impl State {
     /// * `FAILED_PRECONDITION` if the Node is [`Lifetime::SessionRefcounted`]
     ///   (the caller must close sessions instead) or if any sessions are
     ///   currently attached (the caller must close them first).
-    pub fn remove_node(&mut self, seed: &str) -> Result<RemoveNodeOutcome, Status> {
+    pub fn remove_node(
+        &mut self,
+        seed: &str,
+    ) -> Result<(RemoveNodeOutcome, RemoveNodeFfi), Status> {
         require_non_empty_seed(seed)?;
         let entry = self
             .nodes
@@ -788,71 +1217,44 @@ impl State {
         // we still hold the &mut self lock.
         let entry = self.nodes.remove(seed).expect("checked above");
         self.http_ports.remove(&entry.http_port);
-        Ok(RemoveNodeOutcome {
-            node_id: entry.node_id,
-        })
+        // Defer the `NodeServer` drop (destroy + thread-join) to run
+        // outside the `state` lock; see [`RemoveNodeFfi`].
+        Ok((
+            RemoveNodeOutcome {
+                node_id: entry.node_id,
+            },
+            RemoveNodeFfi {
+                server: entry.server,
+            },
+        ))
     }
 
-    /// Create a sender. Thin wrapper around [`State::add_resource`].
-    pub fn add_sender(
-        &mut self,
-        session_handle: &str,
-        transport: Transport,
-        transport_file: &str,
-        claimed_name: &str,
-    ) -> Result<AddResourceOutcome, Status> {
-        self.add_resource(
-            Side::Sender,
-            session_handle,
-            transport,
-            transport_file,
-            claimed_name,
-        )
-    }
-
-    /// Create a receiver. Thin wrapper around [`State::add_resource`].
-    pub fn add_receiver(
-        &mut self,
-        session_handle: &str,
-        transport: Transport,
-        transport_file: &str,
-        claimed_name: &str,
-    ) -> Result<AddResourceOutcome, Status> {
-        self.add_resource(
-            Side::Receiver,
-            session_handle,
-            transport,
-            transport_file,
-            claimed_name,
-        )
-    }
-
-    /// Implementation shared by [`State::add_sender`] /
-    /// [`State::add_receiver`]. The two only differ in which libnvnmos
-    /// add/lookup APIs `side` dispatches to.
+    /// First phase of `AddSender` / `AddReceiver`: validate daemon-side
+    /// bookkeeping and hand back an [`AddResourcePrep`] carrying an
+    /// [`Arc<NodeServer>`] for the FFI add.
     ///
-    /// The validation flow:
+    /// The full validation flow (spanning the three phases):
     ///
-    /// 1. Pre-check in daemon state — refuses a duplicate `name`
-    ///    on the same Node before any FFI happens.
-    /// 2. `add_{sender,receiver}` into libnvnmos. libnvnmos parses the
-    ///    transport file and creates the resource under its embedded
-    ///    resource name.
-    /// 3. `{sender,receiver}_id(claimed_name)` — uses libnvnmos
-    ///    itself as the oracle: success proves the transport file's id
-    ///    equalled the claim. Failure means a mismatch.
-    /// 4. On mismatch, error `INVALID_ARGUMENT` and log. The libnvnmos
-    ///    resource exists as a stray; the activation router will reap
-    ///    it on first activation. See the proto's "Resource lifecycle"
+    /// 1. Pre-check in daemon state — refuses a duplicate `name` on the
+    ///    same Node before any FFI happens (here).
+    /// 2. `add_{sender,receiver}` into libnvnmos, then
+    ///    `{sender,receiver}_id(claimed_name)` — libnvnmos is the oracle:
+    ///    success proves the transport file's id equalled the claim
+    ///    ([`AddResourcePrep::run_ffi`], no lock held).
+    /// 3. On success, finalise the maps ([`State::commit_add_resource`]).
+    ///    On a name mismatch the libnvnmos resource is left as a stray
+    ///    (no compensating remove); activations NACK with
+    ///    [`ActivationDispatch::NoResource`]; the stray is torn down when
+    ///    the Node is destroyed. See the proto's "Resource lifecycle"
     ///    section.
-    fn add_resource(
+    pub fn prepare_add_resource(
         &mut self,
         side: Side,
         session_handle: &str,
         transport: Transport,
         transport_file: &str,
         claimed_name: &str,
-    ) -> Result<AddResourceOutcome, Status> {
+    ) -> Result<AddResourcePrep, Status> {
         if claimed_name.is_empty() {
             return Err(Status::invalid_argument("name must be non-empty"));
         }
@@ -881,62 +1283,77 @@ impl State {
             )));
         }
 
-        let node = self.nodes.get(&node_seed).ok_or_else(|| {
-            Status::internal(format!(
-                "session {session_handle:?} referenced seed {node_seed:?} \
-                 but no Node entry exists"
-            ))
-        })?;
-
-        side.add_to_server(&node.server, transport, transport_file)
-            .map_err(|e| {
-                Status::invalid_argument(format!(
-                    "libnvnmos add_{} failed (transport_file parse error or \
-                     duplicate): {e}",
-                    side.label(),
+        let server = self
+            .nodes
+            .get(&node_seed)
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "session {session_handle:?} referenced seed {node_seed:?} \
+                     but no Node entry exists"
                 ))
-            })?;
+            })?
+            .server
+            .clone();
 
-        let resource_id = match side.lookup_id(&node.server, claimed_name) {
-            Ok(Some(id)) => id,
-            Ok(None) => {
-                tracing::error!(
-                    side = side.label(),
-                    claimed_name,
-                    %node_seed,
-                    "AddSender/AddReceiver: libnvnmos accepted the transport \
-                     file but its embedded name does not match the \
-                     claimed name; left as stray, will be reaped at \
-                     first activation"
-                );
-                return Err(Status::invalid_argument(format!(
-                    "{}'s transport_file embeds a different name than \
-                     {claimed_name:?}",
-                    side.label(),
-                )));
-            }
-            Err(e) => {
-                return Err(Status::internal(format!(
-                    "querying {} id from libnvnmos failed after add: {e}",
-                    side.label(),
-                )));
-            }
-        };
+        Ok(AddResourcePrep {
+            server,
+            side,
+            transport,
+            transport_file: transport_file.to_string(),
+            name: claimed_name.to_string(),
+            node_seed,
+            session_handle: session_handle.to_string(),
+        })
+    }
+
+    /// Third phase of `AddSender` / `AddReceiver`: record the resource in
+    /// daemon state after the libnvnmos add + name-match lookup succeeded.
+    ///
+    /// The session must still exist; if it was closed while the FFI ran
+    /// (a concurrent `CloseSession`), the libnvnmos resource is left as a
+    /// stray (no compensating remove; torn down when the Node is destroyed)
+    /// and this returns `NOT_FOUND`.
+    pub fn commit_add_resource(
+        &mut self,
+        ready: AddResourceReady,
+    ) -> Result<AddResourceOutcome, Status> {
+        let AddResourceReady {
+            side,
+            name,
+            node_seed,
+            session_handle,
+            resource_id,
+        } = ready;
+
+        if !self.sessions.contains_key(&session_handle) {
+            tracing::warn!(
+                session_handle,
+                side = side.label(),
+                name = %name,
+                %node_seed,
+                "AddSender/AddReceiver: session closed while libnvnmos add was \
+                 in flight; libnvnmos resource left as stray"
+            );
+            return Err(Status::not_found(format!(
+                "session {session_handle:?} closed before the add completed"
+            )));
+        }
 
         let resource_handle = self.allocate_resource_handle();
         self.resources.insert(
             resource_handle.clone(),
             ResourceEntry {
-                name: claimed_name.to_string(),
+                name: name.clone(),
                 node_seed: node_seed.clone(),
-                session_handle: session_handle.to_string(),
+                session_handle: session_handle.clone(),
                 side,
             },
         );
-        self.by_name.insert(key, resource_handle.clone());
+        self.by_name
+            .insert((node_seed.clone(), side, name), resource_handle.clone());
         self.sessions
-            .get_mut(session_handle)
-            .expect("session existed at the start of this method")
+            .get_mut(&session_handle)
+            .expect("checked above")
             .resources
             .insert(resource_handle.clone());
 
@@ -955,7 +1372,7 @@ impl State {
         &mut self,
         session_handle: &str,
         resource_handle: &str,
-    ) -> Result<RemoveResourceOutcome, Status> {
+    ) -> Result<(RemoveResourceOutcome, RemoveResourceFfi), Status> {
         let session = self.sessions.get(session_handle).ok_or_else(|| {
             Status::not_found(format!(
                 "session_handle {session_handle:?} is not known to this daemon"
@@ -985,30 +1402,27 @@ impl State {
             .resources
             .remove(resource_handle);
 
-        // Daemon state is consistent at this point. libnvnmos
-        // removal is best-effort — a failure here would leak a resource
-        // in libnvnmos's IS-04 model, but our state stays clean.
-        if let Some(node) = self.nodes.get(&resource.node_seed) {
-            if let Err(e) = resource
-                .side
-                .remove_from_server(&node.server, &resource.name)
-            {
-                tracing::warn!(
-                    resource_handle,
-                    side = resource.side.label(),
-                    name = %resource.name,
-                    error = %e,
-                    "remove_resource: libnvnmos remove_sender/remove_receiver failed; \
-                     daemon state already cleared"
-                );
-            }
-        }
-
-        Ok(RemoveResourceOutcome {
-            node_seed: resource.node_seed,
-            name: resource.name,
+        // Daemon state is consistent at this point. The libnvnmos removal
+        // is best-effort and deferred to run outside the lock — a failure
+        // there would leak a resource in libnvnmos's IS-04 model, but our
+        // state stays clean.
+        let server = self
+            .nodes
+            .get(&resource.node_seed)
+            .map(|n| n.server.clone());
+        let ffi = RemoveResourceFfi {
+            server,
             side: resource.side,
-        })
+            name: resource.name.clone(),
+        };
+        Ok((
+            RemoveResourceOutcome {
+                node_seed: resource.node_seed,
+                name: resource.name,
+                side: resource.side,
+            },
+            ffi,
+        ))
     }
 
     /// Push an out-of-band data-plane state change through libnvnmos so
@@ -1026,7 +1440,7 @@ impl State {
         session_handle: &str,
         resource_handle: &str,
         transport_file: Option<&str>,
-    ) -> Result<SyncResourceStateOutcome, Status> {
+    ) -> Result<(SyncResourceStateOutcome, SyncResourceFfi), Status> {
         let session = self.sessions.get(session_handle).ok_or_else(|| {
             Status::not_found(format!(
                 "session_handle {session_handle:?} is not known to this daemon"
@@ -1045,36 +1459,32 @@ impl State {
                  {resource_handle:?} but no resource entry exists"
             ))
         })?;
-        let node = self.nodes.get(&resource.node_seed).ok_or_else(|| {
-            Status::internal(format!(
-                "resource {resource_handle:?} references seed {:?} but no \
-                 Node entry exists",
-                resource.node_seed,
-            ))
-        })?;
-
-        node.server
-            .activate_connection(resource.side.to_wrapper(), &resource.name, transport_file)
-            .map_err(|e| {
-                let verb = if transport_file.is_some() {
-                    "activate"
-                } else {
-                    "deactivate"
-                };
-                Status::invalid_argument(format!(
-                    "libnvnmos {verb} for {} {:?} failed (transport_file \
-                     parse error or libnvnmos state mismatch): {e}",
-                    resource.side.label(),
-                    resource.name,
+        let server = self
+            .nodes
+            .get(&resource.node_seed)
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "resource {resource_handle:?} references seed {:?} but no \
+                     Node entry exists",
+                    resource.node_seed,
                 ))
-            })?;
+            })?
+            .server
+            .clone();
 
-        Ok(SyncResourceStateOutcome {
+        let outcome = SyncResourceStateOutcome {
             node_seed: resource.node_seed.clone(),
             name: resource.name.clone(),
             side: resource.side,
             activated: transport_file.is_some(),
-        })
+        };
+        let ffi = SyncResourceFfi {
+            server,
+            side: resource.side,
+            name: resource.name.clone(),
+            transport_file: transport_file.map(str::to_string),
+        };
+        Ok((outcome, ffi))
     }
 
     /// Register a `SubscribeActivations` stream for `session_handle`.
@@ -1424,24 +1834,30 @@ impl State {
             && !self.has_any_activation_subscription(session_handle)
     }
 
-    /// Add a channel mapping. Parallel to [`State::add_resource`].
+    /// First phase of `AddChannelMapping`, the IS-08 analogue of
+    /// [`State::prepare_add_resource`].
     ///
-    /// The validation flow:
+    /// The validation flow (spanning the phases):
     ///
     /// 1. Pre-check in daemon state — refuses a duplicate channel mapping
-    ///    `name` on the same Node before any FFI happens.
+    ///    `name` on the same Node before any FFI happens (here).
     /// 2. Assign default IS-08 ids when proto `id` is empty (nvnmosd
-    ///    policy). `routable_inputs` is forwarded like libnvnmos C
-    ///    (empty → unrestricted caps).
-    /// 3. `add_channelmapping` into libnvnmos. Geometry, duplicate ids,
-    ///    labels, and parent/sender linkage are validated there.
-    pub fn add_channelmapping(
+    ///    policy); `routable_inputs` is forwarded like libnvnmos C
+    ///    (empty → unrestricted caps) (here).
+    /// 3. `add_channelmapping` into libnvnmos, which validates geometry,
+    ///    duplicate ids, labels, and parent/sender linkage
+    ///    ([`AddChannelMappingPrep::run_ffi`], no lock held); then record
+    ///    it in daemon state ([`State::commit_add_channelmapping`]). If
+    ///    the session closed during FFI, commit returns `NOT_FOUND` and
+    ///    the libnvnmos mapping is left as a stray (no compensating
+    ///    remove; torn down when the Node is destroyed).
+    pub fn prepare_add_channelmapping(
         &mut self,
         session_handle: &str,
         name: &str,
         inputs: &[ProtoChannelMappingInput],
         outputs: &[ProtoChannelMappingOutput],
-    ) -> Result<AddChannelMappingOutcome, Status> {
+    ) -> Result<AddChannelMappingPrep, Status> {
         if name.is_empty() {
             return Err(Status::invalid_argument("name must be non-empty"));
         }
@@ -1478,22 +1894,62 @@ impl State {
         let effective_output_ids =
             effective_channelmapping_output_ids(name, outputs, first_on_node);
         let mapping =
-            build_channel_mapping(inputs, outputs, &effective_input_ids, &effective_output_ids);
+            build_channelmapping(inputs, outputs, &effective_input_ids, &effective_output_ids);
 
-        let node = self.nodes.get(&node_seed).ok_or_else(|| {
-            Status::internal(format!(
-                "session {session_handle:?} referenced seed {node_seed:?} but no Node entry \
-                 exists"
-            ))
-        })?;
-
-        node.server
-            .add_channelmapping(name, &mapping)
-            .map_err(|e| {
-                Status::invalid_argument(format!(
-                    "libnvnmos add_channelmapping failed (duplicate or invalid geometry): {e}"
+        let server = self
+            .nodes
+            .get(&node_seed)
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "session {session_handle:?} referenced seed {node_seed:?} but no Node entry \
+                     exists"
                 ))
-            })?;
+            })?
+            .server
+            .clone();
+
+        Ok(AddChannelMappingPrep {
+            server,
+            name: name.to_string(),
+            mapping,
+            node_seed,
+            session_handle: session_handle.to_string(),
+            effective_input_ids,
+            effective_output_ids,
+        })
+    }
+
+    /// Third phase of `AddChannelMapping`: record the channel mapping in
+    /// daemon state after the libnvnmos add succeeded.
+    ///
+    /// The session must still exist; if it was closed while the FFI ran
+    /// (a concurrent `CloseSession`), the libnvnmos mapping is left as a
+    /// stray (no compensating remove; torn down when the Node is destroyed)
+    /// and this returns `NOT_FOUND`.
+    pub fn commit_add_channelmapping(
+        &mut self,
+        ready: AddChannelMappingReady,
+    ) -> Result<AddChannelMappingOutcome, Status> {
+        let AddChannelMappingReady {
+            name,
+            node_seed,
+            session_handle,
+            effective_input_ids,
+            effective_output_ids,
+        } = ready;
+
+        if !self.sessions.contains_key(&session_handle) {
+            tracing::warn!(
+                session_handle,
+                name = %name,
+                %node_seed,
+                "AddChannelMapping: session closed while libnvnmos add was in \
+                 flight; libnvnmos channel mapping left as stray"
+            );
+            return Err(Status::not_found(format!(
+                "session {session_handle:?} closed before the add completed"
+            )));
+        }
 
         let channelmapping_handle = self.allocate_channelmapping_handle();
         let output_id_set: HashSet<String> = effective_output_ids.iter().cloned().collect();
@@ -1507,19 +1963,17 @@ impl State {
         self.channelmappings.insert(
             channelmapping_handle.clone(),
             ChannelMappingEntry {
-                name: name.to_string(),
+                name: name.clone(),
                 node_seed: node_seed.clone(),
-                session_handle: session_handle.to_string(),
+                session_handle: session_handle.clone(),
                 output_ids: output_id_set,
             },
         );
-        self.channelmappings_by_name.insert(
-            (node_seed.clone(), name.to_string()),
-            channelmapping_handle.clone(),
-        );
+        self.channelmappings_by_name
+            .insert((node_seed.clone(), name), channelmapping_handle.clone());
         self.sessions
-            .get_mut(session_handle)
-            .expect("session existed at start")
+            .get_mut(&session_handle)
+            .expect("checked above")
             .channelmappings
             .insert(channelmapping_handle.clone());
 
@@ -1535,7 +1989,7 @@ impl State {
         &mut self,
         session_handle: &str,
         channelmapping_handle: &str,
-    ) -> Result<RemoveChannelMappingOutcome, Status> {
+    ) -> Result<(RemoveChannelMappingOutcome, RemoveChannelMappingFfi), Status> {
         let session = self.sessions.get(session_handle).ok_or_else(|| {
             Status::not_found(format!(
                 "session_handle {session_handle:?} is not known to this daemon"
@@ -1569,21 +2023,18 @@ impl State {
             .channelmappings
             .remove(channelmapping_handle);
 
-        if let Some(node) = self.nodes.get(&entry.node_seed) {
-            if let Err(e) = node.server.remove_channelmapping(&entry.name) {
-                tracing::warn!(
-                    channelmapping_handle,
-                    name = %entry.name,
-                    error = %e,
-                    "remove_channelmapping: libnvnmos remove failed; daemon state already cleared"
-                );
-            }
-        }
-
-        Ok(RemoveChannelMappingOutcome {
-            node_seed: entry.node_seed,
-            name: entry.name,
-        })
+        let server = self.nodes.get(&entry.node_seed).map(|n| n.server.clone());
+        let ffi = RemoveChannelMappingFfi {
+            server,
+            name: entry.name.clone(),
+        };
+        Ok((
+            RemoveChannelMappingOutcome {
+                node_seed: entry.node_seed,
+                name: entry.name,
+            },
+            ffi,
+        ))
     }
 
     pub fn sync_channelmapping_state(
@@ -1592,7 +2043,7 @@ impl State {
         channelmapping_handle: &str,
         output_id: &str,
         active_map: &[ProtoActiveMapEntry],
-    ) -> Result<SyncChannelMappingStateOutcome, Status> {
+    ) -> Result<(SyncChannelMappingStateOutcome, SyncChannelMappingFfi), Status> {
         let session = self.sessions.get(session_handle).ok_or_else(|| {
             Status::not_found(format!(
                 "session_handle {session_handle:?} is not known to this daemon"
@@ -1614,28 +2065,30 @@ impl State {
                  {channelmapping_handle:?} but no entry exists"
                 ))
             })?;
-        let node = self.nodes.get(&entry.node_seed).ok_or_else(|| {
-            Status::internal(format!(
-                "channelmapping {channelmapping_handle:?} references seed {:?} but no Node \
-                 entry exists",
-                entry.node_seed,
-            ))
-        })?;
-
-        let mapped = active_map_from_proto(active_map);
-
-        node.server
-            .activate_channelmapping(&entry.name, output_id, &mapped)
-            .map_err(|e| {
-                Status::invalid_argument(format!(
-                    "libnvnmos nmos_channelmapping_activate failed: {e}"
+        let server = self
+            .nodes
+            .get(&entry.node_seed)
+            .ok_or_else(|| {
+                Status::internal(format!(
+                    "channelmapping {channelmapping_handle:?} references seed {:?} but no Node \
+                     entry exists",
+                    entry.node_seed,
                 ))
-            })?;
+            })?
+            .server
+            .clone();
 
-        Ok(SyncChannelMappingStateOutcome {
+        let outcome = SyncChannelMappingStateOutcome {
             node_seed: entry.node_seed.clone(),
             name: entry.name.clone(),
-        })
+        };
+        let ffi = SyncChannelMappingFfi {
+            server,
+            name: entry.name.clone(),
+            output_id: output_id.to_string(),
+            active_map: active_map_from_proto(active_map),
+        };
+        Ok((outcome, ffi))
     }
 
     pub fn dispatch_channelmapping_activation(
@@ -1815,7 +2268,7 @@ fn channelmapping_parent_type(raw: i32) -> ChannelMappingParentType {
     }
 }
 
-fn build_channel_mapping(
+fn build_channelmapping(
     inputs: &[ProtoChannelMappingInput],
     outputs: &[ProtoChannelMappingOutput],
     effective_input_ids: &[String],

--- a/rust/nvnmosd/tests/lock_ordering_regression.rs
+++ b/rust/nvnmosd/tests/lock_ordering_regression.rs
@@ -1,0 +1,500 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression tests for the `state` ↔ `model` lock inversion; see
+//! `doc/designs/nvnmosd/lock-ordering.md`.
+//!
+//! These tests drive an **in-band** IS-05 activation (HTTP PATCH of `/staged`)
+//! so the libnvnmos activation thread holds `model` and blocks on the client
+//! ack, then issue a concurrent gRPC mutation on the same Node. They must
+//! pass after the "no FFI under `state`" fix; they hang or time out on the
+//! pre-fix daemon.
+
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use hyper_util::rt::TokioIo;
+use nvnmos_rpc::v1::nvnmos_daemon_client::NvnmosDaemonClient;
+use nvnmos_rpc::v1::{
+    AddSenderRequest, CloseSessionRequest, NodeConfig, OpenSessionRequest,
+    SubscribeActivationsRequest, Transport as ProtoTransport,
+};
+use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream as AsyncTcpStream, UnixStream};
+use tokio::sync::oneshot;
+use tokio_stream::StreamExt;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+/// Upper bound the concurrent RPC is allowed to take. On the pre-fix daemon the
+/// RPC deadlocks and never returns, so any finite budget fails it. Post-fix the
+/// RPC must complete: `CloseSession` returns promptly (it aborts the parked
+/// activation), while `AddSender` waits — correctly — for libnvnmos's `model`
+/// lock, which the parked activation holds until its `ACTIVATION_ACK_TIMEOUT`
+/// (5 s) elapses. So the budget must exceed that ack timeout with margin.
+const CONCURRENT_RPC_BUDGET: Duration = Duration::from_secs(15);
+const PATCH_HTTP_BUDGET: Duration = Duration::from_secs(30);
+
+struct DaemonHarness {
+    _dir: TempDir,
+    uds: PathBuf,
+    child: Child,
+}
+
+impl DaemonHarness {
+    fn spawn() -> Self {
+        let dir = TempDir::new().expect("tempdir");
+        let uds = dir.path().join("nvnmosd.sock");
+        nvnmosd::uds::prepare_listen_path(&uds).expect("prepare UDS path");
+        let bin = env!("CARGO_BIN_EXE_nvnmosd");
+        let lib_dir = find_libnvnmos_dir();
+        let ld_library_path = prepend_ld_library_path(&lib_dir);
+        let child = Command::new(bin)
+            .arg("--uds")
+            .arg(&uds)
+            .env("NVNMOSD_SESSION_GC", "0")
+            .env("NVNMOSD_MALLOC_TRIM", "0")
+            .env("RUST_LOG", "error")
+            .env("LD_LIBRARY_PATH", &ld_library_path)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn nvnmosd");
+        Self {
+            _dir: dir,
+            uds,
+            child,
+        }
+    }
+
+    async fn ready(&mut self) {
+        wait_for_daemon(&self.uds, &mut self.child).await;
+    }
+}
+
+impl Drop for DaemonHarness {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn find_libnvnmos_dir() -> String {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(dir) = std::env::var("NVNMOS_LIB_DIR") {
+        candidates.push(PathBuf::from(dir));
+    }
+    candidates.push(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../build"));
+    for candidate in candidates {
+        if let Some(abs) = absolutize_lib_dir(&candidate) {
+            return abs;
+        }
+    }
+    panic!("could not find libnvnmos.so; set NVNMOS_LIB_DIR");
+}
+
+fn absolutize_lib_dir(path: &Path) -> Option<String> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(path)
+    };
+    let abs = abs.canonicalize().ok()?;
+    if abs.join("libnvnmos.so").is_file() {
+        Some(abs.to_string_lossy().into_owned())
+    } else {
+        None
+    }
+}
+
+fn prepend_ld_library_path(dir: &str) -> String {
+    match std::env::var("LD_LIBRARY_PATH") {
+        Ok(existing) if !existing.is_empty() => format!("{dir}:{existing}"),
+        _ => dir.to_string(),
+    }
+}
+
+async fn wait_for_daemon(uds: &Path, child: &mut Child) {
+    for _ in 0..200 {
+        if child.try_wait().ok().flatten().is_some() {
+            panic!("nvnmosd exited before binding UDS");
+        }
+        if UnixStream::connect(uds).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("nvnmosd did not become ready on {}", uds.display());
+}
+
+async fn connect(uds: &Path) -> NvnmosDaemonClient<Channel> {
+    let uds = uds.to_path_buf();
+    let endpoint = Endpoint::try_from("http://[::1]:50051").expect("endpoint uri");
+    let channel = endpoint
+        .connect_with_connector(service_fn(move |_: Uri| {
+            let uds = uds.clone();
+            async move {
+                let stream = UnixStream::connect(uds).await?;
+                Ok::<_, std::io::Error>(TokioIo::new(stream))
+            }
+        }))
+        .await
+        .expect("connect UDS");
+    NvnmosDaemonClient::new(channel)
+}
+
+fn autodetect_iface_ip() -> String {
+    use std::net::UdpSocket;
+    let sock = match UdpSocket::bind("0.0.0.0:0") {
+        Ok(s) => s,
+        Err(_) => return "127.0.0.1".to_string(),
+    };
+    if sock.connect("8.8.8.8:80").is_err() {
+        return "127.0.0.1".to_string();
+    }
+    sock.local_addr()
+        .map(|a| a.ip().to_string())
+        .unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+fn sender_sdp(name: &str, iface_ip: &str) -> String {
+    format!(
+        "v=0\r\n\
+         o=- 0 0 IN IP4 {iface_ip}\r\n\
+         s=lock-ordering-regression\r\n\
+         t=0 0\r\n\
+         a=x-nvnmos-name:{name}\r\n\
+         m=video 5020 RTP/AVP 96\r\n\
+         c=IN IP4 233.252.0.0/64\r\n\
+         a=source-filter: incl IN IP4 233.252.0.0 {iface_ip}\r\n\
+         a=x-nvnmos-iface-ip:{iface_ip}\r\n\
+         a=rtpmap:96 raw/90000\r\n\
+         a=fmtp:96 sampling=YCbCr-4:2:2; width=1920; height=1080; \
+         exactframerate=50; depth=10; TCS=SDR; colorimetry=BT709; \
+         PM=2110GPM; SSN=ST2110-20:2017; TP=2110TPN;\r\n\
+         a=mediaclk:direct=0\r\n\
+         a=x-nvnmos-src-port:5004\r\n\
+         a=ts-refclk:localmac=CA-FE-01-CA-FE-02\r\n"
+    )
+}
+
+fn os_port_free(port: u16) -> bool {
+    TcpListener::bind(("0.0.0.0", port)).is_ok()
+}
+
+async fn connection_http(
+    method: &str,
+    host: &str,
+    port: u16,
+    path: &str,
+    body: Option<&str>,
+) -> Result<(u16, String), String> {
+    let addr = format!("{host}:{port}");
+    let request = match body {
+        Some(body) => format!(
+            "{method} {path} HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {len}\r\n\
+             Connection: close\r\n\
+             \r\n\
+             {body}",
+            len = body.len(),
+        ),
+        None => format!(
+            "{method} {path} HTTP/1.1\r\n\
+             Host: {addr}\r\n\
+             Connection: close\r\n\
+             \r\n",
+        ),
+    };
+
+    tokio::time::timeout(PATCH_HTTP_BUDGET, async {
+        let mut sock = AsyncTcpStream::connect(&addr)
+            .await
+            .map_err(|e| e.to_string())?;
+        sock.write_all(request.as_bytes())
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut buf = Vec::with_capacity(4096);
+        sock.read_to_end(&mut buf)
+            .await
+            .map_err(|e| e.to_string())?;
+        let resp = String::from_utf8_lossy(&buf).into_owned();
+        let status_line = resp.lines().next().unwrap_or("");
+        let status: u16 = status_line
+            .split_whitespace()
+            .nth(1)
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| format!("bad HTTP status in {status_line:?}"))?;
+        Ok((status, resp))
+    })
+    .await
+    .map_err(|_| format!("{method} {path} timed out after {:?}", PATCH_HTTP_BUDGET))?
+}
+
+async fn connection_get(host: &str, port: u16, path: &str) -> Result<(u16, String), String> {
+    connection_http("GET", host, port, path, None).await
+}
+
+async fn connection_patch(
+    host: &str,
+    port: u16,
+    path: &str,
+    body: &str,
+) -> Result<(u16, String), String> {
+    connection_http("PATCH", host, port, path, Some(body)).await
+}
+
+/// Build a PATCH body that preserves transport binding from `/active`, mirroring
+/// `gst-nmos-rs-demo.sh` `patch_master_enable`.
+async fn patch_activate_immediate(
+    host: &str,
+    port: u16,
+    staged_path: &str,
+    enable: bool,
+) -> Result<(), String> {
+    let active_path = staged_path.trim_end_matches("/staged");
+    let (status, body) = connection_get(host, port, &format!("{active_path}/active")).await?;
+    if !(200..300).contains(&status) {
+        return Err(format!("GET /active returned HTTP {status}: {body}"));
+    }
+    let json_start = body
+        .find('{')
+        .ok_or_else(|| format!("no JSON in GET /active: {body}"))?;
+    let active: serde_json::Value =
+        serde_json::from_str(&body[json_start..]).map_err(|e| e.to_string())?;
+    let mut patch = serde_json::json!({
+        "master_enable": enable,
+        "activation": { "mode": "activate_immediate" }
+    });
+    if let Some(tp) = active.get("transport_params") {
+        patch["transport_params"] = tp.clone();
+    }
+    if let Some(id) = active.get("sender_id") {
+        patch["sender_id"] = id.clone();
+    }
+    if let Some(id) = active.get("receiver_id") {
+        patch["receiver_id"] = id.clone();
+    }
+    let patch_body = patch.to_string();
+    let (status, resp) = connection_patch(host, port, staged_path, &patch_body).await?;
+    if !(200..300).contains(&status) {
+        return Err(format!("PATCH /staged returned HTTP {status}: {resp}"));
+    }
+    Ok(())
+}
+
+struct ParkedActivation {
+    _parker: tokio::task::JoinHandle<()>,
+}
+
+/// On the first `ActivationEvent`, signal `parked` and hold the ack (no
+/// `AckActivation`) until this handle is dropped.
+fn park_first_activation_on_stream(
+    mut stream: tonic::Streaming<nvnmos_rpc::v1::ActivationEvent>,
+) -> (ParkedActivation, oneshot::Receiver<()>) {
+    let (parked_tx, parked_rx) = oneshot::channel();
+    let parker = tokio::spawn(async move {
+        let msg = stream
+            .next()
+            .await
+            .expect("activation stream ended before first event")
+            .expect("activation stream error");
+        let _ = msg.activation_handle;
+        let _ = parked_tx.send(());
+        std::future::pending::<()>().await;
+    });
+    (ParkedActivation { _parker: parker }, parked_rx)
+}
+
+async fn open_session_with_port(
+    client: &mut NvnmosDaemonClient<Channel>,
+    seed: &str,
+    http_port: u16,
+) -> (String, u16) {
+    let resp = client
+        .open_session(OpenSessionRequest {
+            node_config: Some(NodeConfig {
+                seed: seed.to_string(),
+                http_port: u32::from(http_port),
+                host_addresses: vec!["127.0.0.1".to_string()],
+                ..Default::default()
+            }),
+        })
+        .await
+        .expect("OpenSession")
+        .into_inner();
+    (resp.session_handle, resp.http_port as u16)
+}
+
+async fn subscribe_activations(
+    client: &mut NvnmosDaemonClient<Channel>,
+    session_handle: &str,
+) -> tonic::Streaming<nvnmos_rpc::v1::ActivationEvent> {
+    client
+        .subscribe_activations(SubscribeActivationsRequest {
+            session_handle: session_handle.to_string(),
+        })
+        .await
+        .expect("SubscribeActivations")
+        .into_inner()
+}
+
+fn staged_sender_path(resource_id: &str) -> String {
+    format!("/x-nmos/connection/v1.1/single/senders/{resource_id}/staged")
+}
+
+/// Start an in-band activate_immediate PATCH and wait until the daemon has
+/// delivered the activation event on `stream` (client ack withheld).
+async fn start_parked_in_band_activation_on_stream(
+    stream: tonic::Streaming<nvnmos_rpc::v1::ActivationEvent>,
+    http_port: u16,
+    resource_id: &str,
+) -> ParkedActivation {
+    let (parker, parked_rx) = park_first_activation_on_stream(stream);
+    let staged_path = staged_sender_path(resource_id);
+    let host = "127.0.0.1";
+    tokio::spawn(async move {
+        if let Err(e) = patch_activate_immediate(host, http_port, &staged_path, true).await {
+            eprintln!("[lock-ordering test] PATCH /staged failed: {e}");
+        }
+    });
+    tokio::time::timeout(Duration::from_secs(10), parked_rx)
+        .await
+        .expect("timed out waiting for in-band activation event")
+        .expect("activation parker dropped before signalling");
+    parker
+}
+
+/// While an in-band IS-05 activation is parked on the client ack, adding
+/// another sender on the same Node must not wedge the daemon.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn in_band_activation_does_not_deadlock_add_sender() {
+    let mut harness = DaemonHarness::spawn();
+    harness.ready().await;
+    let mut client = connect(&harness.uds).await;
+    let iface = autodetect_iface_ip();
+
+    let port = {
+        let l = TcpListener::bind("0.0.0.0:0").expect("ephemeral");
+        l.local_addr().expect("addr").port()
+    };
+
+    let (session, http_port) = open_session_with_port(&mut client, "lock-add", port).await;
+    assert_eq!(http_port, port);
+
+    let stream = subscribe_activations(&mut client, &session).await;
+
+    let s1 = client
+        .add_sender(AddSenderRequest {
+            session_handle: session.clone(),
+            name: "s1".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: sender_sdp("s1", &iface),
+        })
+        .await
+        .expect("AddSender s1")
+        .into_inner();
+
+    let parker =
+        start_parked_in_band_activation_on_stream(stream, http_port, &s1.resource_id).await;
+
+    let mut add_client = client.clone();
+    let add_session = session.clone();
+    let add_iface = iface.clone();
+    let add_result = tokio::time::timeout(CONCURRENT_RPC_BUDGET, async move {
+        add_client
+            .add_sender(AddSenderRequest {
+                session_handle: add_session,
+                name: "s2".to_string(),
+                transport: ProtoTransport::Rtp as i32,
+                transport_file: sender_sdp("s2", &add_iface),
+            })
+            .await
+    })
+    .await;
+
+    drop(parker);
+
+    assert!(
+        add_result.is_ok(),
+        "AddSender s2 must complete within {:?} while s1 activation is pending \
+         (daemon deadlocked?)",
+        CONCURRENT_RPC_BUDGET,
+    );
+    add_result
+        .expect("AddSender s2 join")
+        .expect("AddSender s2 RPC");
+
+    let _ = client
+        .close_session(CloseSessionRequest {
+            session_handle: session,
+        })
+        .await;
+}
+
+/// While an in-band IS-05 activation is parked, CloseSession must complete and
+/// release the Node HTTP port (no stranded LISTEN socket).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn in_band_activation_does_not_deadlock_close_session() {
+    let mut harness = DaemonHarness::spawn();
+    harness.ready().await;
+    let mut client = connect(&harness.uds).await;
+    let iface = autodetect_iface_ip();
+
+    let port = {
+        let l = TcpListener::bind("0.0.0.0:0").expect("ephemeral");
+        l.local_addr().expect("addr").port()
+    };
+
+    let (session, http_port) = open_session_with_port(&mut client, "lock-close", port).await;
+    assert_eq!(http_port, port);
+
+    let stream = subscribe_activations(&mut client, &session).await;
+
+    let s1 = client
+        .add_sender(AddSenderRequest {
+            session_handle: session.clone(),
+            name: "s1".to_string(),
+            transport: ProtoTransport::Rtp as i32,
+            transport_file: sender_sdp("s1", &iface),
+        })
+        .await
+        .expect("AddSender s1")
+        .into_inner();
+
+    let parker =
+        start_parked_in_band_activation_on_stream(stream, http_port, &s1.resource_id).await;
+
+    let mut close_client = client.clone();
+    let close_session = session.clone();
+    let close_result = tokio::time::timeout(CONCURRENT_RPC_BUDGET, async move {
+        close_client
+            .close_session(CloseSessionRequest {
+                session_handle: close_session,
+            })
+            .await
+    })
+    .await;
+
+    drop(parker);
+
+    assert!(
+        close_result.is_ok(),
+        "CloseSession must complete within {:?} while activation is pending \
+         (daemon deadlocked?)",
+        CONCURRENT_RPC_BUDGET,
+    );
+    close_result
+        .expect("CloseSession join")
+        .expect("CloseSession RPC");
+
+    assert!(
+        os_port_free(port),
+        "http port {port} must be bindable after CloseSession (LISTEN leaked?)"
+    );
+}


### PR DESCRIPTION
Run all libnvnmos FFI outside the daemon state mutex so in-band IS-05 activations (model then state) cannot deadlock with gRPC handlers that previously held state across FFI. Split mutations into `prepare`/`run_ffi`/`commit` or deferred `*Ffi::run` phases, add lock-ordering regression tests, and document the invariant and accepted stray-object races.

Rationale described in the [`lock-ordering.md`](https://github.com/garethsb/nvnmos/blob/e995d3d5d2b0f9e7e94c52c117969104754ee2aa/doc/designs/nvnmosd/lock-ordering.md) design doc.