### PR TITLE
gst-nmos-rs: preserve MXL flow metadata on activation

### DIFF
--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -54,6 +54,8 @@
 //! shapes that `mxlsink` advertises today are accepted: v210 video,
 //! F32LE audio, ST 2038 ANC.
 
+use std::collections::HashMap;
+
 use gstreamer as gst;
 use serde::Deserialize;
 use thiserror::Error;
@@ -69,6 +71,16 @@ struct RawFlowDef {
     /// NMOS format URN: `urn:x-nmos:format:video|audio|data`.
     /// Optional in the file; the property may supply it instead.
     format: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawFlowMetadata {
+    #[serde(default)]
+    label: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    tags: HashMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -163,6 +175,13 @@ pub(crate) struct FlowDefMeta {
     pub(crate) format: FlowFormat,
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct FlowMetadata {
+    pub(crate) label: String,
+    pub(crate) description: String,
+    pub(crate) group_hint: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ValueOrigin {
     /// User supplied the property; no transport file consulted (or
@@ -205,6 +224,23 @@ pub(crate) fn read_flow_def_meta(text: &str) -> Result<FlowDefMeta, FlowDefError
 
 const NAME_TAG: &str = "urn:x-nvnmos:tag:name";
 const MXL_DOMAIN_ID_TAG: &str = "urn:x-nvnmos:tag:mxl-domain-id";
+const GROUP_HINT_TAG: &str = "urn:x-nmos:tag:grouphint/v1.0";
+
+/// Human-readable metadata from a configuring or activation flow_def.
+pub(crate) fn metadata_from_transport(text: &str) -> Result<FlowMetadata, FlowDefError> {
+    let raw: RawFlowMetadata =
+        serde_json::from_str(text).map_err(|source| FlowDefError::Parse { source })?;
+    Ok(FlowMetadata {
+        label: raw.label,
+        description: raw.description,
+        group_hint: raw
+            .tags
+            .get(GROUP_HINT_TAG)
+            .and_then(|values| values.first())
+            .cloned()
+            .unwrap_or_default(),
+    })
+}
 
 fn mxl_domain_id_from_tag_value(value: &serde_json::Value) -> Result<DomainId, FlowDefError> {
     let Some(arr) = value.as_array() else {
@@ -882,6 +918,33 @@ mod tests {
         let m = read_flow_def_meta(&video_flow_def(UUID_A)).unwrap();
         assert_eq!(m.id, UUID_A);
         assert_eq!(m.format, FlowFormat::Video);
+    }
+
+    #[test]
+    fn metadata_from_transport_reads_effective_flow_metadata() {
+        let json = r#"{
+            "label": "Studio A camera",
+            "description": "v210 1080p50",
+            "tags": {
+                "urn:x-nmos:tag:grouphint/v1.0": ["SDI 1:Video"]
+            }
+        }"#;
+        assert_eq!(
+            metadata_from_transport(json).expect("parse"),
+            FlowMetadata {
+                label: "Studio A camera".to_owned(),
+                description: "v210 1080p50".to_owned(),
+                group_hint: "SDI 1:Video".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_from_transport_defaults_missing_fields() {
+        assert_eq!(
+            metadata_from_transport(&video_flow_def(UUID_A)).expect("parse"),
+            FlowMetadata::default()
+        );
     }
 
     #[test]

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -30,7 +30,7 @@ use gstreamer::prelude::*;
 use gstreamer::subclass::prelude::*;
 use tokio::sync::oneshot;
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 
 use crate::daemon::{ActivationHandler, ActivationOutcome, ActivationRequest, Session};
 use crate::inner;
@@ -929,9 +929,24 @@ fn build_real_sink(
         TransportConfig::Mxl {
             domain_path,
             flow_id,
+            transport_file,
             ..
         } => {
+            let transport_file = transport_file.as_deref().ok_or_else(|| {
+                anyhow!("building real MXL sink without a configuring transport file")
+            })?;
+            let metadata = crate::flow_def::metadata_from_transport(transport_file)
+                .context("reading MXL flow metadata from transport file")?;
             let chain = inner::build_mxlsink(domain_path, flow_id)?;
+            for (property, value) in [
+                ("label", metadata.label.as_str()),
+                ("description", metadata.description.as_str()),
+                ("group-hint", metadata.group_hint.as_str()),
+            ] {
+                if chain.transport.has_property(property) {
+                    chain.transport.set_property(property, value);
+                }
+            }
             inner::apply_mxl_sink_inner_properties(
                 &CAT,
                 "nmossink",


### PR DESCRIPTION
Apply the configured flow label, description, and group hint to mxlsink so activated resources retain their NMOS metadata.

Uses https://github.com/dmf-mxl/mxl/pull/588/changes/8e2faf073ae235be089a3a5fd5fe1c6d9cf50cd3.