### PR TITLE
ci: bump GitHub Actions to Node.js 24–compatible releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       # it without rebuilding the C side from scratch.
       - name: Upload libnvnmos.so (Linux)
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: libnvnmos-linux
           path: build/libnvnmos.so

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,7 +61,7 @@ jobs:
 
     - name: Upload Pages artifact
       if: github.event_name == 'push'
-      uses: actions/upload-pages-artifact@v4
+      uses: actions/upload-pages-artifact@v5
       with:
         path: public
 
@@ -78,7 +78,7 @@ jobs:
 
     - name: Upload preview artifact
       if: github.event_name != 'push'
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ env.artifact_name }}
         path: ${{ runner.temp }}/docs-preview.tar.gz
@@ -95,4 +95,4 @@ jobs:
 
     steps:
     - name: Deploy to GitHub Pages
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v5


### PR DESCRIPTION
Update upload-pages-artifact, deploy-pages, and upload-artifact to versions that declare node24 runtimes, clearing deprecation warnings on ubuntu-latest runners.