### PR TITLE
docs: fix Hotdoc frontmatter parsing and light-mode default

### DIFF
--- a/rust/docs/gstreamer/plugins/avsynctest/index.md
+++ b/rust/docs/gstreamer/plugins/avsynctest/index.md
@@ -1,8 +1,8 @@
+---
+short-description: Phase-locked A/V test sources GStreamer plugin
+...
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-short-description: Phase-locked A/V test sources GStreamer plugin
-...

--- a/rust/docs/gstreamer/plugins/nmos/index.md
+++ b/rust/docs/gstreamer/plugins/nmos/index.md
@@ -1,8 +1,8 @@
+---
+short-description: NMOS Sender/Receiver and audio channel mapping GStreamer plugin
+...
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-short-description: NMOS Sender/Receiver and audio channel mapping GStreamer plugin
-...

--- a/rust/docs/gstreamer/portal/c-api.md
+++ b/rust/docs/gstreamer/portal/c-api.md
@@ -1,11 +1,11 @@
+---
+short-description: API reference for libnvnmos
+...
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-short-description: API reference for libnvnmos
-...
 
 <meta http-equiv="refresh" content="0; url=../index.html">
 

--- a/rust/docs/gstreamer/portal/gst-nmos-rs.md
+++ b/rust/docs/gstreamer/portal/gst-nmos-rs.md
@@ -1,11 +1,11 @@
+---
+short-description: Operator runbooks and example pipelines
+...
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-short-description: Operator runbooks and example pipelines
-...
 
 <meta http-equiv="refresh" content="0; url=https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/README.md">
 

--- a/rust/docs/gstreamer/portal/index.md
+++ b/rust/docs/gstreamer/portal/index.md
@@ -1,11 +1,11 @@
+---
+short-description: NvNmos GStreamer reference
+...
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-short-description: NvNmos GStreamer reference
-...
 
 # NvNmos GStreamer Reference
 

--- a/rust/docs/gstreamer/portal/plugins_doc.md
+++ b/rust/docs/gstreamer/portal/plugins_doc.md
@@ -1,10 +1,10 @@
+---
+short-description: All NvNmos GStreamer plugins and elements
+...
+
 <!--
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
-
----
-short-description: All NvNmos GStreamer plugins and elements
-...
 
 # Plugins

--- a/rust/docs/gstreamer/theme/extra/js/extra_frontend.js
+++ b/rust/docs/gstreamer/theme/extra/js/extra_frontend.js
@@ -13,10 +13,18 @@
 		' 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67-.01-.27.41 0 .59.34.19.73.9.82 1.13.16.39.68 1.31 2.69.94' +
 		' 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path></svg>';
 
+	// The theme's styleswitcher eagerly persists 'hotdoc.style' on load, so a
+	// missing key cannot be used to detect a first visit. Track our own marker
+	// instead: apply light once, then leave the user's later choice alone.
 	function defaultToLightMode() {
-		if (window.localStorage && !localStorage.getItem('hotdoc.style')) {
-			setActiveStyleSheet('light');
+		if (!window.localStorage || typeof setActiveStyleSheet !== 'function') {
+			return;
 		}
+		if (localStorage.getItem('nvnmos.default-style') === 'applied') {
+			return;
+		}
+		localStorage.setItem('nvnmos.default-style', 'applied');
+		setActiveStyleSheet('light');
 	}
 
 	function addGitHubNavLink() {


### PR DESCRIPTION
Move the SPDX comment below the page frontmatter so Hotdoc parses the '---' block instead of rendering 'short-description:' as body text.

Default to light mode via a private marker key, since the theme's styleswitcher eagerly persists 'hotdoc.style' on load and defeats the previous missing-key check.