### PR TITLE
docs: add Hotdoc element prose and plugin index intros

### DIFF
--- a/rust/docs/gstreamer/plugins/avsynctest/index.md
+++ b/rust/docs/gstreamer/plugins/avsynctest/index.md
@@ -6,3 +6,10 @@ short-description: Phase-locked A/V test sources GStreamer plugin
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
+
+# avsynctest
+
+Phase-locked audio and video test sources for measuring end-to-end A/V
+synchronisation. Both sources derive their content purely from running time, so
+they are aligned by construction and any skew observed downstream was introduced
+by the pipeline under test.

--- a/rust/docs/gstreamer/plugins/nmos/index.md
+++ b/rust/docs/gstreamer/plugins/nmos/index.md
@@ -6,3 +6,21 @@ short-description: NMOS Sender/Receiver and audio channel mapping GStreamer plug
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
+
+# nmos
+
+NMOS Sender, Receiver and IS-08 audio channel-mapping elements that connect
+GStreamer pipelines to an NMOS Node hosted by the `nvnmosd` daemon. The elements
+create AMWA IS-04 resources and follow IS-05 / IS-08 activations, so
+controllers manage connections while the pipeline carries ST 2110 (RTP/UDP) or
+MXL essence.
+
+## Prerequisites
+
+`nmossrc` and `nmossink` instantiate an inner data path at runtime. The
+`transport` you choose determines which plugins must be installed and on the
+GStreamer registry when media starts — gst-mxl-rs (`mxlsrc` / `mxlsink` and
+`libmxl.so`) for `transport=mxl`, gst-plugins-good and/or gst-plugins-rs for
+ST 2110 RTP/UDP (`transport=udp` or `udp2`), or the DeepStream plugin for
+`transport=nvdsudp` (Rivermax). See the Usage Guide for building, loading
+`libgstnmos.so` on `GST_PLUGIN_PATH`, and transport-specific setup.

--- a/rust/docs/gstreamer/portal/gst-nmos-rs.md
+++ b/rust/docs/gstreamer/portal/gst-nmos-rs.md
@@ -1,5 +1,5 @@
 ---
-short-description: Operator runbooks and example pipelines
+short-description: Build instructions, pipeline examples, and interactive demo
 ...
 
 <!--
@@ -9,4 +9,4 @@ SPDX-License-Identifier: Apache-2.0
 
 <meta http-equiv="refresh" content="0; url=https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/README.md">
 
-# gst-nmos-rs
+# Usage Guide

--- a/rust/gst-avsynctest-rs/src/audiosrc/mod.rs
+++ b/rust/gst-avsynctest-rs/src/audiosrc/mod.rs
@@ -1,6 +1,33 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * SECTION:element-avsyncaudiotestsrc
+ * @see_also: avsyncvideotestsrc
+ *
+ * `avsyncaudiotestsrc` is one half of a phase-locked audio/video test pair for
+ * measuring end-to-end A/V synchronisation. It emits silence with a short tone
+ * pip centred on every *pip* instant, phase-locked to the bar-centre crossing
+ * of `avsyncvideotestsrc`.
+ *
+ * ## Example
+ *
+ * Eyeball-and-ear check — the bar crosses centre exactly on the beep:
+ *
+ * |[
+ * gst-launch-1.0 \
+ *   avsyncvideotestsrc is-live=true ! videoconvert ! autovideosink \
+ *   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
+ * ]|
+ *
+ * ## Phase locking
+ *
+ * The content is derived purely from each buffer's running time and the shared
+ * `pip-interval`, so the two sources are aligned by construction and any skew
+ * seen downstream was introduced by the pipeline under test. `pip-interval`
+ * *must* be set to the same value on both elements. Set `is-live=true` to pace
+ * output against the pipeline clock for live capture or transmit pipelines.
+ */
 use gst::glib;
 use gst::prelude::*;
 use gstreamer as gst;

--- a/rust/gst-avsynctest-rs/src/videosrc/mod.rs
+++ b/rust/gst-avsynctest-rs/src/videosrc/mod.rs
@@ -1,6 +1,39 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * SECTION:element-avsyncvideotestsrc
+ * @see_also: avsyncaudiotestsrc
+ *
+ * `avsyncvideotestsrc` is one half of a phase-locked audio/video test pair for
+ * measuring end-to-end A/V synchronisation. It renders a white vertical bar on
+ * black that crosses screen centre exactly on every *pip* instant and sweeps
+ * fully across in one pip interval, so the bar-centre crossing lines up with
+ * the tone pip from `avsyncaudiotestsrc`.
+ *
+ * Each frame also carries its frame index and a phase-locked CEA-708 caption
+ * (alternating "TICK"/"TOCK") as ancillary data, so an `st2038extractor` can
+ * split the ANC into its own flow and a downstream analyser can check that
+ * video, audio and caption alignment survive the round trip.
+ *
+ * ## Example
+ *
+ * Eyeball-and-ear check — the bar crosses centre exactly on the beep:
+ *
+ * |[
+ * gst-launch-1.0 \
+ *   avsyncvideotestsrc is-live=true ! videoconvert ! autovideosink \
+ *   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
+ * ]|
+ *
+ * ## Phase locking
+ *
+ * The content is derived purely from each buffer's running time and the shared
+ * `pip-interval`, so the two sources are aligned by construction and any skew
+ * seen downstream was introduced by the pipeline under test. `pip-interval`
+ * *must* be set to the same value on both elements. Set `is-live=true` to pace
+ * output against the pipeline clock for live capture or transmit pipelines.
+ */
 use gst::glib;
 use gst::prelude::*;
 use gstreamer as gst;

--- a/rust/gst-nmos-rs/README.md
+++ b/rust/gst-nmos-rs/README.md
@@ -37,7 +37,7 @@ Both elements:
 | `mxl-domain-path` | string | required for MXL | Local filesystem path identifying the MXL Domain on this host; fed into the inner `mxlsink` / `mxlsrc` `domain=` property. If a `domain_def.json` is present in the directory its `id` is used to populate or cross-check `mxl-domain-id` (mismatch is an error — this is host-level identity). |
 | `auto-activate`  | boolean | optional, default `false` | When `false` the element adds the Sender or Receiver to the daemon so it appears on IS-04 and IS-05 but leaves the inner data path on the fake chain until an IS-05 PATCH activates it (`master_enable: true` on `/single/{senders,receivers}/{id}/active`). When `true` the element brings the inner transport src/sink up immediately once the configuring transport file has been resolved at NULL→READY (or, for a deferred-mode sender, at READY→PAUSED) *and* calls `SyncResourceState` to push the daemon's IS-04/IS-05 view to active — i.e. it's a no-controller shortcut for development pipelines and for setups where flow identity comes entirely from properties / `transport-file*`. Orthogonal to how the transport file itself becomes available: property override of `mxl-flow-id`, supplied `transport-file*`, and caps-driven synthesis (MXL `flow_def` or SDP) all feed the same gate. |
 
-#### `caps` essence shapes {#caps-essence-shapes}
+#### `caps` essence shapes
 
 When `transport-file*` is unset, `caps` drives synthesis of the configuring transport file:
 

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/mod.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/mod.rs
@@ -3,6 +3,106 @@
 
 //! NMOS IS-08 channel mapping element (`nmosaudiochannelmap`).
 
+/**
+ * SECTION:element-nmosaudiochannelmap
+ * @see_also: nmossrc, nmossink
+ *
+ * `nmosaudiochannelmap` exposes AMWA IS-08 audio channel mapping as a
+ * GStreamer element. Request `sink_%u` and `src_%u` audio pads and it
+ * creates matching IS-08 Inputs and Outputs on the Node; a controller then
+ * decides which input channels feed which output channels and the element
+ * re-orders the audio channels accordingly.
+ *
+ * ## Example
+ *
+ * Two-input, two-output matrix from the interactive demo
+ * (`scripts/gst-nmos-rs-demo.sh`, Node 3 audio processor). Each `sink_%u` /
+ * `src_%u` pad becomes an IS-08 Input or Output; channel counts come from the
+ * negotiated caps on that branch. Request every pad before the element reaches
+ * READY.
+ *
+ * |[
+ * gst-launch-1.0 -e \
+ *   nmosaudiochannelmap name=map \
+ *     node-seed=demo-node3 \
+ *     channelmapping-name=demo-map \
+ *     sink_0::input-id=input0 \
+ *     sink_0::receiver-name=audio-in0 \
+ *     sink_0::channels=2 \
+ *     sink_1::input-id=input1 \
+ *     sink_1::receiver-name=audio-in1 \
+ *     sink_1::channels=8 \
+ *     src_0::output-id=output0 \
+ *     src_0::sender-name=audio-out0 \
+ *     src_0::channels=2 \
+ *     src_1::output-id=output1 \
+ *     src_1::sender-name=audio-out1 \
+ *     src_1::channels=8 \
+ *   nmossrc \
+ *     transport=mxl \
+ *     node-seed=demo-node3 \
+ *     receiver-name=audio-in0 \
+ *     mxl-domain-path=/dev/shm/gst-nmos-rs-examples \
+ *     caps="audio/x-raw,format=F32LE,rate=48000,channels=2" ! map.sink_0 \
+ *   nmossrc \
+ *     transport=mxl \
+ *     node-seed=demo-node3 \
+ *     receiver-name=audio-in1 \
+ *     receiver-caps-mode=wide \
+ *     mxl-domain-path=/dev/shm/gst-nmos-rs-examples \
+ *     caps="audio/x-raw,format=F32LE,rate=48000,channels=8" ! map.sink_1 \
+ *   map.src_0 ! volume volume=0.3 ! nmossink \
+ *     transport=mxl \
+ *     node-seed=demo-node3 \
+ *     sender-name=audio-out0 \
+ *     mxl-domain-path=/dev/shm/gst-nmos-rs-examples \
+ *     caps="audio/x-raw,format=F32LE,rate=48000,channels=2" \
+ *   map.src_1 ! volume volume=0.1 ! nmossink \
+ *     transport=mxl \
+ *     node-seed=demo-node3 \
+ *     sender-name=audio-out1 \
+ *     mxl-domain-path=/dev/shm/gst-nmos-rs-examples \
+ *     caps="audio/x-raw,format=F32LE,rate=48000,channels=8"
+ * ]|
+ *
+ * An IS-08 controller PATCHes `/map/active` to re-route channels at runtime;
+ * until then the element applies an identity map wherever the geometry allows.
+ *
+ * ## Daemon connection
+ *
+ * This element is a front end for the `nvnmosd` NMOS daemon and holds no NMOS
+ * state of its own. At NULL→READY it opens a gRPC session to the daemon
+ * (`daemon-uri`) and closes it again at READY→NULL, so `nvnmosd` must already
+ * be running when the pipeline starts. The daemon serves the AMWA IS-04, IS-05
+ * and IS-08 HTTP APIs; the element only drives the session and its inner
+ * GStreamer data path.
+ *
+ * ## Node properties
+ *
+ * Sessions that share a `node-seed` contribute to the same NMOS Node, so one
+ * host can present many Senders, Receivers and channel maps under a single
+ * Node simply by reusing the seed. The Node identity properties — `host-name`,
+ * `domain`, `registration-url`, `system-url` and `http-port` — are taken from
+ * whichever session first creates the Node and ignored by later sessions that
+ * attach to it.
+ *
+ * ## Inputs and outputs
+ *
+ * Request a `sink_%u` pad for each audio stream coming in and a `src_%u` pad
+ * for each stream going out; every pad becomes an IS-08 Input or Output whose
+ * channel count is taken from its negotiated caps. The set of pads is frozen
+ * when the element first reaches READY, so request every pad you need before
+ * starting the pipeline. `channelmapping-name` names the Input/Output bundle on
+ * the Node, and `restrict-routable-inputs` limits each Output to this element's
+ * own Inputs.
+ *
+ * ## Activation
+ *
+ * The element starts with an identity map wherever the channel geometry allows
+ * it; an IS-08 controller then PATCHes the active map to re-route channels at
+ * runtime and the element applies the new routing to the audio passing through
+ * it.
+ */
 use gstreamer as gst;
 use gstreamer::glib;
 use gstreamer::prelude::*;

--- a/rust/gst-nmos-rs/src/nmossink/mod.rs
+++ b/rust/gst-nmos-rs/src/nmossink/mod.rs
@@ -3,6 +3,128 @@
 
 //! NMOS Sender (`nmossink`) element.
 
+/**
+ * SECTION:element-nmossink
+ * @see_also: nmossrc, nmosaudiochannelmap, mxlsink, udpsink, nvdsudpsink
+ *
+ * `nmossink` is an NMOS Sender. It creates an IS-04 Sender on an NMOS Node
+ * hosted by `nvnmosd` and transmits the video, audio or ST 2038 ANC essence
+ * arriving on its sink pad over the configured transport.
+ *
+ * ## Examples
+ *
+ * These pipelines assume `nvnmosd` is listening on `unix:/tmp/nvnmosd.sock`.
+ * With the default `auto-activate=false` the Sender appears on IS-04/IS-05 and
+ * an IS-05 controller PATCHes it to start media.
+ *
+ * Caps-driven MXL sender (`scripts/example-pipelines/minimal-prop-sender-mxl.sh`):
+ *
+ * |[
+ * gst-launch-1.0 -e \
+ *   videotestsrc pattern=smpte is-live=true ! \
+ *   video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive ! \
+ *   nmossink \
+ *     transport=mxl \
+ *     node-seed=example-minimal-producer \
+ *     sender-name=video1 \
+ *     mxl-domain-id=92c696c2-66f9-4d86-8a87-13135d847189 \
+ *     mxl-domain-path=/dev/shm/gst-nmos-rs-examples \
+ *     caps="video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive" \
+ *     label="minimal 1080p25 v210 sender"
+ * ]|
+ *
+ * Caps-driven RTP/UDP sender (`scripts/example-pipelines/minimal-prop-sender-udp.sh`):
+ *
+ * |[
+ * gst-launch-1.0 -e \
+ *   videotestsrc pattern=smpte is-live=true ! \
+ *   video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive ! \
+ *   nmossink \
+ *     transport=udp \
+ *     node-seed=example-minimal-producer \
+ *     sender-name=video1 \
+ *     source-ip=192.0.2.10 \
+ *     caps="video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive" \
+ *     label="minimal 1080p25 UYVP sender"
+ * ]|
+ *
+ * Replace `source-ip` with the IP address of the local NIC to transmit from.
+ *
+ * Deferred sender: omit `caps` and the element synthesises the configuring
+ * transport file from upstream caps at pre-roll — often `videotestsrc ! nmossink`
+ * with only `transport`, `node-seed`, and `sender-name` is enough.
+ *
+ * Transport-file variant: write an MXL `flow_def` or SDP to disk and pass
+ * `transport-file-path=/path/to/file` instead of `caps` and the identity
+ * properties above (`scripts/example-pipelines/minimal-file-sender-mxl.sh`,
+ * `minimal-file-sender-udp.sh`).
+ *
+ * ## Daemon connection
+ *
+ * This element is a front end for the `nvnmosd` NMOS daemon and holds no NMOS
+ * state of its own. At NULL→READY it opens a gRPC session to the daemon
+ * (`daemon-uri`) and closes it again at READY→NULL, so `nvnmosd` must already
+ * be running when the pipeline starts. The daemon serves the AMWA IS-04, IS-05
+ * and IS-08 HTTP APIs; the element only drives the session and its inner
+ * GStreamer data path.
+ *
+ * ## Node properties
+ *
+ * Sessions that share a `node-seed` contribute to the same NMOS Node, so one
+ * host can present many Senders, Receivers and channel maps under a single
+ * Node simply by reusing the seed. The Node identity properties — `host-name`,
+ * `domain`, `registration-url`, `system-url` and `http-port` — are taken from
+ * whichever session first creates the Node and ignored by later sessions that
+ * attach to it.
+ *
+ * ## Transport
+ *
+ * `transport` selects the inner data path — `mxl` (MXL shared memory), `udp`
+ * or `udp2` (ST 2110 over RTP/UDP), or `nvdsudp` (ST 2110 via DeepStream and
+ * Rivermax). The element builds and manages the matching inner elements for
+ * you, so you never add `mxlsink`, `udpsink` and the RTP payloaders to the
+ * pipeline yourself. MXL additionally needs `mxl-domain-path`; the RTP
+ * transports use the IS-05 endpoint properties.
+ *
+ * Inner elements are created when the data path starts and must already be
+ * registered: `mxl` uses `mxlsink` from the gst-mxl-rs plugin (and `libmxl.so`
+ * on the dynamic loader path); `udp` uses `udpsink` plus an essence-specific
+ * `rtp*pay` from gst-plugins-good; `udp2` prefers matching `*pay2` elements
+ * from gst-plugins-rs where available, falling back to gst-plugins-good per
+ * element (`udpsink` is always from gst-plugins-good); `nvdsudp` uses
+ * `nvdsudpsink` from the DeepStream plugin (built-in payloading). The exact RTP
+ * payloader is chosen from the configuring transport file and caps. See the
+ * `transport` property for the full family list; plugin loading and
+ * `GST_PLUGIN_PATH` setup are in the Usage Guide.
+ *
+ * ## Configuring the Sender
+ *
+ * Before it can be added to the Node the Sender needs a *configuring transport
+ * file* — an SDP for the RTP transports or an MXL `flow_def`. Provide it in one
+ * of two ways:
+ *
+ * * **From caps.** Set `caps` to the essence you are sending and the element
+ *   synthesises the file, together with the transport identity properties
+ *   (`mxl-flow-id` on MXL; the IS-05 endpoint properties such as
+ *   `destination-ip` on RTP/UDP).
+ * * **From a transport file.** Set `transport-file-path` (or, for programmatic
+ *   callers, `transport-file`) to a ready-made SDP or `flow_def`.
+ *
+ * If neither is set the Sender is configured lazily: the element reads the
+ * upstream caps as the pipeline pre-rolls and synthesises the file from those,
+ * so a plain `… ! nmossink` often works with no `caps` property at all.
+ * `sender-name` names the Sender on the Node; `label` and `description` are
+ * optional and override the file.
+ *
+ * ## Activation
+ *
+ * Appearing on the Node (visible to IS-04/IS-05 controllers) is separate from
+ * the data path going live. By default (`auto-activate=false`) the Sender is
+ * created but stays idle until an IS-05 controller activates it with a
+ * PATCH. Set `auto-activate=true` to bring the data path up immediately from
+ * the configured transport file and have the daemon reflect that in the IS-05
+ * API — a convenient shortcut for development and controller-less setups.
+ */
 use gstreamer as gst;
 use gstreamer::glib;
 use gstreamer::prelude::*;

--- a/rust/gst-nmos-rs/src/nmossrc/mod.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/mod.rs
@@ -3,6 +3,126 @@
 
 //! NMOS Receiver (`nmossrc`) element.
 
+/**
+ * SECTION:element-nmossrc
+ * @see_also: nmossink, nmosaudiochannelmap, mxlsrc, udpsrc, nvdsudpsrc
+ *
+ * `nmossrc` is an NMOS Receiver. It creates an IS-04 Receiver on an NMOS
+ * Node hosted by `nvnmosd` and, once the Receiver is activated, produces the
+ * received video, audio or ST 2038 ANC essence on its source pad as ordinary
+ * GStreamer buffers.
+ *
+ * ## Examples
+ *
+ * These pipelines assume `nvnmosd` is listening on `unix:/tmp/nvnmosd.sock`.
+ * With the default `auto-activate=false` the Receiver appears on IS-04/IS-05 and
+ * an IS-05 controller PATCHes it to supply the subscription identity and start
+ * media.
+ *
+ * Caps-driven MXL receiver (`scripts/example-pipelines/minimal-prop-receiver-mxl.sh`):
+ *
+ * |[
+ * gst-launch-1.0 -e \
+ *   nmossrc \
+ *     transport=mxl \
+ *     node-seed=example-minimal-consumer \
+ *     receiver-name=video1 \
+ *     mxl-domain-id=92c696c2-66f9-4d86-8a87-13135d847189 \
+ *     mxl-domain-path=/dev/shm/gst-nmos-rs-examples \
+ *     caps="video/x-raw,format=v210,width=1920,height=1080,framerate=25/1,interlace-mode=progressive" \
+ *     label="minimal 1080p25 v210 receiver" ! \
+ *   queue leaky=downstream max-size-buffers=2 max-size-bytes=0 max-size-time=0 ! \
+ *   videoconvert ! autovideosink sync=false
+ * ]|
+ *
+ * Caps-driven RTP/UDP receiver (`scripts/example-pipelines/minimal-prop-receiver-udp.sh`):
+ *
+ * |[
+ * gst-launch-1.0 -e \
+ *   nmossrc \
+ *     transport=udp \
+ *     node-seed=example-minimal-consumer \
+ *     receiver-name=video1 \
+ *     interface-ip=192.0.2.10 \
+ *     caps="video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive" \
+ *     label="minimal 1080p25 UYVP receiver" ! \
+ *   queue leaky=downstream max-size-buffers=2 max-size-bytes=0 max-size-time=0 ! \
+ *   videoconvert ! autovideosink sync=false
+ * ]|
+ *
+ * Replace `interface-ip` with the IP address of the local NIC that should
+ * join the multicast group.
+ *
+ * Transport-file variant: write an MXL `flow_def` or SDP to disk and pass
+ * `transport-file-path=/path/to/file` instead of `caps` and the identity
+ * properties above (`scripts/example-pipelines/minimal-file-receiver-mxl.sh`,
+ * `minimal-file-receiver-udp.sh`).
+ *
+ * ## Daemon connection
+ *
+ * This element is a front end for the `nvnmosd` NMOS daemon and holds no NMOS
+ * state of its own. At NULL→READY it opens a gRPC session to the daemon
+ * (`daemon-uri`) and closes it again at READY→NULL, so `nvnmosd` must already
+ * be running when the pipeline starts. The daemon serves the AMWA IS-04, IS-05
+ * and IS-08 HTTP APIs; the element only drives the session and its inner
+ * GStreamer data path.
+ *
+ * ## Node properties
+ *
+ * Sessions that share a `node-seed` contribute to the same NMOS Node, so one
+ * host can present many Senders, Receivers and channel maps under a single
+ * Node simply by reusing the seed. The Node identity properties — `host-name`,
+ * `domain`, `registration-url`, `system-url` and `http-port` — are taken from
+ * whichever session first creates the Node and ignored by later sessions that
+ * attach to it.
+ *
+ * ## Transport
+ *
+ * `transport` selects the inner data path — `mxl` (MXL shared memory), `udp`
+ * or `udp2` (ST 2110 over RTP/UDP), or `nvdsudp` (ST 2110 via DeepStream and
+ * Rivermax). The element builds and manages the matching inner elements for
+ * you, so you never add `mxlsrc`, `udpsrc` and the RTP depayloaders to the
+ * pipeline yourself. MXL additionally needs `mxl-domain-path`; the RTP
+ * transports use the IS-05 endpoint properties.
+ *
+ * Inner elements are created when the data path starts and must already be
+ * registered: `mxl` uses `mxlsrc` from the gst-mxl-rs plugin (and `libmxl.so`
+ * on the dynamic loader path); `udp` uses `udpsrc` plus an essence-specific
+ * `rtp*depay` from gst-plugins-good; `udp2` prefers `udpsrc2` and matching
+ * `*depay2` elements from gst-plugins-rs where available, falling back to
+ * gst-plugins-good per element; `nvdsudp` uses `nvdsudpsrc` from the DeepStream
+ * plugin (built-in depayloading). The exact RTP depayloader is chosen from the
+ * configuring transport file and caps. See the `transport` property for the
+ * full family list; plugin loading and `GST_PLUGIN_PATH` setup are in the
+ * Usage Guide.
+ *
+ * ## Configuring the Receiver
+ *
+ * Before it can be added to the Node the Receiver needs a *configuring
+ * transport file* — an SDP for the RTP transports or an MXL `flow_def` — which
+ * also determines whether IS-04 advertises BCP-004-01 Receiver Caps. Provide
+ * it in one of two ways:
+ *
+ * * **From caps.** Set `caps` to the essence you want to receive and the
+ *   element synthesises the file; `receiver-caps-mode` chooses whether the
+ *   Receiver is advertised as narrow (these specific caps) or wide (accepts
+ *   any compatible stream).
+ * * **From a transport file.** Set `transport-file-path` (or, for programmatic
+ *   callers, `transport-file`) to a ready-made SDP or `flow_def`.
+ *
+ * With neither set the Receiver is added without a format and waits for an
+ * IS-05 activation to supply one. `receiver-name` names the Receiver on the
+ * Node; `label` and `description` are optional and override the file.
+ *
+ * ## Activation
+ *
+ * Appearing on the Node (visible to IS-04/IS-05 controllers) is separate from
+ * the data path going live. By default (`auto-activate=false`) the Receiver is
+ * created but stays idle until an IS-05 controller activates it with a
+ * PATCH. Set `auto-activate=true` to bring the data path up immediately from
+ * the configuring transport file and have the daemon reflect that in the IS-05
+ * API — a convenient shortcut for development and controller-less setups.
+ */
 use gstreamer as gst;
 use gstreamer::glib;
 use gstreamer::prelude::*;


### PR DESCRIPTION
Add `SECTION:element-*` gtk-doc comments for nmossrc, nmossink, nmosaudiochannelmap, and the avsynctest sources, with Examples sections grounded in the example-pipeline scripts. Add plugin index headings and scope blurbs so pages clear the navbar. Rename the GitHub README portal link to Usage Guide and drop a broken README anchor.