### PR TITLE
feat: add Flow id accessors (nmos_make_flow_id / nmos_get_flow_id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,16 @@ The NMOS resource UUIDs are deterministic pure functions of `(seed, side, name)`
 - `nmos_make_node_id(seed, out, out_len)`
 - `nmos_make_sender_id(seed, sender_name, out, out_len)`
 - `nmos_make_receiver_id(seed, receiver_name, out, out_len)`
-- `nmos_make_source_id(seed, source_name, out, out_len)`
+- `nmos_make_source_id(seed, sender_name, out, out_len)`
+- `nmos_make_flow_id(seed, sender_name, out, out_len)`
 
 Live accessors look them up on a running server:
 
 - `nmos_get_node_id(server, out, out_len)`
 - `nmos_get_sender_id(server, sender_name, out, out_len)`
 - `nmos_get_receiver_id(server, receiver_name, out, out_len)`
-- `nmos_get_source_id(server, source_name, out, out_len)`
+- `nmos_get_source_id(server, sender_name, out, out_len)`
+- `nmos_get_flow_id(server, sender_name, out, out_len)`
 
 All write a null-terminated UUID into a buffer of at least `NVNMOS_ID_LEN` bytes (37, including the terminator). Each returns `bool`.
 

--- a/rust/nvnmos/src/lib.rs
+++ b/rust/nvnmos/src/lib.rs
@@ -16,11 +16,12 @@
 //!   (mirrors the `nmos_connection_activate` C function).
 //! * [`NodeServer::node_id`] / [`sender_id`](NodeServer::sender_id) /
 //!   [`receiver_id`](NodeServer::receiver_id) /
-//!   [`source_id`](NodeServer::source_id) — look up NMOS resource UUIDs on a
+//!   [`source_id`](NodeServer::source_id) /
+//!   [`flow_id`](NodeServer::flow_id) — look up NMOS resource UUIDs on a
 //!   running server.
 //! * [`make_node_id`] / [`make_sender_id`] / [`make_receiver_id`] /
-//!   [`make_source_id`] — pure functions that compute the same UUIDs
-//!   deterministically from a seed, without needing a running server.
+//!   [`make_source_id`] / [`make_flow_id`] — pure functions that compute the
+//!   same UUIDs deterministically from a seed, without needing a running server.
 //! * [`NodeServer::builder`] — opt into IS-05 [`Activation`] handling and / or
 //!   forward libnvnmos's slog output via [`LogMessage`]. Both knobs are
 //!   chainable on the returned [`NodeServerBuilder`]; the bare
@@ -525,10 +526,10 @@ pub fn make_receiver_id(seed: &str, receiver_name: &str) -> Result<String> {
     capture_id(&buf)
 }
 
-/// Compute the IS-04 Source resource id for a seed and source name.
-pub fn make_source_id(seed: &str, source_name: &str) -> Result<String> {
+/// Compute the IS-04 Source resource id for a seed and sender name.
+pub fn make_source_id(seed: &str, sender_name: &str) -> Result<String> {
     let cseed = CString::new(seed)?;
-    let cname = CString::new(source_name)?;
+    let cname = CString::new(sender_name)?;
     let mut buf = [0u8; ID_BUF_LEN];
     let ok = unsafe {
         sys::nmos_make_source_id(
@@ -540,6 +541,28 @@ pub fn make_source_id(seed: &str, source_name: &str) -> Result<String> {
     };
     if !ok {
         return Err(Error::Failed("nmos_make_source_id"));
+    }
+    capture_id(&buf)
+}
+
+/// Compute the IS-04 Flow resource id for a seed and sender name.
+///
+/// This is the Flow id (the Sender's `flow_id` property), not the MXL
+/// `mxl_flow_id` IS-05 transport parameter.
+pub fn make_flow_id(seed: &str, sender_name: &str) -> Result<String> {
+    let cseed = CString::new(seed)?;
+    let cname = CString::new(sender_name)?;
+    let mut buf = [0u8; ID_BUF_LEN];
+    let ok = unsafe {
+        sys::nmos_make_flow_id(
+            cseed.as_ptr(),
+            cname.as_ptr(),
+            buf.as_mut_ptr() as *mut c_char,
+            buf.len(),
+        )
+    };
+    if !ok {
+        return Err(Error::Failed("nmos_make_flow_id"));
     }
     capture_id(&buf)
 }
@@ -1466,14 +1489,38 @@ impl NodeServer {
 
     /// Look up the IS-04 Source UUID paired with a sender by its name.
     ///
-    /// Returns `Ok(None)` if no sender with the given `source_name`
+    /// Returns `Ok(None)` if no sender with the given `sender_name`
     /// currently exists on this server. This is the Source id (IS-08
     /// `/sourceid`), not the Sender id from [`sender_id`](Self::sender_id).
-    pub fn source_id(&self, source_name: &str) -> Result<Option<String>> {
-        let cname = CString::new(source_name)?;
+    pub fn source_id(&self, sender_name: &str) -> Result<Option<String>> {
+        let cname = CString::new(sender_name)?;
         let mut buf = [0u8; ID_BUF_LEN];
         let ok = unsafe {
             sys::nmos_get_source_id(
+                &*self.raw,
+                cname.as_ptr(),
+                buf.as_mut_ptr() as *mut c_char,
+                buf.len(),
+            )
+        };
+        if !ok {
+            return Ok(None);
+        }
+        Ok(Some(capture_id(&buf)?))
+    }
+
+    /// Look up the IS-04 Flow UUID paired with a sender by its name.
+    ///
+    /// Returns `Ok(None)` if no sender with the given `sender_name`
+    /// currently exists on this server. This is the Flow id (the Sender's
+    /// `flow_id` property), not the Sender id from [`sender_id`](Self::sender_id).
+    /// The MXL `mxl_flow_id` IS-05 transport parameter may be overridden
+    /// but is the same by default.
+    pub fn flow_id(&self, sender_name: &str) -> Result<Option<String>> {
+        let cname = CString::new(sender_name)?;
+        let mut buf = [0u8; ID_BUF_LEN];
+        let ok = unsafe {
+            sys::nmos_get_flow_id(
                 &*self.raw,
                 cname.as_ptr(),
                 buf.as_mut_ptr() as *mut c_char,
@@ -1564,6 +1611,15 @@ mod tests {
         assert_uuid_shape(&source);
         assert_ne!(sender, source, "sender and source ids must not collide");
         assert_eq!(source, make_source_id("seed", "video").unwrap());
+    }
+
+    #[test]
+    fn sender_and_flow_ids_diverge() {
+        let sender = make_sender_id("seed", "video").unwrap();
+        let flow = make_flow_id("seed", "video").unwrap();
+        assert_uuid_shape(&flow);
+        assert_ne!(sender, flow, "sender and flow ids must not collide");
+        assert_eq!(flow, make_flow_id("seed", "video").unwrap());
     }
 
     #[test]

--- a/src/main.c
+++ b/src/main.c
@@ -405,6 +405,8 @@ static void print_expected_ids(const char *seed)
         print_id("sender", sender_names[i], sender_success ? id : "<error>");
         const bool source_success = nmos_make_source_id(seed, sender_names[i], id, sizeof id);
         print_id("source", sender_names[i], source_success ? id : "<error>");
+        const bool flow_success = nmos_make_flow_id(seed, sender_names[i], id, sizeof id);
+        print_id("flow", sender_names[i], flow_success ? id : "<error>");
     }
 
     static const char *const receiver_names[] = {
@@ -440,6 +442,8 @@ static void print_actual_ids(const NvNmosNodeServer *server)
         print_id("sender", sender_names[i], sender_success ? id : "<missing>");
         const bool source_success = nmos_get_source_id(server, sender_names[i], id, sizeof id);
         print_id("source", sender_names[i], source_success ? id : "<missing>");
+        const bool flow_success = nmos_get_flow_id(server, sender_names[i], id, sizeof id);
+        print_id("flow", sender_names[i], flow_success ? id : "<missing>");
     }
 
     static const char *const receiver_names[] = {

--- a/src/nvnmos.cpp
+++ b/src/nvnmos.cpp
@@ -196,6 +196,7 @@ namespace nvnmos
         nmos::id sender_id(const std::string& sender_name) const;
         nmos::id receiver_id(const std::string& receiver_name) const;
         nmos::id source_id(const std::string& source_name) const;
+        nmos::id flow_id(const std::string& sender_name) const;
 
     private:
         static nmos::settings make_settings(const NvNmosNodeConfig& config);
@@ -696,6 +697,14 @@ namespace nvnmos
         if (node_model.node_resources.end() == nmos::find_resource(node_model.node_resources, { candidate, nmos::types::source })) return {};
         return candidate;
     }
+
+    nmos::id server::flow_id(const std::string& sender_name) const
+    {
+        auto lock = node_model.read_lock();
+        const auto candidate = impl::make_id(nmos::experimental::fields::seed_id(node_model.settings), nmos::types::flow, utility::s2us(sender_name));
+        if (node_model.node_resources.end() == nmos::find_resource(node_model.node_resources, { candidate, nmos::types::flow })) return {};
+        return candidate;
+    }
 }
 
 NVNMOS_API
@@ -978,15 +987,34 @@ bool nmos_make_receiver_id(
 NVNMOS_API
 bool nmos_make_source_id(
     const char* seed,
-    const char* source_name,
+    const char* sender_name,
     char* out,
     size_t out_len)
 {
-    if (!seed || !source_name) return false;
+    if (!seed || !sender_name) return false;
     try
     {
         const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
-        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::source, utility::s2us(source_name)), out, out_len);
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::source, utility::s2us(sender_name)), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_make_flow_id(
+    const char* seed,
+    const char* sender_name,
+    char* out,
+    size_t out_len)
+{
+    if (!seed || !sender_name) return false;
+    try
+    {
+        const auto seed_id = nmos::make_repeatable_id(nvnmos::seed_namespace_id, utility::s2us(seed));
+        return nvnmos::copy_id_to_buffer(nvnmos::impl::make_id(seed_id, nmos::types::flow, utility::s2us(sender_name)), out, out_len);
     }
     catch (...)
     {
@@ -1056,16 +1084,36 @@ bool nmos_get_receiver_id(
 NVNMOS_API
 bool nmos_get_source_id(
     const NvNmosNodeServer* server,
-    const char* source_name,
+    const char* sender_name,
     char* out,
     size_t out_len)
 {
-    if (!server || !source_name) return false;
+    if (!server || !sender_name) return false;
     auto impl = (nvnmos::server*)server->impl;
     if (!impl) return false;
     try
     {
-        return nvnmos::copy_id_to_buffer(impl->source_id(source_name), out, out_len);
+        return nvnmos::copy_id_to_buffer(impl->source_id(sender_name), out, out_len);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+NVNMOS_API
+bool nmos_get_flow_id(
+    const NvNmosNodeServer* server,
+    const char* sender_name,
+    char* out,
+    size_t out_len)
+{
+    if (!server || !sender_name) return false;
+    auto impl = (nvnmos::server*)server->impl;
+    if (!impl) return false;
+    try
+    {
+        return nvnmos::copy_id_to_buffer(impl->flow_id(sender_name), out, out_len);
     }
     catch (...)
     {

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -850,7 +850,7 @@ bool nmos_make_sender_id(
  * the receiver with the given @p receiver_name.
  *
  * Pure function of (@p seed, @p receiver_name). See
- * @ref nmos_make_node_id for the contract.
+ * @ref nmos_make_node_id for the contract; the same notes apply.
  *
  * @param[in]  seed          Seed string. Must not be null.
  * @param[in]  receiver_name The caller-chosen name of the receiver (see
@@ -870,15 +870,16 @@ bool nmos_make_receiver_id(
 /**
  * Compute the NMOS Source resource id that an @ref NvNmosNodeServer created
  * with the given @p seed will use for the Source paired with a sender
- * named @p source_name.
+ * named @p sender_name.
  *
- * Pure function of (@p seed, @p source_name). See @ref nmos_make_node_id
- * for the contract. This is the IS-04 **Source** id (used for IS-08
- * `/sourceid`), not the Sender id from @ref nmos_make_sender_id — both
- * use the same name string from the transport file.
+ * Pure function of (@p seed, @p sender_name). See @ref nmos_make_node_id
+ * for the contract; the same notes apply. This is the IS-04 **Source** id
+ * (used for IS-08 `/sourceid`), not the Sender id from
+ * @ref nmos_make_sender_id — both are based on the same caller-chosen name
+ * used in the transport file.
  *
  * @param[in]  seed        Seed string. Must not be null.
- * @param[in]  source_name The caller-chosen name of the sender (see
+ * @param[in]  sender_name The caller-chosen name of the sender (see
  *                         @ref NvNmosSenderConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
@@ -888,7 +889,34 @@ bool nmos_make_receiver_id(
 NVNMOS_API
 bool nmos_make_source_id(
     const char *seed,
-    const char *source_name,
+    const char *sender_name,
+    char *out,
+    size_t out_len);
+
+/**
+ * Compute the NMOS Flow resource id that an @ref NvNmosNodeServer created
+ * with the given @p seed will use for the Flow paired with a sender named
+ * @p sender_name.
+ *
+ * Pure function of (@p seed, @p sender_name). See @ref nmos_make_node_id
+ * for the contract; the same notes apply. This is the IS-04 **Flow** id
+ * (the Sender's `flow_id` property), not the Sender id from
+ * @ref nmos_make_sender_id — both are based on the same caller-chosen name
+ * used in the transport file. The MXL `mxl_flow_id` IS-05 transport
+ * parameter may be overridden but is the same by default.
+ *
+ * @param[in]  seed        Seed string. Must not be null.
+ * @param[in]  sender_name The caller-chosen name of the sender (see
+ *                         @ref NvNmosSenderConfig::transport_file).
+ *                         Must not be null.
+ * @param[out] out         Buffer to receive the id.
+ * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_make_flow_id(
+    const char *seed,
+    const char *sender_name,
     char *out,
     size_t out_len);
 
@@ -960,14 +988,14 @@ bool nmos_get_receiver_id(
  *
  * Looks the Source up by the caller-chosen sender name (the same
  * string passed to @ref add_nmos_sender_to_node_server). Returns false
- * (without writing to @p out) if no sender with the given @p source_name
+ * (without writing to @p out) if no sender with the given @p sender_name
  * has been added to the server.
  *
  * This is the IS-04 **Source** id (used for IS-08 `/sourceid`), not the
  * Sender id from @ref nmos_get_sender_id.
  *
  * @param[in]  server      Pointer to the server.
- * @param[in]  source_name The caller-chosen name of the sender (see
+ * @param[in]  sender_name The caller-chosen name of the sender (see
  *                         @ref NvNmosSenderConfig::transport_file).
  *                         Must not be null.
  * @param[out] out         Buffer to receive the id.
@@ -977,7 +1005,35 @@ bool nmos_get_receiver_id(
 NVNMOS_API
 bool nmos_get_source_id(
     const NvNmosNodeServer *server,
-    const char *source_name,
+    const char *sender_name,
+    char *out,
+    size_t out_len);
+
+/**
+ * Get the NMOS Flow resource id paired with a sender currently
+ * registered with the specified server.
+ *
+ * Looks the Flow up by the caller-chosen sender name (the same
+ * string passed to @ref add_nmos_sender_to_node_server). Returns false
+ * (without writing to @p out) if no sender with the given @p sender_name
+ * has been added to the server.
+ *
+ * This is the IS-04 **Flow** id (the Sender's `flow_id` property), not
+ * the Sender id from @ref nmos_get_sender_id. The MXL `mxl_flow_id` IS-05
+ * transport parameter may be overridden but is the same by default.
+ *
+ * @param[in]  server      Pointer to the server.
+ * @param[in]  sender_name The caller-chosen name of the sender (see
+ *                         @ref NvNmosSenderConfig::transport_file).
+ *                         Must not be null.
+ * @param[out] out         Buffer to receive the id.
+ * @param[in]  out_len     Size of @p out, at least @ref NVNMOS_ID_LEN.
+ * @return Whether the id has been written to @p out.
+ */
+NVNMOS_API
+bool nmos_get_flow_id(
+    const NvNmosNodeServer *server,
+    const char *sender_name,
     char *out,
     size_t out_len);
 


### PR DESCRIPTION
Add the C API `nmos_make_flow_id` (pure) and `nmos_get_flow_id` (live lookup) alongside the existing sender/source id accessors, plus the Rust `make_flow_id` and `NodeServer::flow_id` wrappers and an example print in `main.c`. The Flow id is the IS-04 Flow resource `id` (the Sender's `flow_id` property), distinct from the Sender `id`; by default it also seeds the MXL `mxl_flow_id` transport parameter.

Rename the source-id accessor parameter from `source_name` to `sender_name` to match, since both the Source and Flow ids are keyed on the sender's caller-chosen name.