### PR TITLE
docs: add Hotdoc GStreamer plugin reference and publish in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,5 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
-    - run: mkdir LICENSES && cp LICENSE LICENSES/Apache-2.0.txt
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (C) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (C) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-name: Deploy Doxygen Documentation to GitHub Pages
+name: Deploy Documentation to GitHub Pages
 
 on:
   push:
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
@@ -19,8 +19,34 @@ jobs:
     - name: Install Doxygen
       run: sudo apt update && sudo apt install -y doxygen graphviz
 
-    - name: Generate Documentation
+    - name: Generate C API documentation
       run: cd src && doxygen ../Doxyfile && mv html ../public
+
+    - name: Install GStreamer plugin documentation toolchain
+      run: |
+        sudo apt-get install -y \
+          meson ninja-build \
+          libgstreamer1.0-dev \
+          python3-dev libxml2-dev libxslt1-dev cmake libyaml-dev \
+          libjson-glib-dev flex
+        python3 -m venv .venv-hotdoc
+        . .venv-hotdoc/bin/activate
+        pip install "hotdoc~=0.18.0"
+        echo "$PWD/.venv-hotdoc/bin" >> "$GITHUB_PATH"
+
+    - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606
+      with:
+        rust-src-dir: rust
+        rustflags: ""
+
+    - name: Build GStreamer plugin documentation
+      run: |
+        export CARGO_TARGET_DIR="$PWD/rust/target"
+        cd rust/docs/gstreamer
+        meson setup build -Ddoc=enabled
+        ninja -C build gstreamer-doc
+        mkdir -p "$GITHUB_WORKSPACE/public/gstreamer"
+        cp -a build/NvNmos-GStreamer-doc/html/* "$GITHUB_WORKSPACE/public/gstreamer/"
 
     - name: Upload Documentation Artifact
       uses: actions/upload-pages-artifact@v4

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/LGPL-2.1-or-later.txt
+++ b/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,176 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+
+Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts as the successor of the GNU Library Public License, version 2, hence the version number 2.1.]
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share and change it. By contrast, the GNU General Public Licenses are intended to guarantee your freedom to share and change free software--to make sure the software is free for all its users.
+
+This license, the Lesser General Public License, applies to some specially designated software packages--typically libraries--of the Free Software Foundation and other authors who decide to use it. You can use it too, but we suggest you first think carefully about whether this license or the ordinary General Public License is the better strategy to use in any particular case, based on the explanations below.
+
+When we speak of free software, we are referring to freedom of use, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for this service if you wish); that you receive source code or can get it if you want it; that you can change the software and use pieces of it in new free programs; and that you are informed that you can do these things.
+
+To protect your rights, we need to make restrictions that forbid distributors to deny you these rights or to ask you to surrender these rights. These restrictions translate to certain responsibilities for you if you distribute copies of the library or if you modify it.
+
+For example, if you distribute copies of the library, whether gratis or for a fee, you must give the recipients all the rights that we gave you. You must make sure that they, too, receive or can get the source code. If you link other code with the library, you must provide complete object files to the recipients, so that they can relink them with the library after making changes to the library and recompiling it. And you must show them these terms so they know their rights.
+
+We protect your rights with a two-step method: (1) we copyright the library, and (2) we offer you this license, which gives you legal permission to copy, distribute and/or modify the library.
+
+To protect each distributor, we want to make it very clear that there is no warranty for the free library. Also, if the library is modified by someone else and passed on, the recipients should know that what they have is not the original version, so that the original author's reputation will not be affected by problems that might be introduced by others.
+
+Finally, software patents pose a constant threat to the existence of any free program. We wish to make sure that a company cannot effectively restrict the users of a free program by obtaining a restrictive license from a patent holder. Therefore, we insist that any patent license obtained for a version of the library must be consistent with the full freedom of use specified in this license.
+
+Most GNU software, including some libraries, is covered by the ordinary GNU General Public License. This license, the GNU Lesser General Public License, applies to certain designated libraries, and is quite different from the ordinary General Public License. We use this license for certain libraries in order to permit linking those libraries into non-free programs.
+
+When a program is linked with a library, whether statically or using a shared library, the combination of the two is legally speaking a combined work, a derivative of the original library. The ordinary General Public License therefore permits such linking only if the entire combination fits its criteria of freedom. The Lesser General Public License permits more lax criteria for linking other code with the library.
+
+We call this license the "Lesser" General Public License because it does Less to protect the user's freedom than the ordinary General Public License. It also provides other free software developers Less of an advantage over competing non-free programs. These disadvantages are the reason we use the ordinary General Public License for many libraries. However, the Lesser license provides advantages in certain special circumstances.
+
+For example, on rare occasions, there may be a special need to encourage the widest possible use of a certain library, so that it becomes a de-facto standard. To achieve this, non-free programs must be allowed to use the library. A more frequent case is that a free library does the same job as widely used non-free libraries. In this case, there is little to gain by limiting the free library to free software only, so we use the Lesser General Public License.
+
+In other cases, permission to use a particular library in non-free programs enables a greater number of people to use a large body of free software. For example, permission to use the GNU C Library in non-free programs enables many more people to use the whole GNU operating system, as well as its variant, the GNU/Linux operating system.
+
+Although the Lesser General Public License is Less protective of the users' freedom, it does ensure that the user of a program that is linked with the Library has the freedom and the wherewithal to run that program using a modified version of the Library.
+
+The precise terms and conditions for copying, distribution and modification follow. Pay close attention to the difference between a "work based on the library" and a "work that uses the library". The former contains code derived from the library, whereas the latter must be combined with the library in order to run.
+
+GNU LESSER GENERAL PUBLIC LICENSE
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License Agreement applies to any software library or other program which contains a notice placed by the copyright holder or other authorized party saying it may be distributed under the terms of this Lesser General Public License (also called "this License"). Each licensee is addressed as "you".
+
+A "library" means a collection of software functions and/or data prepared so as to be conveniently linked with application programs (which use some of those functions and data) to form executables.
+
+The "Library", below, refers to any such software library or work which has been distributed under these terms. A "work based on the Library" means either the Library or any derivative work under copyright law: that is to say, a work containing the Library or a portion of it, either verbatim or with modifications and/or translated straightforwardly into another language. (Hereinafter, translation is included without limitation in the term "modification".)
+
+"Source code" for a work means the preferred form of the work for making modifications to it. For a library, complete source code means all the source code for all modules it contains, plus any associated interface definition files, plus the scripts used to control compilation and installation of the library.
+
+Activities other than copying, distribution and modification are not covered by this License; they are outside its scope. The act of running a program using the Library is not restricted, and output from such a program is covered only if its contents constitute a work based on the Library (independent of the use of the Library in a tool for writing it). Whether that is true depends on what the Library does and what the program that uses the Library does.
+
+1. You may copy and distribute verbatim copies of the Library's complete source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice and disclaimer of warranty; keep intact all the notices that refer to this License and to the absence of any warranty; and distribute a copy of this License along with the Library.
+
+You may charge a fee for the physical act of transferring a copy, and you may at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Library or any portion of it, thus forming a work based on the Library, and copy and distribute such modifications or work under the terms of Section 1 above, provided that you also meet all of these conditions:
+
+     a) The modified work must itself be a software library.
+
+     b) You must cause the files modified to carry prominent notices stating that you changed the files and the date of any change.
+
+     c) You must cause the whole of the work to be licensed at no charge to all third parties under the terms of this License.
+
+     d) If a facility in the modified Library refers to a function or a table of data to be supplied by an application program that uses the facility, other than as an argument passed when the facility is invoked, then you must make a good faith effort to ensure that, in the event an application does not supply such function or table, the facility still operates, and performs whatever part of its purpose remains meaningful.
+
+(For example, a function in a library to compute square roots has a purpose that is entirely well-defined independent of the application. Therefore, Subsection 2d requires that any application-supplied function or table used by this function must be optional: if the application does not supply it, the square root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole. If identifiable sections of that work are not derived from the Library, and can be reasonably considered independent and separate works in themselves, then this License, and its terms, do not apply to those sections when you distribute them as separate works. But when you distribute the same sections as part of a whole which is a work based on the Library, the distribution of the whole must be on the terms of this License, whose permissions for other licensees extend to the entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your rights to work written entirely by you; rather, the intent is to exercise the right to control the distribution of derivative or collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library with the Library (or with a work based on the Library) on a volume of a storage or distribution medium does not bring the other work under the scope of this License.
+
+3. You may opt to apply the terms of the ordinary GNU General Public License instead of this License to a given copy of the Library. To do this, you must alter all the notices that refer to this License, so that they refer to the ordinary GNU General Public License, version 2, instead of to this License. (If a newer version than version 2 of the ordinary GNU General Public License has appeared, then you can specify that version instead if you wish.) Do not make any other change in these notices.
+
+Once this change is made in a given copy, it is irreversible for that copy, so the ordinary GNU General Public License applies to all subsequent copies and derivative works made from that copy.
+
+This option is useful when you wish to copy part of the code of the Library into a program that is not a library.
+
+4. You may copy and distribute the Library (or a portion or derivative of it, under Section 2) in object code or executable form under the terms of Sections 1 and 2 above provided that you accompany it with the complete corresponding machine-readable source code, which must be distributed under the terms of Sections 1 and 2 above on a medium customarily used for software interchange.
+
+If distribution of object code is made by offering access to copy from a designated place, then offering equivalent access to copy the source code from the same place satisfies the requirement to distribute the source code, even though third parties are not compelled to copy the source along with the object code.
+
+5. A program that contains no derivative of any portion of the Library, but is designed to work with the Library by being compiled or linked with it, is called a "work that uses the Library". Such a work, in isolation, is not a derivative work of the Library, and therefore falls outside the scope of this License.
+
+However, linking a "work that uses the Library" with the Library creates an executable that is a derivative of the Library (because it contains portions of the Library), rather than a "work that uses the library". The executable is therefore covered by this License. Section 6 states terms for distribution of such executables.
+
+When a "work that uses the Library" uses material from a header file that is part of the Library, the object code for the work may be a derivative work of the Library even though the source code is not. Whether this is true is especially significant if the work can be linked without the Library, or if the work is itself a library. The threshold for this to be true is not precisely defined by law.
+
+If such an object file uses only numerical parameters, data structure layouts and accessors, and small macros and small inline functions (ten lines or less in length), then the use of the object file is unrestricted, regardless of whether it is legally a derivative work. (Executables containing this object code plus portions of the Library will still fall under Section 6.)
+
+Otherwise, if the work is a derivative of the Library, you may distribute the object code for the work under the terms of Section 6. Any executables containing that work also fall under Section 6, whether or not they are linked directly with the Library itself.
+
+6. As an exception to the Sections above, you may also combine or link a "work that uses the Library" with the Library to produce a work containing portions of the Library, and distribute that work under terms of your choice, provided that the terms permit modification of the work for the customer's own use and reverse engineering for debugging such modifications.
+
+You must give prominent notice with each copy of the work that the Library is used in it and that the Library and its use are covered by this License. You must supply a copy of this License. If the work during execution displays copyright notices, you must include the copyright notice for the Library among them, as well as a reference directing the user to the copy of this License. Also, you must do one of these things:
+
+     a) Accompany the work with the complete corresponding machine-readable source code for the Library including whatever changes were used in the work (which must be distributed under Sections 1 and 2 above); and, if the work is an executable linked with the Library, with the complete machine-readable "work that uses the Library", as object code and/or source code, so that the user can modify the Library and then relink to produce a modified executable containing the modified Library. (It is understood that the user who changes the contents of definitions files in the Library will not necessarily be able to recompile the application to use the modified definitions.)
+
+     b) Use a suitable shared library mechanism for linking with the Library. A suitable mechanism is one that (1) uses at run time a copy of the library already present on the user's computer system, rather than copying library functions into the executable, and (2) will operate properly with a modified version of the library, if the user installs one, as long as the modified version is interface-compatible with the version that the work was made with.
+
+     c) Accompany the work with a written offer, valid for at least three years, to give the same user the materials specified in Subsection 6a, above, for a charge no more than the cost of performing this distribution.
+
+     d) If distribution of the work is made by offering access to copy from a designated place, offer equivalent access to copy the above specified materials from the same place.
+
+     e) Verify that the user has already received a copy of these materials or that you have already sent this user a copy.
+
+For an executable, the required form of the "work that uses the Library" must include any data and utility programs needed for reproducing the executable from it. However, as a special exception, the materials to be distributed need not include anything that is normally distributed (in either source or binary form) with the major components (compiler, kernel, and so on) of the operating system on which the executable runs, unless that component itself accompanies the executable.
+
+It may happen that this requirement contradicts the license restrictions of other proprietary libraries that do not normally accompany the operating system. Such a contradiction means you cannot use both them and the Library together in an executable that you distribute.
+
+7. You may place library facilities that are a work based on the Library side-by-side in a single library together with other library facilities not covered by this License, and distribute such a combined library, provided that the separate distribution of the work based on the Library and of the other library facilities is otherwise permitted, and provided that you do these two things:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities. This must be distributed under the terms of the Sections above.
+
+     b) Give prominent notice with the combined library of the fact that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+8. You may not copy, modify, sublicense, link with, or distribute the Library except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, link with, or distribute the Library is void, and will automatically terminate your rights under this License. However, parties who have received copies, or rights, from you under this License will not have their licenses terminated so long as such parties remain in full compliance.
+
+9. You are not required to accept this License, since you have not signed it. However, nothing else grants you permission to modify or distribute the Library or its derivative works. These actions are prohibited by law if you do not accept this License. Therefore, by modifying or distributing the Library (or any work based on the Library), you indicate your acceptance of this License to do so, and all its terms and conditions for copying, distributing or modifying the Library or works based on it.
+
+10. Each time you redistribute the Library (or any work based on the Library), the recipient automatically receives a license from the original licensor to copy, distribute, link with or modify the Library subject to these terms and conditions. You may not impose any further restrictions on the recipients' exercise of the rights granted herein. You are not responsible for enforcing compliance by third parties with this License.
+
+11. If, as a consequence of a court judgment or allegation of patent infringement or for any other reason (not limited to patent issues), conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot distribute so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not distribute the Library at all. For example, if a patent license would not permit royalty-free redistribution of the Library by all those who receive copies directly or indirectly through you, then the only way you could satisfy both it and this License would be to refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any particular circumstance, the balance of the section is intended to apply, and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or other property right claims or to contest validity of any such claims; this section has the sole purpose of protecting the integrity of the free software distribution system which is implemented by public license practices. Many people have made generous contributions to the wide range of software distributed through that system in reliance on consistent application of that system; it is up to the author/donor to decide if he or she is willing to distribute software through any other system and a licensee cannot impose that choice.
+
+This section is intended to make thoroughly clear what is believed to be a consequence of the rest of this License.
+
+12. If the distribution and/or use of the Library is restricted in certain countries either by patents or by copyrighted interfaces, the original copyright holder who places the Library under this License may add an explicit geographical distribution limitation excluding those countries, so that distribution is permitted only in or among countries not thus excluded. In such case, this License incorporates the limitation as if written in the body of this License.
+
+13. The Free Software Foundation may publish revised and/or new versions of the Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library specifies a version number of this License which applies to it and "any later version", you have the option of following the terms and conditions either of that version or of any later version published by the Free Software Foundation. If the Library does not specify a license version number, you may choose any version ever published by the Free Software Foundation.
+
+14. If you wish to incorporate parts of the Library into other free programs whose distribution conditions are incompatible with these, write to the author to ask for permission. For software which is copyrighted by the Free Software Foundation, write to the Free Software Foundation; we sometimes make exceptions for this. Our decision will be guided by the two goals of preserving the free status of all derivatives of our free software and of promoting the sharing and reuse of software generally.
+
+NO WARRANTY
+
+15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE LIBRARY IS WITH YOU. SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Libraries
+
+If you develop a new library, and you want it to be of the greatest possible use to the public, we recommend making it free software that everyone can redistribute and change. You can do so by permitting redistribution under these terms (or, alternatively, under the terms of the ordinary General Public License).
+
+To apply these terms, attach the following notices to the library. It is safest to attach them to the start of each source file to most effectively convey the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
+
+     one line to give the library's name and an idea of what it does.
+     Copyright (C) year  name of author
+
+     This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
+
+     This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+
+     You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your school, if any, to sign a "copyright disclaimer" for the library, if necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in
+the library `Frob' (a library for tweaking knobs) written
+by James Random Hacker.
+
+signature of Ty Coon, 1 April 1990
+Ty Coon, President of Vice
+That's all there is to it!

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ These callbacks can be used to update running DeepStream pipelines with new tran
 
 NvNmos currently supports Senders and Receivers for video, audio, and ancillary data flows over RTP (i.e., SMPTE ST 2110-20, -22, -30, and -40 streams) and over the Media eXchange Layer (MXL).
 
+The GStreamer plugin and element reference is published at
+[https://nvidia.github.io/nvnmos/gstreamer/](https://nvidia.github.io/nvnmos/gstreamer/).
+
 The NvNmos library supports the following specifications, using the [Sony nmos-cpp](https://github.com/sony/nmos-cpp) implementation internally:
 - [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04/) v1.3
 - [AMWA IS-05 NMOS Device Connection Management Specification](https://specs.amwa.tv/is-05/) v1.1 and v1.2-dev (for MXL)
@@ -46,8 +49,8 @@ The following operating systems and compilers have been tested.
 
 ## Usage
 
-NvNmos consists of a single shared library (_libnvnmos.so_ on Linux, _nvnmos.dll_ on Windows).
-The API is specified by the _nvnmos.h_ header file.
+NvNmos consists of a single shared library (`libnvnmos.so` on Linux, `nvnmos.dll` on Windows).
+The API is specified by the `nvnmos.h` header file.
 
 The nvnmos-example application demonstrates use of the library.
 
@@ -132,7 +135,7 @@ All write a null-terminated UUID into a buffer of at least `NVNMOS_ID_LEN` bytes
 
 For `NVNMOS_TRANSPORT_MXL` the transport file is an MXL flow definition JSON (the form consumed by the MXL SDK), with NvNmos extensions carried as entries in the standard `tags` property keyed by `urn:x-nvnmos:tag:*` URN strings. See *NvNmos Extensions to the Transport File* above for the full set.
 
-For the full per-field documentation see [`src/nvnmos.h`](src/nvnmos.h).
+For the full per-field documentation see [`src/nvnmos.h`](https://github.com/NVIDIA/nvnmos/blob/main/src/nvnmos.h).
 
 ## API Changes for RTP Sender IS-05 Defaults
 
@@ -145,11 +148,11 @@ On IS-05 activation, `"auto"` values for RTP Senders are now resolved based on t
 
 ## Container Images
 
-Container definitions live under [`docker/`](docker/). Build context is always the repository root.
+Container definitions live under [`docker/`](https://github.com/NVIDIA/nvnmos/tree/main/docker). Build context is always the repository root.
 
-### Library Package Image (`docker/nvnmos`)
+### nvnmos Library Package Image
 
-Builds and packages the C++ library and Rust workspace from source (see [`docker/nvnmos/README.md`](docker/nvnmos/README.md) for build arguments and runtime behaviour). With the defaults (`ubuntu:24.04`, `src/conan.lock`) the image produces **`nvnmos-ubuntu-24.04.tar.gz`**:
+Builds and packages the C++ library and Rust workspace from source (see [`docker/nvnmos/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/docker/nvnmos/README.md) for build arguments and runtime behaviour). With the defaults (`ubuntu:24.04`, `src/conan.lock`) the image produces `nvnmos-ubuntu-24.04.tar.gz`:
 
 ```sh
 docker build -f docker/nvnmos/Dockerfile -t nvnmos .
@@ -158,9 +161,9 @@ docker cp nvnmos-test:/nvnmos-ubuntu-24.04.tar.gz .
 docker rm nvnmos-test
 ```
 
-### gst-nmos-rs Operator Image (`docker/gst-nmos-rs`)
+### gst-nmos-rs Operator Image
 
-Combined runtime for `nvnmosd` + `gst-nmos-rs`, intended for `gst-launch-1.0` pipelines (`transport=mxl` via gst-mxl-rs, `udp` via gst-plugins-good, `udp2` via gst-plugins-rs). See [`docker/gst-nmos-rs/README.md`](docker/gst-nmos-rs/README.md) for build arguments, run, and Kubernetes notes.
+Combined runtime for `nvnmosd` + `gst-nmos-rs`, intended for `gst-launch-1.0` pipelines (`transport=mxl` via gst-mxl-rs, `udp` via gst-plugins-good, `udp2` via gst-plugins-rs). See [`docker/gst-nmos-rs/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/docker/gst-nmos-rs/README.md) for build arguments, run, and Kubernetes notes.
 
 ```sh
 docker build -f docker/gst-nmos-rs/Dockerfile -t nvnmos-gst .
@@ -317,7 +320,7 @@ os=Windows
 
 **Linux**
 
-Prepare a _build_ directory adjacent to the _src_ directory.
+Prepare a `build` directory adjacent to the `src` directory.
 
 ```sh
 mkdir build
@@ -327,7 +330,7 @@ To install the dependencies using Conan, use the following command.
 
 > 💬 **Note:**
 > Replace `<Release-or-Debug>` with the necessary value.
-> Passing `--lockfile=src/conan.lock` pins dependency versions per _src/conan.lock_ (Conan Center `nmos-cpp` package graph).
+> Passing `--lockfile=src/conan.lock` pins dependency versions per `src/conan.lock` (Conan Center `nmos-cpp` package graph).
 > Do not pass `-g CMakeToolchain` or `-g CMakeDeps`; `src/conanfile.py` already generates them, and Conan fails if they are duplicated (for example when copying older command lines).
 
 ```sh
@@ -342,7 +345,7 @@ Use the following CMake command to configure the build.
 
 > 💬 **Note:**
 > Replace `<Release-or-Debug>` with the necessary value.
-> The `CMAKE_TOOLCHAIN_FILE` path is resolved relative to the top-level _src_ directory passed as the last argument.
+> The `CMAKE_TOOLCHAIN_FILE` path is resolved relative to the top-level `src` directory passed as the last argument.
 
 ```sh
 cmake -B build \
@@ -359,7 +362,7 @@ cmake --build build --parallel
 
 **Windows**
 
-Prepare a _build_ directory adjacent to the _src_ directory.
+Prepare a `build` directory adjacent to the `src` directory.
 
 ```PowerShell
 mkdir build
@@ -370,7 +373,7 @@ To install the dependencies using Conan, use the following command.
 > 💬 **Note:**
 > The `` ` `` is the PowerShell line continuation character. In the Windows command prompt, use `^` instead.
 > Replace `<Release-or-Debug>` with the necessary value.
-> Passing `--lockfile=src/conan.lock` pins dependency versions per _src/conan.lock_ (Conan Center `nmos-cpp` package graph).
+> Passing `--lockfile=src/conan.lock` pins dependency versions per `src/conan.lock` (Conan Center `nmos-cpp` package graph).
 > Do not pass `-g CMakeToolchain` or `-g CMakeDeps`; `src/conanfile.py` already generates them, and Conan fails if they are duplicated (for example when copying older command lines).
 
 ```PowerShell

--- a/rust/docs/gstreamer/README.md
+++ b/rust/docs/gstreamer/README.md
@@ -1,0 +1,100 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# GStreamer plugin documentation (Hotdoc)
+
+Builds official-style Hotdoc HTML for the `nmos` and `avsynctest` plugins
+(`gst-nmos-rs`, `gst-avsynctest-rs`).
+
+Published at [nvidia.github.io/nvnmos/gstreamer/](https://nvidia.github.io/nvnmos/gstreamer/)
+alongside the Doxygen C API.
+
+## Toolchain pins
+
+| Component | Pin | Notes |
+| --------- | --- | ----- |
+| Hotdoc | `~=0.18.0` | Enforced in `meson.build` and CI |
+| Lumen theme | 0.16 (sha256 in `meson.build`) | Downloaded at build time |
+| Plugin scanner | GStreamer **1.24.2** (`tools/`) | Vendored; newer scanner needs newer GStreamer API |
+| Sitemap generator | gst-docs **1.26.0** (`scripts/generate_sitemap.py`) | See below |
+
+`scripts/generate_sitemap.py` is from gst-docs 1.26 because that release uses
+`argparse` (`--input-sitemap`, …), which matches how our Meson `custom_target`
+invokes it. The 1.24 script expects positional arguments only and fails with
+Meson's flag-style command line.
+
+## Prerequisites
+
+Ubuntu / Debian packages:
+
+```sh
+sudo apt-get install -y \
+  meson ninja-build \
+  libgstreamer1.0-dev \
+  python3-dev libxml2-dev libxslt1-dev cmake libyaml-dev \
+  libjson-glib-dev flex
+```
+
+Hotdoc (virtualenv recommended):
+
+```sh
+python3 -m venv .venv-hotdoc
+. .venv-hotdoc/bin/activate
+pip install "hotdoc~=0.18.0"
+```
+
+Rust toolchain plus workspace dependencies (same as `rust/` CI).
+
+## Build
+
+```sh
+export CARGO_TARGET_DIR=/path/to/nvnmos/rust/target
+cd rust/docs/gstreamer
+meson setup build -Ddoc=enabled
+ninja -C build gstreamer-doc
+```
+
+HTML output: `build/NvNmos-GStreamer-doc/html/`
+
+## Refresh committed plugin cache
+
+When element properties or pad templates change, regenerate
+`plugins/gst_plugins_cache.json`:
+
+```sh
+./scripts/refresh-plugins-cache.sh
+git add plugins/gst_plugins_cache.json
+```
+
+The introspection tools under `tools/` are vendored from GStreamer 1.24.2
+(`gst-hotdoc-plugins-scanner.c`, `gst-plugins-doc-cache-generator.py`).
+
+## Site customisation (`theme/extra/`)
+
+Portal chrome (light-mode default, “View on GitHub” with octocat icon) lives in
+`theme/extra/` as Hotdoc `html_extra_theme` overlays — a small CSS/JS pair rather
+than a fork of the upstream navbar template. The octocat SVG uses `currentColor`
+so it follows navbar link colour in both light and dark mode.
+
+## Upgrading Hotdoc or the Lumen theme
+
+After bumping Hotdoc or `html_theme` in `meson.build`:
+
+1. Rebuild: `ninja -C build gstreamer-doc` and open `index.html` locally.
+2. Check the navbar: home icon, search, theme toggle, and **View on GitHub**
+   (right-aligned, octocat + label).
+3. Toggle dark/light mode; confirm the octocat remains visible and the sidebar
+   iframe tracks the theme.
+4. Spot-check portal Subpages (C API, gst-nmos-rs, Plugins) and one element
+   page per plugin.
+5. If the upstream navbar markup changed, adjust `theme/extra/js/extra_frontend.js`
+   (injection target / classes) and `theme/extra/css/extra_frontend.css` — do
+   **not** copy the whole `navbar.html` unless unavoidable.
+
+After bumping the vendored GStreamer scanner (`tools/`):
+
+1. Rebuild the scanner: `ninja -C build`.
+2. Regenerate the cache: `./scripts/refresh-plugins-cache.sh`.
+3. Re-run `ninja -C build gstreamer-doc` and diff element property tables.

--- a/rust/docs/gstreamer/meson.build
+++ b/rust/docs/gstreamer/meson.build
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+project(
+  'nvnmos-gstreamer-docs',
+  'c',
+  version: '0.1.0',
+  meson_version: '>= 1.2',
+  default_options: ['buildtype=plain'],
+)
+
+if get_option('doc').disabled()
+  subdir_done()
+endif
+
+if meson.is_cross_build()
+  error('GStreamer plugin documentation cannot be built while cross-compiling')
+endif
+
+build_hotdoc = false
+
+gst_dep = dependency('gstreamer-1.0', version: '>= 1.20')
+gio_dep = dependency('gio-2.0')
+
+cdir = meson.current_source_dir()
+rust_root = cdir / '..' / '..'
+plugins_cache = cdir / 'plugins' / 'gst_plugins_cache.json'
+build_plugins_cache = meson.current_build_dir() / 'gst_plugins_cache.json'
+if host_machine.system() == 'windows'
+  pathsep = ';'
+else
+  pathsep = ':'
+endif
+tools_dir = cdir / 'tools'
+build_plugins = find_program(cdir / 'scripts' / 'build-plugins.sh')
+
+hotdoc_plugin_scanner = executable(
+  'gst-hotdoc-plugins-scanner',
+  tools_dir / 'gst-hotdoc-plugins-scanner.c',
+  dependencies: [gst_dep, gio_dep],
+  install: false,
+)
+
+plugins_cache_generator = find_program(tools_dir / 'gst-plugins-doc-cache-generator.py')
+
+plugin_build = custom_target(
+  'gst-plugins-build',
+  command: [build_plugins],
+  output: 'plugins-built.stamp',
+  build_always_stale: true,
+)
+
+gstnmos_plugin = custom_target(
+  'libgstnmos.so',
+  command: [
+    'cp',
+    rust_root / 'target' / 'release' / 'libgstnmos.so',
+    '@OUTPUT@',
+  ],
+  output: 'libgstnmos.so',
+  depends: plugin_build,
+  build_always_stale: true,
+)
+
+gstavsynctest_plugin = custom_target(
+  'libgstavsynctest.so',
+  command: [
+    'cp',
+    rust_root / 'target' / 'release' / 'libgstavsynctest.so',
+    '@OUTPUT@',
+  ],
+  output: 'libgstavsynctest.so',
+  depends: plugin_build,
+  build_always_stale: true,
+)
+
+gst_plugins_doc_dep = custom_target(
+  'nvnmos-plugins-doc-cache',
+  command: [
+    plugins_cache_generator,
+    plugins_cache,
+    '@OUTPUT@',
+    gstnmos_plugin,
+    gstavsynctest_plugin,
+  ],
+  input: [gstnmos_plugin, gstavsynctest_plugin],
+  output: 'gst_plugins_cache.json',
+  env: {
+    'GST_HOTDOC_PLUGINS_SCANNER': hotdoc_plugin_scanner.full_path(),
+    'MESON_BUILD_ROOT': meson.current_build_dir(),
+    'GST_PLUGIN_PATH': meson.current_build_dir(),
+  },
+  depends: hotdoc_plugin_scanner,
+  build_always_stale: true,
+)
+
+hotdoc_p = find_program('hotdoc', required: get_option('doc'))
+if not hotdoc_p.found()
+  message('Hotdoc not found, not building GStreamer plugin documentation')
+  subdir_done()
+endif
+
+hotdoc_req_min = '>=0.18.0'
+hotdoc_req_max = '<0.19.0'
+hotdoc_version = run_command(hotdoc_p, '--version', check: false).stdout().strip()
+if not hotdoc_version.version_compare(hotdoc_req_min) or not hotdoc_version.version_compare(hotdoc_req_max)
+  error('Hotdoc @0@, <0.19.0 required, found @1@'.format(hotdoc_req_min, hotdoc_version))
+endif
+
+hotdoc = import('hotdoc')
+required_hotdoc_extensions = ['gst-extension']
+foreach extension: required_hotdoc_extensions
+  if not hotdoc.has_extensions(extension)
+    error('Hotdoc gst-extension missing (install hotdoc with system json-glib dev packages)')
+  endif
+endforeach
+
+build_hotdoc = true
+
+gst_nmos_rs_globs = [
+  rust_root / 'gst-nmos-rs' / 'src' / '*.rs',
+  rust_root / 'gst-nmos-rs' / 'src' / '*/*.rs',
+  rust_root / 'gst-nmos-rs' / 'src' / '*/*/*.rs',
+  rust_root / 'gst-nmos-rs' / 'src' / '*/*/*/*.rs',
+]
+
+gst_avsynctest_rs_globs = [
+  rust_root / 'gst-avsynctest-rs' / 'src' / '*.rs',
+  rust_root / 'gst-avsynctest-rs' / 'src' / '*/*.rs',
+  rust_root / 'gst-avsynctest-rs' / 'src' / '*/*/*.rs',
+]
+
+nmos_doc = hotdoc.generate_doc(
+  'nmos',
+  project_version: meson.project_version(),
+  sitemap: cdir / 'plugins' / 'sitemap.txt',
+  index: cdir / 'plugins' / 'nmos' / 'index.md',
+  gst_index: cdir / 'plugins' / 'nmos' / 'index.md',
+  gst_smart_index: true,
+  gst_c_sources: gst_nmos_rs_globs,
+  gst_cache_file: build_plugins_cache,
+  gst_plugin_name: 'nmos',
+  extra_assets: [rust_root / 'gst-nmos-rs' / 'images'],
+  dependencies: [gst_dep, gst_plugins_doc_dep, gstnmos_plugin],
+  install: false,
+)
+
+avsynctest_doc = hotdoc.generate_doc(
+  'avsynctest',
+  project_version: meson.project_version(),
+  sitemap: cdir / 'plugins' / 'sitemap.txt',
+  index: cdir / 'plugins' / 'avsynctest' / 'index.md',
+  gst_index: cdir / 'plugins' / 'avsynctest' / 'index.md',
+  gst_smart_index: true,
+  gst_c_sources: gst_avsynctest_rs_globs,
+  gst_cache_file: build_plugins_cache,
+  gst_plugin_name: 'avsynctest',
+  dependencies: [gst_dep, gst_plugins_doc_dep, gstavsynctest_plugin],
+  install: false,
+)
+
+sitemap_gen = find_program(cdir / 'scripts' / 'generate_sitemap.py')
+
+portal_sitemap = custom_target(
+  'portal-sitemap',
+  command: [
+    sitemap_gen,
+    '--input-sitemap', cdir / 'portal' / 'sitemap.txt',
+    '--output-sitemap', '@OUTPUT@',
+    '--markdown-index', 'index.md',
+    '--plugins', nmos_doc.full_path() + pathsep + avsynctest_doc.full_path(),
+  ],
+  depends: [nmos_doc, avsynctest_doc],
+  output: 'portal-sitemap.txt',
+)
+
+html_theme = 'https://github.com/hotdoc/hotdoc_lumen_theme/releases/download/0.16/hotdoc_lumen_theme-0.16.tar.xz?sha256=b7d7dde51285d1c90836c44ae298754e4cfa957e9a6d14ee5844b8a2cac04b5a'
+
+nvnmos_gstreamer_doc = hotdoc.generate_doc(
+  'NvNmos-GStreamer',
+  project_version: meson.project_version(),
+  sitemap: portal_sitemap,
+  index: cdir / 'portal' / 'index.md',
+  gst_index: cdir / 'portal' / 'plugins_doc.md',
+  html_theme: html_theme,
+  html_extra_theme: cdir / 'theme' / 'extra',
+  syntax_highlighting_activate: true,
+  gst_list_plugins_page: 'gst-index',
+  subprojects: [nmos_doc, avsynctest_doc],
+  dependencies: [portal_sitemap, nmos_doc, avsynctest_doc],
+  install: false,
+)
+
+alias_target('gstreamer-doc', nvnmos_gstreamer_doc)

--- a/rust/docs/gstreamer/meson_options.txt
+++ b/rust/docs/gstreamer/meson_options.txt
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+option('doc', type: 'feature', value: 'enabled',
+       description: 'Build Hotdoc HTML for NvNmos GStreamer plugins')

--- a/rust/docs/gstreamer/plugins/avsynctest/index.md
+++ b/rust/docs/gstreamer/plugins/avsynctest/index.md
@@ -1,0 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+short-description: Phase-locked A/V test sources GStreamer plugin
+...

--- a/rust/docs/gstreamer/plugins/gst_plugins_cache.json
+++ b/rust/docs/gstreamer/plugins/gst_plugins_cache.json
@@ -1,0 +1,1113 @@
+{
+    "avsynctest": {
+        "description": "Aligned audio/video test sources for sync testing",
+        "elements": {
+            "avsyncaudiotestsrc": {
+                "author": "NVIDIA Corporation",
+                "description": "Emits tone pips phase-locked to avsyncvideotestsrc for A/V sync testing",
+                "hierarchy": [
+                    "GstAvSyncAudioTestSrc",
+                    "GstPushSrc",
+                    "GstBaseSrc",
+                    "GstElement",
+                    "GstObject",
+                    "GInitiallyUnowned",
+                    "GObject"
+                ],
+                "klass": "Source/Audio",
+                "pad-templates": {
+                    "src": {
+                        "caps": "audio/x-raw:\n           rate: [ 1, 2147483647 ]\n       channels: [ 1, 2147483647 ]\n         layout: interleaved\n         format: { F32LE, S24BE, S16BE }\n",
+                        "direction": "src",
+                        "presence": "always"
+                    }
+                },
+                "properties": {
+                    "is-live": {
+                        "blurb": "Whether to pace output against the pipeline clock",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "false",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gboolean",
+                        "writable": true
+                    },
+                    "pip-duration": {
+                        "blurb": "Nanoseconds each tone pip lasts",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "4000000",
+                        "max": "18446744073709551615",
+                        "min": "1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "pip-freq": {
+                        "blurb": "Tone frequency of the pip in Hz",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "1000",
+                        "max": "1.79769e+308",
+                        "min": "1",
+                        "mutable": "playing",
+                        "readable": true,
+                        "type": "gdouble",
+                        "writable": true
+                    },
+                    "pip-interval": {
+                        "blurb": "Nanoseconds between pips (must match the video source)",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "1000000000",
+                        "max": "18446744073709551615",
+                        "min": "1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "pip-volume": {
+                        "blurb": "Peak amplitude of the pip (0.0-1.0)",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0.8",
+                        "max": "1",
+                        "min": "0",
+                        "mutable": "playing",
+                        "readable": true,
+                        "type": "gdouble",
+                        "writable": true
+                    },
+                    "samples-per-buffer": {
+                        "blurb": "Number of samples per output buffer",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "1024",
+                        "max": "-1",
+                        "min": "1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    }
+                },
+                "rank": "none"
+            },
+            "avsyncvideotestsrc": {
+                "author": "NVIDIA Corporation",
+                "description": "Emits a sweeping bar phase-locked to avsyncaudiotestsrc for A/V sync testing",
+                "hierarchy": [
+                    "GstAvSyncVideoTestSrc",
+                    "GstPushSrc",
+                    "GstBaseSrc",
+                    "GstElement",
+                    "GstObject",
+                    "GInitiallyUnowned",
+                    "GObject"
+                ],
+                "klass": "Source/Video",
+                "pad-templates": {
+                    "src": {
+                        "caps": "video/x-raw:\n         format: { v210, UYVP }\n          width: [ 1, 2147483647 ]\n         height: [ 1, 2147483647 ]\n      framerate: { (fraction)24000/1001, (fraction)24/1, (fraction)25/1, (fraction)30000/1001, (fraction)30/1, (fraction)50/1, (fraction)60000/1001, (fraction)60/1 }\n",
+                        "direction": "src",
+                        "presence": "always"
+                    }
+                },
+                "properties": {
+                    "framerate": {
+                        "blurb": "Default output framerate when downstream leaves it open",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "30000/1001",
+                        "max": "2147483647/1",
+                        "min": "1/1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstFraction",
+                        "writable": true
+                    },
+                    "height": {
+                        "blurb": "Default output height when downstream leaves it open",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "720",
+                        "max": "2147483647",
+                        "min": "1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gint",
+                        "writable": true
+                    },
+                    "is-live": {
+                        "blurb": "Whether to pace output against the pipeline clock",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "false",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gboolean",
+                        "writable": true
+                    },
+                    "pip-interval": {
+                        "blurb": "Nanoseconds between bar-centre crossings (must match the audio source)",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "1000000000",
+                        "max": "18446744073709551615",
+                        "min": "1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "width": {
+                        "blurb": "Default output width when downstream leaves it open",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "1280",
+                        "max": "2147483647",
+                        "min": "1",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gint",
+                        "writable": true
+                    }
+                },
+                "rank": "none"
+            }
+        },
+        "filename": "gstavsynctest",
+        "license": "Apache-2.0",
+        "other-types": {},
+        "package": "gst-avsynctest-rs",
+        "source": "gst-avsynctest-rs",
+        "tracers": {},
+        "url": "https://github.com/NVIDIA/nvnmos"
+    },
+    "nmos": {
+        "description": "GStreamer NMOS plugin (nmossrc / nmossink) talking to nvnmosd over gRPC",
+        "elements": {
+            "nmosaudiochannelmap": {
+                "author": "NVIDIA Corporation",
+                "description": "IS-08 channel mapping between NMOS audio streams, backed by nvnmosd",
+                "hierarchy": [
+                    "GstNmosAudioChannelMap",
+                    "GstBin",
+                    "GstElement",
+                    "GstObject",
+                    "GInitiallyUnowned",
+                    "GObject"
+                ],
+                "interfaces": [
+                    "GstChildProxy"
+                ],
+                "klass": "Filter/Audio/Network",
+                "pad-templates": {
+                    "sink_%%u": {
+                        "caps": "audio/x-raw:\n",
+                        "direction": "sink",
+                        "presence": "request",
+                        "type": "GstNmosAudioChannelMapSinkPad"
+                    },
+                    "src_%%u": {
+                        "caps": "audio/x-raw:\n",
+                        "direction": "src",
+                        "presence": "request",
+                        "type": "GstNmosAudioChannelMapSrcPad"
+                    }
+                },
+                "properties": {
+                    "channelmapping-name": {
+                        "blurb": "Caller-chosen name for this channel mapping within the Node. Unique per Node; identifies the Input/Output bundle added at NULL→READY. Not an IS-08 Input or Output id.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "daemon-uri": {
+                        "blurb": "gRPC endpoint for nvnmosd. Only `unix:/path/to/sock` URIs are currently supported.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "unix:/tmp/nvnmosd.sock",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "domain": {
+                        "blurb": "DNS domain for NMOS network services (`network_services.domain`). Use `local` to force mDNS. Empty (the default) leaves libnvnmos on automatic discovery. Not to be confused with `mxl-domain-id` / `mxl-domain-path`, which identify an MXL shared-memory Domain. Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "host-name": {
+                        "blurb": "NMOS Node host name (`node_config.host_name`). Empty (the default) leaves libnvnmos to autodetect. Honoured only by the OpenSession that actually creates the Node; ignored when attaching to a pre-existing Node with the same `node-seed`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "http-port": {
+                        "blurb": "TCP port libnvnmos serves the NMOS HTTP APIs on (node_config.http_port). 0 (the default) asks nvnmosd to allocate from NVNMOSD_HTTP_PORT_MIN..NVNMOSD_HTTP_PORT_MAX. Non-zero selects an explicit port (rejected when unavailable). Honoured only by the OpenSession that actually creates the Node — when attaching to a pre-existing Node (e.g. another nmossink / nmossrc opened first with the same node-seed) this property is ignored. The effective port is returned in OpenSessionResponse.http_port.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "65535",
+                        "min": "0",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    },
+                    "node-seed": {
+                        "blurb": "NvNmos Node seed (node_config.seed). Required. Sessions sharing this seed contribute to the same NMOS Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "registration-url": {
+                        "blurb": "Fixed IS-04 Registration API URL. Format: `http://host[:port]/x-nmos/registration/v<X.Y>[/]`. Parsed into `network_services.registration_*`; invalid URLs are logged and ignored. Empty (the default) leaves libnvnmos on DNS-SD discovery based on `host-name`. Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "restrict-routable-inputs": {
+                        "blurb": "When true, each Output's IS-08 /caps routable_inputs lists only this element's Input ids. When false (default), routable inputs are unrestricted on the IS-08 Output /caps endpoint.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "false",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gboolean",
+                        "writable": true
+                    },
+                    "system-url": {
+                        "blurb": "Fixed IS-09 System API URL. Format: `http://host[:port]/x-nmos/system/v<X.Y>[/]`. Parsed into `network_services.system_*`; invalid URLs are logged and ignored. Honoured only when `registration-url` is also set (libnvnmos ignores a standalone System API). Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    }
+                },
+                "rank": "none"
+            },
+            "nmossink": {
+                "author": "NVIDIA Corporation",
+                "description": "NMOS Sender wrapper element backed by nvnmosd",
+                "hierarchy": [
+                    "GstNmosSink",
+                    "GstBin",
+                    "GstElement",
+                    "GstObject",
+                    "GInitiallyUnowned",
+                    "GObject"
+                ],
+                "interfaces": [
+                    "GstChildProxy"
+                ],
+                "klass": "Sink/Network/NMOS",
+                "pad-templates": {
+                    "sink": {
+                        "caps": "ANY",
+                        "direction": "sink",
+                        "presence": "always"
+                    }
+                },
+                "properties": {
+                    "auto-activate": {
+                        "blurb": "When `true`, swap in the real transport sink or source (instead of the fake chain) once the configuring transport file has been resolved at NULL→READY (or READY→PAUSED for deferred senders), and call `SyncResourceState` so IS-04/IS-05 show active without an IS-05 PATCH. Does not force PLAYING — child state still follows the bin. Default `false`: add via AddSender / AddReceiver (visible on IS-04) but keep the fake chain until an external IS-05 controller activates the resource.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "false",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gboolean",
+                        "writable": true
+                    },
+                    "caps": {
+                        "blurb": "Essence caps for this Sender. Synthesises the configuring transport file when `transport-file*` is unset (MXL `flow_def` or SDP depending on `transport`). On `transport=mxl`, requires `mxl-flow-id`; supported shapes: v210 video, F32LE audio, `meta/x-st-2038` data. On RTP transports, requires the relevant IS-05 endpoint properties. When `transport-file*` is also set, the file wins and `caps` are cross-checked against it — mismatch is a hard error.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstCaps",
+                        "writable": true
+                    },
+                    "daemon-uri": {
+                        "blurb": "gRPC endpoint for nvnmosd. Only `unix:/path/to/sock` URIs are currently supported.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "unix:/tmp/nvnmosd.sock",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "description": {
+                        "blurb": "NMOS description for the Sender. Optional. Overrides the transport file when both are supplied (top-level `description` in an MXL `flow_def`; SDP `i=` line for RTP/UDP).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "destination-ip": {
+                        "blurb": "IS-05 sender transport_params `destination_ip`: remote destination (unicast peer or multicast group). Becomes the configuring SDP `c=` line address and `udpsink.host` on the RTP transports. Empty = unset (use the transport file's `c=` line if present; otherwise the daemon fills the IS-05 `auto` sentinel). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "destination-port": {
+                        "blurb": "IS-05 sender transport_params `destination_port`: remote destination port. Becomes the configuring SDP `m=` line port and `udpsink.port` on the RTP transports. 0 (the default) = unset; falls back to the transport file's `m=` port if present, else to the canonical RTP default 5004 (`nmos-cpp` `auto_rtp_port`). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "65535",
+                        "min": "0",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    },
+                    "domain": {
+                        "blurb": "DNS domain for NMOS network services (`network_services.domain`). Use `local` to force mDNS. Empty (the default) leaves libnvnmos on automatic discovery. Not to be confused with `mxl-domain-id` / `mxl-domain-path`, which identify an MXL shared-memory Domain. Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "format-bit-rate": {
+                        "blurb": "Coded essence (Flow) bit rate in kilobits per second (1000 bits/s), matching NMOS Flow `bit_rate` and SDP fmtp `x-nvnmos-format-bit-rate`. On JPEG XS RTP transports, synthesises the configuring SDP `a=fmtp:… x-nvnmos-format-bit-rate=` attribute and `b=AS:` (via the derived transport rate) and sets `rtpjxsvpay max-codestream-bitrate` to this value times 1000 (bit/s) unless `pay-properties` already supplies it. 0 (the default) = unset. When only one of `format-bit-rate` and `transport-bit-rate` is set, the other is derived using the same overhead factor as `nvnmosd` (AMWA BCP-006-01 / VSF TR-08 style). With a supplied `transport-file*`, cross-checks when both sides declare a rate and splices when the file omits it. Ignored on `transport=mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "18446744073709551615",
+                        "min": "0",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "group-hint": {
+                        "blurb": "NMOS group hint for the Sender (the `urn:x-nmos:tag:grouphint/v1.0` tag), e.g. `\"SDI 1:Video\"`. Becomes the `x-nvnmos-group-hint` session-level SDP attribute on RTP/UDP or the grouphint tag in an MXL `flow_def`. Overrides the transport file when both are supplied. Optional. Omitted when unset.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "host-name": {
+                        "blurb": "NMOS Node host name (`node_config.host_name`). Empty (the default) leaves libnvnmos to autodetect. Honoured only by the OpenSession that actually creates the Node; ignored when attaching to a pre-existing Node with the same `node-seed`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "http-port": {
+                        "blurb": "TCP port libnvnmos serves the NMOS HTTP APIs on (node_config.http_port). 0 (the default) asks nvnmosd to allocate from NVNMOSD_HTTP_PORT_MIN..NVNMOSD_HTTP_PORT_MAX. Non-zero selects an explicit port (rejected when unavailable). Honoured only by the OpenSession that actually creates the Node — when attaching to a pre-existing Node (e.g. another nmossink / nmossrc opened first with the same node-seed) this property is ignored. The effective port is returned in OpenSessionResponse.http_port.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "65535",
+                        "min": "0",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    },
+                    "label": {
+                        "blurb": "NMOS label for the Sender. Optional. Overrides the transport file when both are supplied (top-level `label` in an MXL `flow_def`; SDP `s=` line for RTP/UDP).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "mxl-domain-id": {
+                        "blurb": "MXL Domain identifier (UUID) included as `urn:x-nvnmos:tag:mxl-domain-id` in the transport file. Optional when transport=mxl: the path's `domain_def.json` `id` supplies it when present (for a `caps`-synthesised file; a supplied `transport-file*` keeps its own tag, cross-checked at activation); otherwise the tag is left application-resolved (`[\"\"]`) and the data plane uses `mxl-domain-path` locally. When supplied, overrides the transport file's tag. Cross-checked against `domain_def.json` when both are supplied (mismatch is an error). On `nmossrc`, set before NULL→READY; on `nmossink` it may also be set in READY for deferred AddSender.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "mxl-domain-path": {
+                        "blurb": "Local filesystem path identifying the MXL Domain on this host. If the directory contains a `domain_def.json` (AMWA BCP-007-03 WIP) its `id` is used to populate `mxl-domain-id` (or cross-checked against it when both are set). Without `domain_def.json`, an unset `mxl-domain-id` leaves the NMOS tag application-resolved while the data plane still uses this path. The path itself will be consumed by the inner `mxlsink` `domain=` property when the data path is wired up.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "mxl-flow-id": {
+                        "blurb": "MXL flow id (UUID) the inner `mxlsink` should push into. Overrides the transport file's top-level `id` when both are supplied.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "node-seed": {
+                        "blurb": "NvNmos Node seed (node_config.seed). Required. Sessions sharing this seed contribute to the same NMOS Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "pay-properties": {
+                        "blurb": "Overrides applied to the inner RTP payloader every time the UDP sender chain is built. Same `GstStructure` syntax as `transport-properties`; ignored on non-UDP transports (a warning is logged if non-empty). Takes effect on the next chain build.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstStructure",
+                        "writable": true
+                    },
+                    "registration-url": {
+                        "blurb": "Fixed IS-04 Registration API URL. Format: `http://host[:port]/x-nmos/registration/v<X.Y>[/]`. Parsed into `network_services.registration_*`; invalid URLs are logged and ignored. Empty (the default) leaves libnvnmos on DNS-SD discovery based on `host-name`. Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "sender-name": {
+                        "blurb": "Name for this Sender within the Node (becomes the `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` flow-def tag in the transport file). Unique across Senders on the Node; a Receiver on the same Node may share the same name (the daemon scopes names by side). Required unless the name is already carried in `transport-file*`. Overrides the transport file's value when both are supplied. The Sender's IS-04 id is derived from the name and the element's `node-seed`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "source-ip": {
+                        "blurb": "IS-05 sender transport_params `source_ip`: local egress NIC IP. Drives both the SDP `a=source-filter:` include-source (RFC 4607 SSM convention) and the `a=x-nvnmos-iface-ip:` attribute, and `udpsink.bind-address` on the RTP transports (`udp`, `udp2`, `nvdsudp`). Empty = unset (leave the daemon / SDP / IS-05 `auto` resolver to fill at activation time). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "source-port": {
+                        "blurb": "IS-05 sender transport_params `source_port`: local egress port. Drives `udpsink.bind-port` and the SDP `a=x-nvnmos-src-port:` attribute on the RTP transports. 0 (the default) = unset; the OS picks an ephemeral port. Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "65535",
+                        "min": "0",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    },
+                    "system-url": {
+                        "blurb": "Fixed IS-09 System API URL. Format: `http://host[:port]/x-nmos/system/v<X.Y>[/]`. Parsed into `network_services.system_*`; invalid URLs are logged and ignored. Honoured only when `registration-url` is also set (libnvnmos ignores a standalone System API). Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "transport": {
+                        "blurb": "Inner data path family. `mxl`: MXL shared-memory transport (`mxlsrc` / `mxlsink`). `udp`: ST 2110 over RTP/UDP via gst-plugins-good (`udpsrc` / `udpsink` + the `rtpvrawpay` / `rtpL24pay` / `rtpsmpte291pay` family). `udp2`: ST 2110 over RTP/UDP via gst-plugins-rs (`udpsrc2` + the `*pay2` / `*depay2` family where available, falling back to gst-plugins-good per-element). `nvdsudp`: ST 2110 via DeepStream's `nvdsudpsrc` / `nvdsudpsink` (Rivermax kernel-bypass, built-in RTP (de)payload, Mode 3). Requires ConnectX-5+ and the Rivermax SDK.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "mxl (0)",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstNmosTransport",
+                        "writable": true
+                    },
+                    "transport-bit-rate": {
+                        "blurb": "Transport (Sender) bit rate in kilobits per second (1000 bits/s), including RTP/UDP/IP overhead, matching NMOS Sender `bit_rate`, SDP `b=AS:`, and fmtp `x-nvnmos-transport-bit-rate`. On JPEG XS RTP transports, synthesises the configuring SDP `b=AS:` bandwidth line and `a=fmtp:… x-nvnmos-transport-bit-rate=` attribute. 0 (the default) = unset. When only one of `format-bit-rate` and `transport-bit-rate` is set, the other is derived using the same overhead factor as `nvnmosd`. With a supplied `transport-file*`, cross-checks when both sides declare a rate and splices when the file omits it. Ignored on `transport=mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "18446744073709551615",
+                        "min": "0",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "transport-caps": {
+                        "blurb": "Per-transport overrides (SDP fmtp-style). Typically empty for MXL.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstCaps",
+                        "writable": true
+                    },
+                    "transport-file": {
+                        "blurb": "Literal contents of the NvNmos transport file: MXL `flow_def` JSON for `transport=mxl`, SDP text for `transport=udp` / `udp2` / `nvdsudp`. The daemon adds the Sender via AddSender and re-publishes the transport file on IS-05 activation. Pass the text, not a path. Convenient for programmatic callers; from gst-launch use `transport-file-path` instead. Mutually exclusive with `transport-file-path`. When unset and `caps` is supplied the element synthesises a configuring transport file from the essence caps (MXL `flow_def` or SDP, depending on `transport`).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "transport-file-path": {
+                        "blurb": "Filesystem path read at NULL→READY into `transport-file`. Convenience for gst-launch; mutually exclusive with `transport-file`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "transport-properties": {
+                        "blurb": "Overrides applied to the inner source or sink (`udpsrc`, `udpsink`, `nvdsudpsrc`, `nvdsudpsink`, `mxlsrc`, or `mxlsink`) every time the data-path chain is built. Pass a `GstStructure` whose fields are GObject property names on that inner source or sink — for example `properties,buffer-size=26214400`. The structure name is not interpreted. Takes effect on the next chain build, not immediately on the one currently in the chain.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstStructure",
+                        "writable": true
+                    }
+                },
+                "rank": "none"
+            },
+            "nmossrc": {
+                "author": "NVIDIA Corporation",
+                "description": "NMOS Receiver wrapper element backed by nvnmosd",
+                "hierarchy": [
+                    "GstNmosSrc",
+                    "GstBin",
+                    "GstElement",
+                    "GstObject",
+                    "GInitiallyUnowned",
+                    "GObject"
+                ],
+                "interfaces": [
+                    "GstChildProxy"
+                ],
+                "klass": "Source/Network/NMOS",
+                "pad-templates": {
+                    "src": {
+                        "caps": "ANY",
+                        "direction": "src",
+                        "presence": "always"
+                    }
+                },
+                "properties": {
+                    "auto-activate": {
+                        "blurb": "When `true`, swap in the real transport sink or source (instead of the fake chain) once the configuring transport file has been resolved at NULL→READY (or READY→PAUSED for deferred senders), and call `SyncResourceState` so IS-04/IS-05 show active without an IS-05 PATCH. Does not force PLAYING — child state still follows the bin. Default `false`: add via AddSender / AddReceiver (visible on IS-04) but keep the fake chain until an external IS-05 controller activates the resource.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "false",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gboolean",
+                        "writable": true
+                    },
+                    "caps": {
+                        "blurb": "Essence caps for this Receiver. Required when `transport-file*` is unset; synthesises the configuring transport file (MXL `flow_def` or SDP depending on `transport`). On `transport=mxl`, requires `mxl-flow-id` (media-type structure name picks the matching `mxlsrc` flow-id slot); supported shapes: v210 video, F32LE audio, `meta/x-st-2038` data. On RTP transports, requires the relevant IS-05 endpoint properties. When `transport-file*` is also set, the file wins and `caps` are cross-checked against it — mismatch is a hard error.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "GstCaps",
+                        "writable": true
+                    },
+                    "daemon-uri": {
+                        "blurb": "gRPC endpoint for nvnmosd. Only `unix:/path/to/sock` URIs are currently supported.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "unix:/tmp/nvnmosd.sock",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "depay-properties": {
+                        "blurb": "Overrides applied to the inner RTP depayloader every time the UDP receiver chain is built. Same `GstStructure` syntax as `transport-properties`; ignored on non-UDP transports (a warning is logged if non-empty). Takes effect on the next chain build.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstStructure",
+                        "writable": true
+                    },
+                    "description": {
+                        "blurb": "NMOS description for the Receiver. Optional. Overrides the transport file when both are supplied (top-level `description` in an MXL `flow_def`; SDP `i=` line for RTP/UDP).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "destination-port": {
+                        "blurb": "IS-05 receiver transport_params `destination_port`: local listen port (becomes `udpsrc.port` and the SDP `m=` port slot). 0 (the default) = unset; falls back to the transport file's `m=` port if present, else to the canonical RTP default 5004 (`nmos-cpp` `auto_rtp_port`). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "65535",
+                        "min": "0",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    },
+                    "domain": {
+                        "blurb": "DNS domain for NMOS network services (`network_services.domain`). Use `local` to force mDNS. Empty (the default) leaves libnvnmos on automatic discovery. Not to be confused with `mxl-domain-id` / `mxl-domain-path`, which identify an MXL shared-memory Domain. Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "format-bit-rate": {
+                        "blurb": "Coded essence (Flow) bit rate in kilobits per second (1000 bits/s), matching NMOS Flow `bit_rate` and SDP fmtp `x-nvnmos-format-bit-rate`. On JPEG XS RTP transports, synthesises the configuring SDP `a=fmtp:… x-nvnmos-format-bit-rate=` attribute and `b=AS:` (via the derived transport rate) and sets `rtpjxsvpay max-codestream-bitrate` to this value times 1000 (bit/s) unless `pay-properties` already supplies it. 0 (the default) = unset. When only one of `format-bit-rate` and `transport-bit-rate` is set, the other is derived using the same overhead factor as `nvnmosd` (AMWA BCP-006-01 / VSF TR-08 style). With a supplied `transport-file*`, cross-checks when both sides declare a rate and splices when the file omits it. Ignored on `transport=mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "18446744073709551615",
+                        "min": "0",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "group-hint": {
+                        "blurb": "NMOS group hint for the Receiver (the `urn:x-nmos:tag:grouphint/v1.0` tag), e.g. `\"SDI 1:Video\"`. Becomes the `x-nvnmos-group-hint` session-level SDP attribute on RTP/UDP or the grouphint tag in an MXL `flow_def`. Overrides the transport file when both are supplied. Optional. Omitted when unset.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "host-name": {
+                        "blurb": "NMOS Node host name (`node_config.host_name`). Empty (the default) leaves libnvnmos to autodetect. Honoured only by the OpenSession that actually creates the Node; ignored when attaching to a pre-existing Node with the same `node-seed`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "http-port": {
+                        "blurb": "TCP port libnvnmos serves the NMOS HTTP APIs on (node_config.http_port). 0 (the default) asks nvnmosd to allocate from NVNMOSD_HTTP_PORT_MIN..NVNMOSD_HTTP_PORT_MAX. Non-zero selects an explicit port (rejected when unavailable). Honoured only by the OpenSession that actually creates the Node — when attaching to a pre-existing Node (e.g. another nmossink / nmossrc opened first with the same node-seed) this property is ignored. The effective port is returned in OpenSessionResponse.http_port.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "65535",
+                        "min": "0",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "guint",
+                        "writable": true
+                    },
+                    "interface-ip": {
+                        "blurb": "IS-05 receiver transport_params `interface_ip`: local NIC IP used for the IGMP join. Resolved to an interface name and fed into `udpsrc.multicast-iface` on the RTP transports. Also emitted in the configuring SDP as `a=x-nvnmos-iface-ip:`. Empty = unset (let the kernel pick). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "label": {
+                        "blurb": "NMOS label for the Receiver. Optional. Overrides the transport file when both are supplied (top-level `label` in an MXL `flow_def`; SDP `s=` line for RTP/UDP).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "multicast-ip": {
+                        "blurb": "IS-05 receiver transport_params `multicast_ip`: multicast group to join. Becomes `udpsrc.address` and the SDP `c=` line address on the RTP transports. Empty = unset (unicast reception). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "mxl-domain-id": {
+                        "blurb": "MXL Domain identifier (UUID) included as `urn:x-nvnmos:tag:mxl-domain-id` in the transport file. Optional when transport=mxl: the path's `domain_def.json` `id` supplies it when present (for a `caps`-synthesised file; a supplied `transport-file*` keeps its own tag, cross-checked at activation); otherwise the tag is left application-resolved (`[\"\"]`) and the data plane uses `mxl-domain-path` locally. When supplied, overrides the transport file's tag. Cross-checked against `domain_def.json` when both are supplied (mismatch is an error). On `nmossrc`, set before NULL→READY; on `nmossink` it may also be set in READY for deferred AddSender.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "mxl-domain-path": {
+                        "blurb": "Local filesystem path identifying the MXL Domain on this host. If the directory contains a `domain_def.json` (AMWA BCP-007-03 WIP) its `id` is used to populate `mxl-domain-id` (or cross-checked against it when both are set). Without `domain_def.json`, an unset `mxl-domain-id` leaves the NMOS tag application-resolved while the data plane still uses this path. Fed into the inner `mxlsrc` `domain=` property when the real inner chain is installed (after IS-05 activation, or at startup when `auto-activate=true`).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "mxl-flow-id": {
+                        "blurb": "MXL flow id (UUID) the inner `mxlsrc` should pull. An NMOS Receiver is normally configured by IS-05 PATCH activation, so this is mainly a development convenience: combined with `auto-activate=true` (plus `caps` and `mxl-domain-path`) the receiver starts up pre-bound to a known flow without an external controller. Overrides the transport file's top-level `id` when both are supplied.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "node-seed": {
+                        "blurb": "NvNmos Node seed (node_config.seed). Required. Sessions sharing this seed contribute to the same NMOS Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "receiver-caps-mode": {
+                        "blurb": "Whether the Receiver advertises BCP-004-01 Receiver Caps on IS-04 (narrow) or none (wide). On MXL, wide is encoded via `urn:x-nvnmos:tag:caps`; on RTP/UDP via media-level `a=x-nvnmos-caps:`. `auto` (default) leaves the marker untouched in the spliced transport file — narrow when absent (or with no transport file), wide when present. `narrow` strips it; `wide` ensures it is present (libnvnmos: present + non-empty = wide).",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "auto (0)",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "GstNmosCapsMode",
+                        "writable": true
+                    },
+                    "receiver-name": {
+                        "blurb": "Name for this Receiver within the Node (becomes the `x-nvnmos-name` SDP attribute or the `urn:x-nvnmos:tag:name` flow-def tag in the transport file). Unique across Receivers on the Node; a Sender on the same Node may share the same name (the daemon scopes names by side). Required unless the name is already carried in `transport-file*`. Overrides the transport file's value when both are supplied. The Receiver's IS-04 id is derived from the name and the element's `node-seed`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "registration-url": {
+                        "blurb": "Fixed IS-04 Registration API URL. Format: `http://host[:port]/x-nmos/registration/v<X.Y>[/]`. Parsed into `network_services.registration_*`; invalid URLs are logged and ignored. Empty (the default) leaves libnvnmos on DNS-SD discovery based on `host-name`. Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "source-ip": {
+                        "blurb": "IS-05 receiver transport_params `source_ip`: SSM include-source — the remote sender's IP. Drives the configuring SDP `a=source-filter:` include-source. On the `udp2` (gst-plugins-rs `udpsrc2`) variant this translates to `source-filter`; on the `udp` (gst-plugins-good `udpsrc`) variant it translates to `multicast-source`. Empty = unset (any-source multicast / unicast). Honoured only on the RTP transports; ignored on `mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "system-url": {
+                        "blurb": "Fixed IS-09 System API URL. Format: `http://host[:port]/x-nmos/system/v<X.Y>[/]`. Parsed into `network_services.system_*`; invalid URLs are logged and ignored. Honoured only when `registration-url` is also set (libnvnmos ignores a standalone System API). Honoured only by the OpenSession that creates the Node.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "transport": {
+                        "blurb": "Inner data path family. `mxl`: MXL shared-memory transport (`mxlsrc` / `mxlsink`). `udp`: ST 2110 over RTP/UDP via gst-plugins-good (`udpsrc` / `udpsink` + the `rtpvrawpay` / `rtpL24pay` / `rtpsmpte291pay` family). `udp2`: ST 2110 over RTP/UDP via gst-plugins-rs (`udpsrc2` + the `*pay2` / `*depay2` family where available, falling back to gst-plugins-good per-element). `nvdsudp`: ST 2110 via DeepStream's `nvdsudpsrc` / `nvdsudpsink` (Rivermax kernel-bypass, built-in RTP (de)payload, Mode 3). Requires ConnectX-5+ and the Rivermax SDK.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "mxl (0)",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "GstNmosTransport",
+                        "writable": true
+                    },
+                    "transport-bit-rate": {
+                        "blurb": "Transport (Sender) bit rate in kilobits per second (1000 bits/s), including RTP/UDP/IP overhead, matching NMOS Sender `bit_rate`, SDP `b=AS:`, and fmtp `x-nvnmos-transport-bit-rate`. On JPEG XS RTP transports, synthesises the configuring SDP `b=AS:` bandwidth line and `a=fmtp:… x-nvnmos-transport-bit-rate=` attribute. 0 (the default) = unset. When only one of `format-bit-rate` and `transport-bit-rate` is set, the other is derived using the same overhead factor as `nvnmosd`. With a supplied `transport-file*`, cross-checks when both sides declare a rate and splices when the file omits it. Ignored on `transport=mxl`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "0",
+                        "max": "18446744073709551615",
+                        "min": "0",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "guint64",
+                        "writable": true
+                    },
+                    "transport-caps": {
+                        "blurb": "Per-transport overrides (SDP fmtp-style). Typically empty for MXL.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "GstCaps",
+                        "writable": true
+                    },
+                    "transport-file": {
+                        "blurb": "Literal contents of the NvNmos transport file: MXL `flow_def` JSON for `transport=mxl`, SDP text for `transport=udp` / `udp2` / `nvdsudp`. The daemon adds the Receiver via AddReceiver and re-publishes the transport file on IS-05 activation. Pass the text, not a path. Convenient for programmatic callers; from gst-launch use `transport-file-path` instead. Mutually exclusive with `transport-file-path`. Required unless `caps` is provided.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "transport-file-path": {
+                        "blurb": "Filesystem path read at NULL→READY into `transport-file`. Convenience for gst-launch; mutually exclusive with `transport-file`.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "default": "",
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "gchararray",
+                        "writable": true
+                    },
+                    "transport-properties": {
+                        "blurb": "Overrides applied to the inner source or sink (`udpsrc`, `udpsink`, `nvdsudpsrc`, `nvdsudpsink`, `mxlsrc`, or `mxlsink`) every time the data-path chain is built. Pass a `GstStructure` whose fields are GObject property names on that inner source or sink — for example `properties,buffer-size=26214400`. The structure name is not interpreted. Takes effect on the next chain build, not immediately on the one currently in the chain.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "ready",
+                        "readable": true,
+                        "type": "GstStructure",
+                        "writable": true
+                    }
+                },
+                "rank": "none"
+            }
+        },
+        "filename": "gstnmos",
+        "license": "Apache-2.0",
+        "other-types": {},
+        "package": "gst-nmos-rs",
+        "source": "gst-nmos-rs",
+        "tracers": {},
+        "url": "https://github.com/NVIDIA/nvnmos"
+    }
+}

--- a/rust/docs/gstreamer/plugins/gst_plugins_cache.json.license
+++ b/rust/docs/gstreamer/plugins/gst_plugins_cache.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/rust/docs/gstreamer/plugins/nmos/index.md
+++ b/rust/docs/gstreamer/plugins/nmos/index.md
@@ -1,0 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+short-description: NMOS Sender/Receiver and audio channel mapping GStreamer plugin
+...

--- a/rust/docs/gstreamer/plugins/sitemap.txt
+++ b/rust/docs/gstreamer/plugins/sitemap.txt
@@ -1,0 +1,1 @@
+gst-index

--- a/rust/docs/gstreamer/plugins/sitemap.txt.license
+++ b/rust/docs/gstreamer/plugins/sitemap.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/rust/docs/gstreamer/portal/c-api.md
+++ b/rust/docs/gstreamer/portal/c-api.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+short-description: API reference for libnvnmos
+...
+
+<meta http-equiv="refresh" content="0; url=../index.html">
+
+# C API (libnvnmos)

--- a/rust/docs/gstreamer/portal/gst-nmos-rs.md
+++ b/rust/docs/gstreamer/portal/gst-nmos-rs.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+short-description: Operator runbooks and example pipelines
+...
+
+<meta http-equiv="refresh" content="0; url=https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/README.md">
+
+# gst-nmos-rs

--- a/rust/docs/gstreamer/portal/index.md
+++ b/rust/docs/gstreamer/portal/index.md
@@ -1,0 +1,12 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+short-description: NvNmos GStreamer reference
+...
+
+# NvNmos GStreamer Reference
+
+Reference for the GStreamer plugins in the NvNmos repository.

--- a/rust/docs/gstreamer/portal/plugins_doc.md
+++ b/rust/docs/gstreamer/portal/plugins_doc.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+---
+short-description: All NvNmos GStreamer plugins and elements
+...
+
+# Plugins

--- a/rust/docs/gstreamer/portal/sitemap.txt
+++ b/rust/docs/gstreamer/portal/sitemap.txt
@@ -1,0 +1,2 @@
+	c-api.md
+	gst-nmos-rs.md

--- a/rust/docs/gstreamer/portal/sitemap.txt.license
+++ b/rust/docs/gstreamer/portal/sitemap.txt.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/rust/docs/gstreamer/scripts/build-plugins.sh
+++ b/rust/docs/gstreamer/scripts/build-plugins.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+rust_root="$(cd "$(dirname "$0")/../../.." && pwd)"
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$rust_root/target}"
+
+cd "$rust_root"
+cargo build --release -p gst-nmos-rs -p gst-avsynctest-rs

--- a/rust/docs/gstreamer/scripts/generate_sitemap.py
+++ b/rust/docs/gstreamer/scripts/generate_sitemap.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Vendored from GStreamer gst-docs 1.26.0 (scripts/generate_sitemap.py).
+# The upstream file carries no per-file license header; the tags below record
+# the contributors per upstream git history and the module's license.
+#
+# SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Thibault Saunier <tsaunier@igalia.com>
+# SPDX-FileCopyrightText: Copyright (c) 2025 Mathieu Duponchelle <mathieu@centricular.com>
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import json
+import os
+from argparse import ArgumentParser
+from pathlib import Path as P
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument('--input-sitemap', type=P)
+    parser.add_argument('--output-sitemap', type=P)
+    parser.add_argument('--markdown-index', type=P)
+    parser.add_argument('--libs', type=str)
+    parser.add_argument('--plugins', type=str)
+    parser.add_argument('--plugin-configs', nargs='*', default=[])
+    parser.add_argument('--lib-configs', nargs='*', default=[])
+
+    args = parser.parse_args()
+
+    in_ = args.input_sitemap
+    out = args.output_sitemap
+    index_md = args.markdown_index
+    plugin_configs = args.plugin_configs
+    lib_configs = args.lib_configs
+
+    with open(in_) as f:
+        index = f.read()
+        index = '\n'.join(line for line in index.splitlines())
+
+        if args.libs is None:
+            libs = []
+        else:
+            libs = args.libs.split(os.pathsep)
+        for config in lib_configs:
+            with open(config) as f:
+                libs += json.load(f)
+
+        if args.plugins is None:
+            plugins = []
+        else:
+            plugins = args.plugins.replace('\n', '').split(os.pathsep)
+        for config in plugin_configs:
+            with open(config) as f:
+                plugins += json.load(f)
+        plugins = sorted(plugins, key=lambda x: os.path.basename(x))
+
+        if libs:
+            index += '\n\tlibs.md'
+            for lib in libs:
+                if not lib:
+                    continue
+                name = lib
+                if not name.endswith('.json'):
+                    name += '.json'
+                index += "\n\t\t" + name
+        if plugins:
+            index += '\n\tgst-index'
+            for plugin in plugins:
+                if not plugin:
+                    continue
+                fname = plugin
+                if not fname.endswith('.json'):
+                    fname += '.json'
+                index += "\n\t\t" + fname
+
+        index = '%s\n%s' % (index_md, index)
+
+        with open(out, 'w') as fw:
+            fw.write(index)

--- a/rust/docs/gstreamer/scripts/refresh-plugins-cache.sh
+++ b/rust/docs/gstreamer/scripts/refresh-plugins-cache.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+doc_root="$(cd "$(dirname "$0")/.." && pwd)"
+rust_root="$(cd "$doc_root/../.." && pwd)"
+tools_dir="$doc_root/tools"
+cache_file="$doc_root/plugins/gst_plugins_cache.json"
+build_cache="$doc_root/build/gst_plugins_cache.json"
+scanner="${GST_HOTDOC_PLUGINS_SCANNER:-$doc_root/build/gst-hotdoc-plugins-scanner}"
+generator="$tools_dir/gst-plugins-doc-cache-generator.py"
+
+export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$rust_root/target}"
+"$doc_root/scripts/build-plugins.sh"
+
+mkdir -p "$doc_root/build"
+export GST_HOTDOC_PLUGINS_SCANNER="$scanner"
+export GST_PLUGIN_PATH="$rust_root/target/release${GST_PLUGIN_PATH:+:$GST_PLUGIN_PATH}"
+export MESON_BUILD_ROOT="$doc_root/build"
+
+python3 "$generator" \
+  "$cache_file" \
+  "$build_cache" \
+  "$rust_root/target/release/libgstnmos.so" \
+  "$rust_root/target/release/libgstavsynctest.so"
+
+if ! cmp -s "$build_cache" "$cache_file"; then
+  cp "$build_cache" "$cache_file"
+  echo "Updated $cache_file"
+else
+  echo "Plugin cache unchanged"
+fi

--- a/rust/docs/gstreamer/theme/extra/css/extra_frontend.css
+++ b/rust/docs/gstreamer/theme/extra/css/extra_frontend.css
@@ -1,0 +1,15 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* #extra-menu raises specificity above Bootstrap's `.navbar-nav > li > a`,
+   which otherwise forces `display: block` and drops the icon to the baseline. */
+#extra-menu .nvnmos-github-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.35em;
+}
+
+#extra-menu .nvnmos-github-icon {
+	flex-shrink: 0;
+}

--- a/rust/docs/gstreamer/theme/extra/js/extra_frontend.js
+++ b/rust/docs/gstreamer/theme/extra/js/extra_frontend.js
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+(function () {
+	'use strict';
+
+	var GITHUB_REPO = 'https://github.com/NVIDIA/nvnmos';
+	var OCTOCAT_SVG =
+		'<svg class="nvnmos-github-icon" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">' +
+		'<path fill="currentColor" d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38' +
+		' 0-.27.01-1.13.01-2.2 0-.75-.25-1.29-.54-1.55 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12' +
+		' 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15' +
+		' 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67-.01-.27.41 0 .59.34.19.73.9.82 1.13.16.39.68 1.31 2.69.94' +
+		' 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path></svg>';
+
+	function defaultToLightMode() {
+		if (window.localStorage && !localStorage.getItem('hotdoc.style')) {
+			setActiveStyleSheet('light');
+		}
+	}
+
+	function addGitHubNavLink() {
+		if (document.getElementById('extra-menu')) {
+			return;
+		}
+
+		var wrapper = document.getElementById('navbar-wrapper');
+		if (!wrapper) {
+			return;
+		}
+
+		var menu = document.createElement('ul');
+		menu.className = 'nav navbar-nav navbar-right';
+		menu.id = 'extra-menu';
+		menu.innerHTML =
+			'<li><a class="nvnmos-github-link" href="' + GITHUB_REPO +
+			'" title="NvNmos on GitHub">' + OCTOCAT_SVG +
+			'<span>View on GitHub</span></a></li>';
+
+		var center = wrapper.querySelector('.navbar-center');
+		if (center) {
+			wrapper.insertBefore(menu, center);
+		} else {
+			wrapper.appendChild(menu);
+		}
+	}
+
+	defaultToLightMode();
+
+	if (window.jQuery) {
+		jQuery(document).ready(addGitHubNavLink);
+	} else {
+		document.addEventListener('DOMContentLoaded', addGitHubNavLink);
+	}
+})();

--- a/rust/docs/gstreamer/tools/gst-hotdoc-plugins-scanner.c
+++ b/rust/docs/gstreamer/tools/gst-hotdoc-plugins-scanner.c
@@ -1,0 +1,987 @@
+/* Vendored from GStreamer 1.24.2 (docs/gst-hotdoc-plugins-scanner.c).
+ * The upstream file carries no per-file license header; the SPDX tags below record
+ * the module's license (GStreamer core is LGPL-2.1-or-later) and the original
+ * author per upstream git history.
+ *
+ * SPDX-FileCopyrightText: Copyright (c) 2018 Thibault Saunier <tsaunier@igalia.com>
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+#include <locale.h>
+#include <glib/gprintf.h>
+#include <gst/gst.h>
+#include <gio/gio.h>
+#include <glib/gi18n.h>
+
+static GRegex *cleanup_caps_field = NULL;
+static void _add_object_details (GString * json, GString * other_types,
+    GHashTable * seen_other_types, GObject * object, GType gtype,
+    GType inst_type);
+
+static gchar *
+json_strescape (const gchar * str)
+{
+  const gchar *p;
+  const gchar *end;
+  GString *output;
+  gsize len;
+
+  if (!str)
+    return g_strdup ("NULL");
+
+  len = strlen (str);
+  end = str + len;
+  output = g_string_sized_new (len);
+
+  for (p = str; p < end; p++) {
+    if (*p == '\\' || *p == '"') {
+      g_string_append_c (output, '\\');
+      g_string_append_c (output, *p);
+    } else if (*p == '%') {
+      g_string_append_c (output, '%');
+      g_string_append_c (output, *p);
+    } else if ((*p > 0 && *p < 0x1f) || *p == 0x7f) {
+      switch (*p) {
+        case '\b':
+          g_string_append (output, "\\b");
+          break;
+        case '\f':
+          g_string_append (output, "\\f");
+          break;
+        case '\n':
+          g_string_append (output, "\\n");
+          break;
+        case '\r':
+          g_string_append (output, "\\r");
+          break;
+        case '\t':
+          g_string_append (output, "\\t");
+          break;
+        default:
+          g_string_append_printf (output, "\\u00%02x", (guint) * p);
+          break;
+      }
+    } else {
+      g_string_append_c (output, *p);
+    }
+  }
+
+  return g_string_free (output, FALSE);
+}
+
+static gchar *
+flags_to_string (GFlagsValue * values, guint flags)
+{
+  GString *s = NULL;
+  guint flags_left, i;
+
+  /* first look for an exact match and count the number of values */
+  for (i = 0; values[i].value_name != NULL; ++i) {
+    if (values[i].value == flags)
+      return g_strdup (values[i].value_nick);
+  }
+
+  s = g_string_new (NULL);
+
+  /* we assume the values are sorted from lowest to highest value */
+  flags_left = flags;
+  while (i > 0) {
+    --i;
+    if (values[i].value != 0
+        && (flags_left & values[i].value) == values[i].value) {
+      if (s->len > 0)
+        g_string_append_c (s, '+');
+      g_string_append (s, values[i].value_nick);
+      flags_left -= values[i].value;
+      if (flags_left == 0)
+        break;
+    }
+  }
+
+  if (s->len == 0)
+    g_string_assign (s, "(none)");
+
+  return g_string_free (s, FALSE);
+}
+
+static void
+_serialize_flags_default (GString * json, GType gtype, GValue * value)
+{
+  GFlagsValue *values = G_FLAGS_CLASS (g_type_class_ref (gtype))->values;
+  gchar *cur;
+
+  cur = flags_to_string (values, g_value_get_flags (value));
+  g_string_append_printf (json, ",\"default\": \"%s\"", cur);
+  g_free (cur);
+}
+
+static void
+_serialize_flags (GString * json, GType gtype)
+{
+  GFlagsValue *values = G_FLAGS_CLASS (g_type_class_ref (gtype))->values;
+
+  g_string_append_printf (json, "%s\"%s\": { "
+      "\"kind\": \"flags\"," "\"values\": [", json->len ? "," : "",
+      g_type_name (gtype));
+
+  while (values[0].value_name) {
+    gchar *value_name = json_strescape (values[0].value_name);
+    gchar *value_nick = json_strescape (values[0].value_nick);
+
+    g_string_append_printf (json, "{\"name\": \"%s\","
+        "\"value\": \"0x%08x\","
+        "\"desc\": \"%s\"}", value_nick, values[0].value, value_name);
+    ++values;
+
+    if (values[0].value_name)
+      g_string_append_c (json, ',');
+
+    g_free (value_name);
+    g_free (value_nick);
+  }
+
+  g_string_append (json, "]}");
+}
+
+static void
+_serialize_enum_default (GString * json, GType gtype, GValue * value)
+{
+  GEnumValue *values;
+  guint j = 0;
+  gint enum_value;
+  gchar *value_nick = g_strdup ("");
+
+  values = G_ENUM_CLASS (g_type_class_ref (gtype))->values;
+
+  enum_value = g_value_get_enum (value);
+  while (values[j].value_name) {
+    if (values[j].value == enum_value) {
+      g_free (value_nick);
+      value_nick = json_strescape (values[j].value_nick);
+      break;
+    }
+
+    j++;
+  }
+  g_string_append_printf (json, ",\"default\": \"%s (%d)\"", value_nick,
+      enum_value);;
+  g_free (value_nick);
+}
+
+static void
+_serialize_enum (GString * json, GType gtype, GstPluginAPIFlags api_flags)
+{
+  GEnumValue *values;
+  guint j = 0;
+
+  values = G_ENUM_CLASS (g_type_class_ref (gtype))->values;
+
+  g_string_append_printf (json, "%s\"%s\": { "
+      "\"kind\": \"enum\"", json->len ? "," : "", g_type_name (gtype));
+
+  if (api_flags & GST_PLUGIN_API_FLAG_IGNORE_ENUM_MEMBERS) {
+    g_string_append (json, ",\"ignore-enum-members\": true, \"values\": []}");
+  } else {
+    g_string_append (json, ",\"values\": [");
+
+    while (values[j].value_name) {
+      gchar *value_name = json_strescape (values[j].value_name);
+      gchar *value_nick = json_strescape (values[j].value_nick);
+
+      g_string_append_printf (json, "{\"name\": \"%s\","
+          "\"value\": \"%d\","
+          "\"desc\": \"%s\"}", value_nick, values[j].value, value_name);
+      j++;
+      if (values[j].value_name)
+        g_string_append_c (json, ',');
+
+      g_free (value_name);
+      g_free (value_nick);
+    }
+
+    g_string_append (json, "]}");
+  }
+}
+
+/* @inst_type is used when serializing base classes in the hierarchy:
+ * we don't instantiate the base class, which may very well be abstract,
+ * but instantiate the final type (@inst_type), and use @type to determine
+ * what properties / signals / etc.. we are actually interested in.
+ */
+static void
+_serialize_object (GString * json, GHashTable * seen_other_types, GType gtype,
+    GType inst_type)
+{
+  GObject *tmpobj;
+  GString *other_types = NULL;
+
+  g_string_append_printf (json, "%s\"%s\": { "
+      "\"kind\": \"%s\"", json->len ? "," : "", g_type_name (gtype),
+      G_TYPE_IS_INTERFACE (gtype) ? "interface" : "object");
+
+  other_types = g_string_new ("");
+  g_string_append_c (json, ',');
+  tmpobj = g_object_new (inst_type, NULL);
+  _add_object_details (json, other_types, seen_other_types, tmpobj, gtype,
+      inst_type);
+  gst_object_unref (tmpobj);
+
+  g_string_append_c (json, '}');
+
+  if (other_types && other_types->len) {
+    g_string_append_printf (json, ",%s", other_types->str);
+  }
+  g_string_free (other_types, TRUE);
+}
+
+static void
+_add_signals (GString * json, GString * other_types,
+    GHashTable * seen_other_types, GObject * object, GType type)
+{
+  gboolean opened = FALSE;
+  guint *signals = NULL;
+  guint nsignals;
+  gint i = 0, j;
+  GstPluginAPIFlags api_flags;
+
+  signals = g_signal_list_ids (type, &nsignals);
+  for (i = 0; i < nsignals; i++) {
+    GSignalQuery query = { 0, };
+
+    g_signal_query (signals[i], &query);
+    g_string_append_printf (json,
+        "%s\"%s\" : {", opened ? "," : ",\"signals\": {", query.signal_name);
+
+    opened = TRUE;
+
+    g_string_append (json, "\"args\": [");
+    for (j = 0; j < query.n_params; j++) {
+      gchar *arg_name = g_strdup_printf ("arg%u", j);
+      if (j) {
+        g_string_append_c (json, ',');
+      }
+
+      g_string_append_printf (json, "{ \"name\": \"%s\","
+          "\"type\": \"%s\" }", arg_name, g_type_name (query.param_types[j]));
+
+      if (!g_hash_table_contains (seen_other_types,
+              g_type_name (query.param_types[j])) &&
+          gst_type_is_plugin_api (query.param_types[j], &api_flags)) {
+        g_hash_table_insert (seen_other_types,
+            (gpointer) g_type_name (query.param_types[j]), NULL);
+
+        if (g_type_is_a (query.param_types[j], G_TYPE_ENUM)) {
+          _serialize_enum (other_types, query.param_types[j], api_flags);
+        } else if (g_type_is_a (query.param_types[j], G_TYPE_FLAGS)) {
+          _serialize_flags (other_types, query.param_types[j]);
+        } else if (g_type_is_a (query.param_types[j], G_TYPE_OBJECT)) {
+          _serialize_object (other_types, seen_other_types,
+              query.param_types[j], query.param_types[j]);
+        }
+      }
+    }
+    g_string_append_c (json, ']');
+
+    if (g_type_name (query.return_type) &&
+        !g_hash_table_contains (seen_other_types,
+            g_type_name (query.return_type)) &&
+        gst_type_is_plugin_api (query.return_type, &api_flags)) {
+      g_hash_table_insert (seen_other_types,
+          (gpointer) g_type_name (query.return_type), NULL);
+      if (g_type_is_a (query.return_type, G_TYPE_ENUM)) {
+        _serialize_enum (other_types, query.return_type, api_flags);
+      } else if (g_type_is_a (query.return_type, G_TYPE_FLAGS)) {
+        _serialize_flags (other_types, query.return_type);
+      } else if (g_type_is_a (query.return_type, G_TYPE_OBJECT)) {
+        _serialize_object (other_types, seen_other_types, query.return_type,
+            query.return_type);
+      }
+    }
+
+    g_string_append_printf (json,
+        ",\"return-type\": \"%s\"", g_type_name (query.return_type));
+
+    if (query.signal_flags & G_SIGNAL_RUN_FIRST)
+      g_string_append (json, ",\"when\": \"first\"");
+    else if (query.signal_flags & G_SIGNAL_RUN_LAST)
+      g_string_append (json, ",\"when\": \"last\"");
+    else if (query.signal_flags & G_SIGNAL_RUN_CLEANUP)
+      g_string_append (json, ",\"when\": \"cleanup\"");
+
+    if (query.signal_flags & G_SIGNAL_NO_RECURSE)
+      g_string_append (json, ",\"no-recurse\": true");
+
+    if (query.signal_flags & G_SIGNAL_DETAILED)
+      g_string_append (json, ",\"detailed\": true");
+
+    if (query.signal_flags & G_SIGNAL_ACTION)
+      g_string_append (json, ",\"action\": true");
+
+    if (query.signal_flags & G_SIGNAL_NO_HOOKS)
+      g_string_append (json, ",\"no-hooks\": true");
+
+    g_string_append_c (json, '}');
+
+    opened = TRUE;
+  }
+  g_free (signals);
+
+  if (opened)
+    g_string_append (json, "}");
+}
+
+static void
+_add_properties (GString * json, GString * other_types,
+    GHashTable * seen_other_types, GObject * object, GObjectClass * klass,
+    GType type)
+{
+  gchar *tmpstr;
+  guint i, n_props;
+  gboolean opened = FALSE;
+  GParamSpec **specs, *spec;
+  GstPluginAPIFlags api_flags;
+
+  specs = g_object_class_list_properties (klass, &n_props);
+
+  for (i = 0; i < n_props; i++) {
+    GValue value = { 0, };
+    const gchar *mutable_str = NULL;
+    spec = specs[i];
+
+    if (spec->owner_type != type)
+      continue;
+
+    g_value_init (&value, spec->value_type);
+    if (object && !!(spec->flags & G_PARAM_READABLE) &&
+        !(spec->flags & GST_PARAM_DOC_SHOW_DEFAULT)) {
+      g_object_get_property (G_OBJECT (object), spec->name, &value);
+    } else {
+      /* if we can't read the property value, assume it's set to the default
+       * (which might not be entirely true for sub-classes, but that's an
+       * unlikely corner-case anyway) */
+      g_param_value_set_default (spec, &value);
+    }
+
+    if (!opened)
+      g_string_append (json, ",\"properties\": {");
+
+    if ((spec->flags & GST_PARAM_MUTABLE_PLAYING)) {
+      mutable_str = "\"playing\"";
+    } else if ((spec->flags & GST_PARAM_MUTABLE_PAUSED)) {
+      mutable_str = "\"paused\"";
+    } else if ((spec->flags & GST_PARAM_MUTABLE_READY)) {
+      mutable_str = "\"ready\"";
+    } else {
+      mutable_str = "\"null\"";
+    }
+
+    tmpstr = json_strescape (g_param_spec_get_blurb (spec));
+    g_string_append_printf (json,
+        "%s"
+        "\"%s\": {"
+        "\"construct-only\": %s,"
+        "\"construct\": %s,"
+        "\"readable\": %s,"
+        "\"writable\": %s,"
+        "\"blurb\": \"%s\","
+        "\"controllable\": %s,"
+        "\"conditionally-available\": %s,"
+        "\"mutable\": %s,"
+        "\"type\": \"%s\"",
+        opened ? "," : "",
+        spec->name,
+        spec->flags & G_PARAM_CONSTRUCT_ONLY ? "true" : "false",
+        spec->flags & G_PARAM_CONSTRUCT ? "true" : "false",
+        spec->flags & G_PARAM_READABLE ? "true" : "false",
+        spec->flags & G_PARAM_WRITABLE ? "true" : "false", tmpstr,
+        spec->flags & GST_PARAM_CONTROLLABLE ? "true" : "false",
+        spec->flags & GST_PARAM_CONDITIONALLY_AVAILABLE ? "true" : "false",
+        mutable_str, g_type_name (G_PARAM_SPEC_VALUE_TYPE (spec)));
+    g_free (tmpstr);
+
+    if (!g_hash_table_contains (seen_other_types,
+            g_type_name (spec->value_type))
+        && gst_type_is_plugin_api (spec->value_type, &api_flags)) {
+      g_hash_table_insert (seen_other_types,
+          (gpointer) g_type_name (spec->value_type), NULL);
+      if (G_IS_PARAM_SPEC_ENUM (spec)) {
+        _serialize_enum (other_types, spec->value_type, api_flags);
+      } else if (G_IS_PARAM_SPEC_FLAGS (spec)) {
+        _serialize_flags (other_types, spec->value_type);
+      } else if (G_IS_PARAM_SPEC_OBJECT (spec)) {
+        GType inst_type = spec->value_type;
+        GObject *obj = g_value_get_object (&value);
+
+        if (obj) {
+          inst_type = G_OBJECT_TYPE (obj);
+        }
+
+        _serialize_object (other_types, seen_other_types, spec->value_type,
+            inst_type);
+      }
+    }
+
+    switch (G_VALUE_TYPE (&value)) {
+      case G_TYPE_STRING:
+      {
+        const char *string_val = g_value_get_string (&value);
+        gchar *tmpstr = json_strescape (string_val);
+
+        g_string_append_printf (json, ",\"default\": \"%s\"", tmpstr);;
+        g_free (tmpstr);
+        break;
+      }
+      case G_TYPE_BOOLEAN:
+      {
+        gboolean bool_val = g_value_get_boolean (&value);
+
+        g_string_append_printf (json, ",\"default\": \"%s\"",
+            bool_val ? "true" : "false");
+        break;
+      }
+      case G_TYPE_ULONG:
+      {
+        GParamSpecULong *pulong = G_PARAM_SPEC_ULONG (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%lu\""
+            ",\"min\": \"%lu\""
+            ",\"max\": \"%lu\"",
+            g_value_get_ulong (&value), pulong->minimum, pulong->maximum);
+
+        GST_ERROR_OBJECT (object,
+            "property '%s' of type ulong: consider changing to " "uint/uint64",
+            g_param_spec_get_name (spec));
+        break;
+      }
+      case G_TYPE_LONG:
+      {
+        GParamSpecLong *plong = G_PARAM_SPEC_LONG (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%ld\""
+            ",\"min\": \"%ld\""
+            ",\"max\": \"%ld\"",
+            g_value_get_long (&value), plong->minimum, plong->maximum);
+
+        GST_ERROR_OBJECT (object,
+            "property '%s' of type long: consider changing to " "int/int64",
+            g_param_spec_get_name (spec));
+        break;
+      }
+      case G_TYPE_UINT:
+      {
+        GParamSpecUInt *puint = G_PARAM_SPEC_UINT (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%d\""
+            ",\"min\": \"%d\""
+            ",\"max\": \"%d\"",
+            g_value_get_uint (&value), puint->minimum, puint->maximum);
+        break;
+      }
+      case G_TYPE_INT:
+      {
+        GParamSpecInt *pint = G_PARAM_SPEC_INT (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%d\""
+            ",\"min\": \"%d\""
+            ",\"max\": \"%d\"",
+            g_value_get_int (&value), pint->minimum, pint->maximum);
+        break;
+      }
+      case G_TYPE_UINT64:
+      {
+        GParamSpecUInt64 *puint64 = G_PARAM_SPEC_UINT64 (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%" G_GUINT64_FORMAT
+            "\",\"min\": \"%" G_GUINT64_FORMAT
+            "\",\"max\": \"%" G_GUINT64_FORMAT "\"",
+            g_value_get_uint64 (&value), puint64->minimum, puint64->maximum);
+        break;
+      }
+      case G_TYPE_INT64:
+      {
+        GParamSpecInt64 *pint64 = G_PARAM_SPEC_INT64 (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%" G_GUINT64_FORMAT
+            "\",\"min\": \"%" G_GINT64_FORMAT
+            "\",\"max\": \"%" G_GINT64_FORMAT "\"",
+            g_value_get_int64 (&value), pint64->minimum, pint64->maximum);
+        break;
+      }
+      case G_TYPE_FLOAT:
+      {
+        GParamSpecFloat *pfloat = G_PARAM_SPEC_FLOAT (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%g\""
+            ",\"min\": \"%g\""
+            ",\"max\": \"%g\"",
+            g_value_get_float (&value), pfloat->minimum, pfloat->maximum);
+        break;
+      }
+      case G_TYPE_DOUBLE:
+      {
+        GParamSpecDouble *pdouble = G_PARAM_SPEC_DOUBLE (spec);
+
+        g_string_append_printf (json,
+            ",\"default\": \"%g\""
+            ",\"min\": \"%g\""
+            ",\"max\": \"%g\"",
+            g_value_get_double (&value), pdouble->minimum, pdouble->maximum);
+        break;
+      }
+      case G_TYPE_CHAR:
+      case G_TYPE_UCHAR:
+        GST_ERROR_OBJECT (object,
+            "property '%s' of type char: consider changing to " "int/string",
+            g_param_spec_get_name (spec));
+        /* fall through */
+      default:
+        if (spec->value_type == GST_TYPE_CAPS) {
+          const GstCaps *caps = gst_value_get_caps (&value);
+
+          if (caps) {
+            gchar *capsstr = gst_caps_to_string (caps);
+            gchar *tmpcapsstr = json_strescape (capsstr);
+
+            g_string_append_printf (json, ",\"default\": \"%s\"", tmpcapsstr);
+            g_free (capsstr);
+            g_free (tmpcapsstr);
+          }
+        } else if (G_IS_PARAM_SPEC_BOXED (spec)) {
+          if (spec->value_type == GST_TYPE_STRUCTURE) {
+            const GstStructure *s = gst_value_get_structure (&value);
+            if (s) {
+              gchar *str = gst_structure_to_string (s);
+              gchar *tmpstr = json_strescape (str);
+
+              g_string_append_printf (json, ",\"default\": \"%s\"", tmpstr);
+              g_free (str);
+              g_free (tmpstr);
+            }
+          }
+        } else if (GST_IS_PARAM_SPEC_FRACTION (spec)) {
+          GstParamSpecFraction *pfraction = GST_PARAM_SPEC_FRACTION (spec);
+
+          g_string_append_printf (json,
+              ",\"default\": \"%d/%d\""
+              ",\"min\": \"%d/%d\""
+              ",\"max\": \"%d/%d\"",
+              gst_value_get_fraction_numerator (&value),
+              gst_value_get_fraction_denominator (&value),
+              pfraction->min_num, pfraction->min_den,
+              pfraction->max_num, pfraction->max_den);
+        } else if (G_IS_PARAM_SPEC_ENUM (spec)) {
+          _serialize_enum_default (json, spec->value_type, &value);
+        } else if (G_IS_PARAM_SPEC_FLAGS (spec)) {
+          _serialize_flags_default (json, spec->value_type, &value);
+        }
+        break;
+    }
+
+    g_string_append_c (json, '}');
+
+
+    opened = TRUE;
+  }
+
+  if (opened)
+    g_string_append (json, "}");
+
+}
+
+static gboolean
+print_field (GQuark field, const GValue * value, GString * jcaps)
+{
+  gchar *tmp, *str = gst_value_serialize (value);
+
+  if (!g_strcmp0 (g_quark_to_string (field), "format") ||
+      !g_strcmp0 (g_quark_to_string (field), "rate")) {
+    if (!cleanup_caps_field)
+      cleanup_caps_field = g_regex_new ("\\(string\\)|\\(rate\\)", 0, 0, NULL);
+
+    tmp = str;
+    str = g_regex_replace (cleanup_caps_field, str, -1, 0, "", 0, NULL);;
+    g_free (tmp);
+  }
+
+  g_string_append_printf (jcaps, "%15s: %s\n", g_quark_to_string (field), str);
+  g_free (str);
+  return TRUE;
+}
+
+static gchar *
+_build_caps (const GstCaps * caps)
+{
+  guint i;
+  gchar *res;
+  GString *jcaps = g_string_new (NULL);
+
+  if (gst_caps_is_any (caps)) {
+    g_string_append (jcaps, "ANY");
+    return g_string_free (jcaps, FALSE);
+  }
+
+  if (gst_caps_is_empty (caps)) {
+    g_string_append (jcaps, "EMPTY");
+    return g_string_free (jcaps, FALSE);
+  }
+
+  for (i = 0; i < gst_caps_get_size (caps); i++) {
+    GstStructure *structure = gst_caps_get_structure (caps, i);
+    GstCapsFeatures *features = gst_caps_get_features (caps, i);
+
+    if (features && (gst_caps_features_is_any (features) ||
+            !gst_caps_features_is_equal (features,
+                GST_CAPS_FEATURES_MEMORY_SYSTEM_MEMORY))) {
+      gchar *features_string = gst_caps_features_to_string (features);
+
+      g_string_append_printf (jcaps, "%s%s(%s):\n",
+          i ? "\n" : "", gst_structure_get_name (structure), features_string);
+      g_free (features_string);
+    } else {
+      g_string_append_printf (jcaps, "%s:\n",
+          gst_structure_get_name (structure));
+    }
+    gst_structure_foreach (structure, (GstStructureForeachFunc) print_field,
+        jcaps);
+  }
+
+  res = json_strescape (jcaps->str);
+  g_string_free (jcaps, TRUE);
+
+  return res;
+}
+
+static void
+_add_element_pad_templates (GString * json, GString * other_types,
+    GHashTable * seen_other_types, GstElement * element,
+    GstElementFactory * factory)
+{
+  gboolean opened = FALSE;
+  const GList *pads;
+  GstStaticPadTemplate *padtemplate;
+  GRegex *re = g_regex_new ("%", 0, 0, NULL);
+  GstPluginAPIFlags api_flags;
+
+  pads = gst_element_factory_get_static_pad_templates (factory);
+  while (pads) {
+    GstCaps *documentation_caps;
+    gchar *name, *caps;
+    GType pad_type;
+    GstPadTemplate *tmpl;
+    padtemplate = (GstStaticPadTemplate *) (pads->data);
+    pads = g_list_next (pads);
+
+    tmpl = gst_element_class_get_pad_template (GST_ELEMENT_GET_CLASS (element),
+        padtemplate->name_template);
+
+    name = g_regex_replace (re, padtemplate->name_template,
+        -1, 0, "%%", 0, NULL);;
+    documentation_caps = gst_pad_template_get_documentation_caps (tmpl);
+    caps = _build_caps (documentation_caps);
+    gst_caps_replace (&documentation_caps, NULL);
+    g_string_append_printf (json, "%s"
+        "\"%s\": {"
+        "\"caps\": \"%s\","
+        "\"direction\": \"%s\","
+        "\"presence\": \"%s\"",
+        opened ? "," : ",\"pad-templates\": {",
+        name, caps,
+        padtemplate->direction ==
+        GST_PAD_SRC ? "src" : padtemplate->direction ==
+        GST_PAD_SINK ? "sink" : "unknown",
+        padtemplate->presence ==
+        GST_PAD_ALWAYS ? "always" : padtemplate->presence ==
+        GST_PAD_SOMETIMES ? "sometimes" : padtemplate->presence ==
+        GST_PAD_REQUEST ? "request" : "unknown");
+    opened = TRUE;
+    g_free (name);
+
+    pad_type = GST_PAD_TEMPLATE_GTYPE (tmpl);
+    if (pad_type != G_TYPE_NONE && pad_type != GST_TYPE_PAD) {
+      g_string_append_printf (json, ", \"type\": \"%s\"",
+          g_type_name (pad_type));
+
+      if (!g_hash_table_contains (seen_other_types, g_type_name (pad_type))
+          && gst_type_is_plugin_api (pad_type, &api_flags)) {
+        g_hash_table_insert (seen_other_types,
+            (gpointer) g_type_name (pad_type), NULL);
+        _serialize_object (other_types, seen_other_types, pad_type, pad_type);
+      }
+    }
+    g_string_append_c (json, '}');
+  }
+  if (opened)
+    g_string_append_c (json, '}');
+
+  g_regex_unref (re);
+}
+
+static const char *
+get_rank_name (char *s, gint rank)
+{
+  static const int ranks[4] = {
+    GST_RANK_NONE, GST_RANK_MARGINAL, GST_RANK_SECONDARY, GST_RANK_PRIMARY
+  };
+  static const char *rank_names[4] = { "none", "marginal", "secondary",
+    "primary"
+  };
+  int i;
+  int best_i;
+
+  best_i = 0;
+  for (i = 0; i < 4; i++) {
+    if (rank == ranks[i])
+      return rank_names[i];
+    if (abs (rank - ranks[i]) < abs (rank - ranks[best_i])) {
+      best_i = i;
+    }
+  }
+
+  sprintf (s, "%s %c %d", rank_names[best_i],
+      (rank - ranks[best_i] > 0) ? '+' : '-', abs (ranks[best_i] - rank));
+
+  return s;
+}
+
+static void
+_add_factory_details (GString * json, GstElementFactory * factory)
+{
+  gchar **keys, **k;
+  gboolean f = TRUE;
+
+  keys = gst_element_factory_get_metadata_keys (factory);
+  if (keys != NULL) {
+    for (k = keys; *k != NULL; ++k) {
+      gchar *val;
+      gchar *key = *k;
+
+      /* "long-name" can be varying depending on environment, skip this */
+      if (g_strcmp0 (key, "long-name") == 0)
+        continue;
+
+      val = json_strescape (gst_element_factory_get_metadata (factory, key));
+      g_string_append_printf (json, "%s\"%s\": \"%s\"", f ? "" : ",", key, val);
+      f = FALSE;
+      g_free (val);
+    }
+    g_strfreev (keys);
+    g_string_append (json, ",");
+  }
+}
+
+static void
+_add_object_details (GString * json, GString * other_types,
+    GHashTable * seen_other_types, GObject * object, GType type,
+    GType inst_type)
+{
+  GType *interfaces;
+  guint n_interfaces;
+  GType ptype = type;
+
+  g_string_append (json, "\"hierarchy\": [");
+
+  for (;; ptype = g_type_parent (ptype)) {
+    g_string_append_printf (json, "\"%s\"%c", g_type_name (ptype),
+        ((ptype == G_TYPE_OBJECT || ptype == G_TYPE_INTERFACE) ? ' ' : ','));
+
+    if (!g_hash_table_contains (seen_other_types, g_type_name (ptype))
+        && gst_type_is_plugin_api (ptype, NULL)) {
+      g_hash_table_insert (seen_other_types, (gpointer) g_type_name (ptype),
+          NULL);
+      _serialize_object (other_types, seen_other_types, ptype, inst_type);
+    }
+
+    if (ptype == G_TYPE_OBJECT || ptype == G_TYPE_INTERFACE)
+      break;
+  }
+  g_string_append (json, "]");
+
+  interfaces = g_type_interfaces (type, &n_interfaces);
+  if (n_interfaces) {
+    GType *iface;
+
+    g_string_append (json, ",\"interfaces\": [");
+    for (iface = interfaces; *iface; iface++, n_interfaces--) {
+      g_string_append_printf (json, "\"%s\"%c", g_type_name (*iface),
+          n_interfaces > 1 ? ',' : ' ');
+
+      if (!g_hash_table_contains (seen_other_types, g_type_name (*iface))
+          && gst_type_is_plugin_api (*iface, NULL)) {
+        g_hash_table_insert (seen_other_types, (gpointer) g_type_name (*iface),
+            NULL);
+        _serialize_object (other_types, seen_other_types, *iface, inst_type);
+      }
+    }
+
+    g_string_append (json, "]");
+    g_free (interfaces);
+  }
+
+  _add_properties (json, other_types, seen_other_types, object,
+      G_OBJECT_GET_CLASS (object), type);
+  _add_signals (json, other_types, seen_other_types, object, type);
+}
+
+static void
+_add_element_details (GString * json, GString * other_types,
+    GHashTable * seen_other_types, GstPluginFeature * feature)
+{
+  GstElement *element =
+      gst_element_factory_create (GST_ELEMENT_FACTORY (feature), NULL);
+  char s[20];
+
+  if (!element)
+    g_error ("Couldn't not make `%s`", GST_OBJECT_NAME (feature));
+
+  g_string_append_printf (json,
+      "\"%s\": {"
+      "\"rank\":\"%s\",",
+      GST_OBJECT_NAME (feature),
+      get_rank_name (s, gst_plugin_feature_get_rank (feature)));
+
+  _add_factory_details (json, GST_ELEMENT_FACTORY (feature));
+  _add_object_details (json, other_types, seen_other_types, G_OBJECT (element),
+      G_OBJECT_TYPE (element), G_OBJECT_TYPE (element));
+
+  _add_element_pad_templates (json, other_types, seen_other_types, element,
+      GST_ELEMENT_FACTORY (feature));
+
+  g_string_append (json, "}");
+}
+
+int
+main (int argc, char *argv[])
+{
+  gchar *libfile;
+  GError *error = NULL;
+  GString *json;
+  GString *other_types;
+  GHashTable *seen_other_types;
+  GstPlugin *plugin;
+  gboolean f = TRUE;
+  GList *features, *tmp;
+  gint i;
+  gboolean first = TRUE;
+  GError *err = NULL;
+
+  g_assert (argc >= 3);
+
+  setlocale (LC_ALL, "");
+  setlocale (LC_NUMERIC, "C");
+
+#ifdef ENABLE_NLS
+  bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+  bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+  textdomain (GETTEXT_PACKAGE);
+#endif
+
+  gst_init (NULL, NULL);
+
+  json = g_string_new ("{");
+  for (i = 2; i < argc; i++) {
+    gchar *basename, **splitext, *filename;
+    libfile = argv[i];
+    plugin = gst_plugin_load_file (libfile, &error);
+    if (!plugin) {
+      g_printerr ("%s could not be loaded as a GstPlugin: %s", libfile,
+          error->message ? error->message : "no known reasons");
+      g_clear_error (&error);
+
+      continue;
+    }
+
+    other_types = g_string_new ("");
+    seen_other_types = g_hash_table_new (g_str_hash, g_str_equal);
+
+    basename = g_filename_display_basename (libfile);
+    splitext = g_strsplit (basename, ".", 2);
+    filename =
+        g_str_has_prefix (splitext[0], "lib") ? &splitext[0][3] : splitext[0];
+    g_string_append_printf (json,
+        "%s\"%s\": {"
+        "\"description\":\"%s\","
+        "\"filename\":\"%s\","
+        "\"source\":\"%s\","
+        "\"package\":\"%s\","
+        "\"license\":\"%s\","
+        "\"url\":\"%s\","
+        "\"elements\":{",
+        first ? "" : ",",
+        gst_plugin_get_name (plugin),
+        gst_plugin_get_description (plugin),
+        filename,
+        gst_plugin_get_source (plugin),
+        gst_plugin_get_package (plugin),
+        gst_plugin_get_license (plugin), gst_plugin_get_origin (plugin));
+    g_free (basename);
+    g_strfreev (splitext);
+    first = FALSE;
+
+    features =
+        gst_registry_get_feature_list_by_plugin (gst_registry_get (),
+        gst_plugin_get_name (plugin));
+
+    f = TRUE;
+    for (tmp = features; tmp; tmp = tmp->next) {
+      GstPluginFeature *feature = tmp->data;
+      if (GST_IS_ELEMENT_FACTORY (feature)) {
+        GstElementFactory *factory = GST_ELEMENT_FACTORY (feature);
+        if (gst_element_factory_get_skip_documentation (factory))
+          continue;
+
+        if (!f)
+          g_string_append_printf (json, ",");
+        _add_element_details (json, other_types, seen_other_types, feature);
+        f = FALSE;
+      }
+    }
+
+    g_string_append (json, "}, \"tracers\": {");
+    gst_plugin_feature_list_free (features);
+
+    f = TRUE;
+    features =
+        gst_registry_get_feature_list_by_plugin (gst_registry_get (),
+        gst_plugin_get_name (plugin));
+    for (tmp = features; tmp; tmp = tmp->next) {
+      GstPluginFeature *feature = tmp->data;
+
+      if (GST_IS_TRACER_FACTORY (feature)) {
+        if (!f)
+          g_string_append_printf (json, ",");
+        g_string_append_printf (json, "\"%s\": {}", GST_OBJECT_NAME (feature));
+        f = FALSE;
+      }
+    }
+    g_string_append_printf (json, "}, \"other-types\": {%s}}",
+        other_types->str);
+    gst_plugin_feature_list_free (features);
+
+    g_hash_table_unref (seen_other_types);
+    g_string_free (other_types, TRUE);
+  }
+
+  g_string_append_c (json, '}');
+  if (!g_file_set_contents (argv[1], json->str, -1, &err)) {
+    g_printerr ("Could not set json to %s: %s", argv[1], err->message);
+    g_clear_error (&err);
+
+    return -1;
+  }
+  g_string_free (json, TRUE);
+
+  return 0;
+}

--- a/rust/docs/gstreamer/tools/gst-plugins-doc-cache-generator.py
+++ b/rust/docs/gstreamer/tools/gst-plugins-doc-cache-generator.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Vendored from GStreamer 1.24.2 (docs/gst-plugins-doc-cache-generator.py).
+# The upstream copyright and license notice below is preserved verbatim; only
+# the SPDX tags are added.
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Copyright © 2018 Thibault Saunier <tsaunier@igalia.com>
+#
+# This library is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import json
+import os
+import sys
+import re
+import subprocess
+import tempfile
+from pathlib import Path as P
+from argparse import ArgumentParser
+
+from collections import OrderedDict
+try:
+    from collections.abc import Mapping
+except ImportError:  # python <3.3
+    from collections import Mapping
+
+
+class GstPluginsHotdocConfGen:
+    def __init__(self):
+
+        parser = ArgumentParser()
+        parser.add_argument('--builddir', type=P)
+        parser.add_argument('--gst_cache_file', type=P)
+        parser.add_argument('--sitemap', type=P)
+        parser.add_argument('--index', type=P)
+        parser.add_argument('--c_flags')
+        parser.add_argument('--gst_index', type=P)
+        parser.add_argument('--gst_c_sources', nargs='*', default=[])
+        parser.add_argument('--project_version')
+        parser.add_argument('--include_paths', nargs='*', default=[])
+        parser.add_argument('--gst_c_source_filters', nargs='*', default=[])
+
+        parser.parse_args(namespace=self, args=sys.argv[2:])
+
+    def generate_plugins_configs(self):
+        plugin_files = []
+        with self.gst_cache_file.open() as fd:
+            all_plugins = json.load(fd)
+
+            for plugin_name in all_plugins.keys():
+                conf = self.builddir / f'plugin-{plugin_name}.json'
+                plugin_files.append(str(conf))
+                with conf.open('w') as f:
+                    json.dump({
+                        'sitemap': str(self.sitemap),
+                        'index': str(self.index),
+                        'gst_index': str(self.index),
+                        'output': f'plugin-{plugin_name}',
+                        'conf': str(conf),
+                        'project_name': plugin_name,
+                        'project_version': self.project_version,
+                        'gst_cache_file': str(self.gst_cache_file),
+                        'gst_plugin_name': plugin_name,
+                        'c_flags': self.c_flags,
+                        'gst_smart_index': True,
+                        'gst_c_sources': self.gst_c_sources,
+                        'gst_c_source_filters': [str(s) for s in self.gst_c_source_filters],
+                        'include_paths': self.include_paths,
+                        'gst_order_generated_subpages': True,
+                    }, f, indent=4)
+
+        return plugin_files
+
+
+# Marks values in the json file as "unstable" so that they are
+# not updated automatically, this aims at making the cache file
+# stable and handle corner cases were we can't automatically
+# make it happen. For properties, the best way is to use th
+# GST_PARAM_DOC_SHOW_DEFAULT flag.
+UNSTABLE_VALUE = "unstable-values"
+
+
+
+def dict_recursive_update(d, u):
+    modified = False
+    unstable_values = d.get(UNSTABLE_VALUE, [])
+    if not isinstance(unstable_values, list):
+        unstable_values = [unstable_values]
+    for k, v in u.items():
+        if isinstance(v, Mapping):
+            r = d.get(k, {})
+            modified |= dict_recursive_update(r, v)
+            d[k] = r
+        elif k not in unstable_values:
+            modified = True
+            if k == "package":
+                d[k] = re.sub(" git$| source release$| prerelease$", "", v)
+            else:
+                d[k] = u[k]
+    return modified
+
+
+def test_unstable_values():
+    current_cache = { "v1": "yes", "unstable-values": "v1"}
+    new_cache = { "v1": "no" }
+
+    assert(dict_recursive_update(current_cache, new_cache) == False)
+
+    new_cache = { "v1": "no", "unstable-values": "v2" }
+    assert(dict_recursive_update(current_cache, new_cache) == True)
+
+    current_cache = { "v1": "yes", "v2": "yay", "unstable-values": "v1",}
+    new_cache = { "v1": "no" }
+    assert(dict_recursive_update(current_cache, new_cache) == False)
+
+    current_cache = { "v1": "yes", "v2": "yay", "unstable-values": "v2"}
+    new_cache = { "v1": "no", "v2": "unstable" }
+    assert (dict_recursive_update(current_cache, new_cache) == True)
+    assert (current_cache == { "v1": "no", "v2": "yay", "unstable-values": "v2" })
+
+if __name__ == "__main__":
+    if sys.argv[1] == "hotdoc-config":
+        fs = GstPluginsHotdocConfGen().generate_plugins_configs()
+        print(os.pathsep.join(fs))
+        sys.exit(0)
+
+    cache_filename = sys.argv[1]
+    output_filename = sys.argv[2]
+    build_root = os.environ.get('MESON_BUILD_ROOT', '')
+
+    subenv = os.environ.copy()
+    cache = {}
+    try:
+        with open(cache_filename, newline='\n', encoding='utf8') as f:
+            cache = json.load(f)
+    except FileNotFoundError:
+        pass
+
+    out = output_filename + '.tmp'
+    scanner = os.environ.get('GST_HOTDOC_PLUGINS_SCANNER')
+    if not scanner:
+        scanner = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), 'gst-hotdoc-plugins-scanner'
+        )
+    cmd = [scanner, out]
+    gst_plugins_paths = []
+    for plugin_path in sys.argv[3:]:
+        cmd.append(plugin_path)
+        gst_plugins_paths.append(os.path.dirname(plugin_path))
+
+    try:
+        with open(os.path.join(build_root, 'GstPluginsPath.json'), newline='\n', encoding='utf8') as f:
+            plugin_paths = os.pathsep.join(json.load(f))
+    except FileNotFoundError:
+        plugin_paths = ""
+
+    if plugin_paths:
+        subenv['GST_PLUGIN_PATH'] = subenv.get('GST_PLUGIN_PATH', '') + ':' + plugin_paths
+
+    # Hide stderr unless an actual error happens as we have cases where we get g_warnings
+    # and other issues because plugins are being built while `gst_init` is called
+    stderrlogfile = output_filename + '.stderr'
+    with open(stderrlogfile, 'w', encoding='utf8') as log:
+        try:
+            data = subprocess.check_output(cmd, env=subenv, stderr=log, encoding='utf8', universal_newlines=True)
+        except subprocess.CalledProcessError as e:
+            log.flush()
+            with open(stderrlogfile, 'r', encoding='utf8') as f:
+                print(f.read(), file=sys.stderr, end='')
+            raise
+
+    with open(out, 'r', newline='\n', encoding='utf8') as jfile:
+        try:
+            plugins = json.load(jfile, object_pairs_hook=OrderedDict)
+        except json.decoder.JSONDecodeError:
+            print("Could not decode:\n%s" % jfile.read(), file=sys.stderr)
+            raise
+
+    modified = dict_recursive_update(cache, plugins)
+
+    with open(output_filename, 'w', newline='\n', encoding='utf8') as f:
+        json.dump(cache, f, indent=4, sort_keys=True, ensure_ascii=False)
+
+    if modified:
+        with open(cache_filename, 'w', newline='\n', encoding='utf8') as f:
+            json.dump(cache, f, indent=4, sort_keys=True, ensure_ascii=False)

--- a/rust/gst-avsynctest-rs/src/lib.rs
+++ b/rust/gst-avsynctest-rs/src/lib.rs
@@ -25,6 +25,8 @@
 //!   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
 //! ```
 
+#![allow(unused_doc_comments)]
+
 use gst::glib;
 use gstreamer as gst;
 
@@ -41,6 +43,11 @@ fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     Ok(())
 }
 
+/**
+ * plugin-avsynctest:
+ *
+ * Phase-locked audio/video test sources for end-to-end synchronisation testing.
+ */
 gst::plugin_define!(
     avsynctest,
     env!("CARGO_PKG_DESCRIPTION"),

--- a/rust/gst-nmos-rs/src/lib.rs
+++ b/rust/gst-nmos-rs/src/lib.rs
@@ -137,6 +137,8 @@
 //! synthesised `flow_def` omits top-level `id`) but keeps the fake
 //! inner chain until IS-05 activation supplies the MXL flow id.
 
+#![allow(unused_doc_comments)]
+
 use std::sync::LazyLock;
 
 use gst::glib;
@@ -193,6 +195,13 @@ fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     Ok(())
 }
 
+/**
+ * plugin-nmos:
+ *
+ * NMOS Sender and Receiver elements (`nmossrc`, `nmossink`) and IS-08 audio
+ * channel mapping (`nmosaudiochannelmap`), talking to the `nvnmosd` NMOS daemon
+ * over gRPC.
+ */
 gst::plugin_define!(
     nmos,
     env!("CARGO_PKG_DESCRIPTION"),

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/imp.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/imp.rs
@@ -232,8 +232,8 @@ impl ElementImpl for NmosAudioChannelMap {
             gst::subclass::ElementMetadata::new(
                 "NMOS IS-08 audio channel map",
                 "Filter/Audio/Network",
-                "IS-08 channel mapping between NMOS audio streams",
-                "NVIDIA",
+                "IS-08 channel mapping between NMOS audio streams, backed by nvnmosd",
+                "NVIDIA Corporation",
             )
         });
         Some(&*ELEMENT_METADATA)


### PR DESCRIPTION
Add rust/docs/gstreamer Meson/Hotdoc build for gst-nmos-rs and gst-avsynctest-rs, deploy the generated site under /gstreamer/ on GitHub Pages alongside Doxygen, and fix README markdown for Doxygen.

Add Apache-2.0 SPDX headers (or .license sidecars) across the docs tree, and preserve upstream LGPL notices on the vendored GStreamer doc tools with contributor attribution per upstream git history.