### PR TITLE
docs: fix Ways To Use NvNmos formatting for doxygen site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ SPDX-License-Identifier: Apache-2.0
 
 NvNmos can be integrated in three ways:
 
-1. **C library (`libnvnmos`)** — embed the NMOS control plane directly in a Media Node application. The API is in `nvnmos.h`; see [Usage](#usage) and the `nvnmos-example` application below.
-2. **Daemon and gRPC API (`nvnmosd`)** — run the control plane out-of-process; Media Node applications attach as clients over gRPC. See [`rust/nvnmosd/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/nvnmosd/README.md), the Rust workspace quick start in [`rust/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/README.md), and [`doc/designs/nvnmosd/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/doc/designs/nvnmosd/README.md).
-3. **GStreamer elements (`gst-nmos-rs`)** — `nmossrc` and `nmossink` talk to `nvnmosd` and wire up the data path (MXL, RTP/UDP, DeepStream). See the published element reference at [https://nvidia.github.io/nvnmos/gstreamer/](https://nvidia.github.io/nvnmos/gstreamer/), [`rust/gst-nmos-rs/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/README.md), and the Rust workspace quick start in [`rust/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/README.md).
+1. **C library** (`libnvnmos`) — embed the NMOS control plane directly in a Media Node application.
+   - The API is in `nvnmos.h`; see [Usage](#usage) and the `nvnmos-example` application below.
+2. **Daemon and gRPC API** (`nvnmosd`) — run the control plane out-of-process; Media Node applications attach as clients over gRPC.
+   - See [`rust/nvnmosd/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/nvnmosd/README.md), the Rust workspace quick start in [`rust/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/README.md), and the design record in [`doc/designs/nvnmosd/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/doc/designs/nvnmosd/README.md).
+3. **GStreamer elements** (`gst-nmos-rs`) — `nmossrc` and `nmossink` talk to `nvnmosd` and wire up the data path (MXL, RTP/UDP, DeepStream).
+   - See the published element reference at [https://nvidia.github.io/nvnmos/gstreamer/](https://nvidia.github.io/nvnmos/gstreamer/), the usage guide in [`rust/gst-nmos-rs/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/README.md), and the Rust workspace quick start in [`rust/README.md`](https://github.com/NVIDIA/nvnmos/blob/main/rust/README.md).
 
 ## Introduction
 


### PR DESCRIPTION
## Summary
- Fix doxygen rendering of the **Ways To Use NvNmos** list by moving code spans outside bold markers (doxygen does not parse `**text (`code`)**` as emphasis).
- Split the long per-item link sentences onto nested bullets for readability on GitHub and the published docs site.
- Clarify link labels: "the design record in" for `doc/designs/nvnmosd/README.md` and "the usage guide in" for `rust/gst-nmos-rs/README.md`.

## Test plan
- [ ] Merge and confirm https://nvidia.github.io/nvnmos/ renders bold labels and nested bullets correctly after the pages workflow runs.