### PR TITLE
docs: improve daemon reference navigation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,6 +49,7 @@ jobs:
         cd rust/nvnmos-rpc/proto
         protoc nvnmosd.proto -o descriptor.pb --include_source_info
         sabledocs
+        sed -i 's#<span>Source</span>#<span>View on GitHub</span>#g' sabledocs_output/*.html
         cat nvnmos-theme.css >> sabledocs_output/static/mystyles.css
         mkdir -p "$GITHUB_WORKSPACE/public/grpc"
         cp -a sabledocs_output/* "$GITHUB_WORKSPACE/public/grpc/"

--- a/rust/nvnmos-rpc/proto/nvnmos-theme.css
+++ b/rust/nvnmos-rpc/proto/nvnmos-theme.css
@@ -49,6 +49,66 @@ html.dark code a {
   border-color: var(--nvnmos-green);
 }
 
+nav .level-right .level-item > .link.is-info {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-size: 0.9rem;
+}
+
+nav .level-right .level-item > .link.is-info .icon {
+  width: 1rem;
+  height: 1rem;
+  font-size: 1rem;
+}
+
+.toc {
+  float: right;
+  max-width: 24rem;
+  margin: 0 0 1.5rem 2rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid #dbdbdb;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.toc::before {
+  content: "Contents";
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+}
+
+.toc > ul {
+  margin-top: 0;
+  margin-left: 0;
+}
+
+.toc > ul > li > ul {
+  margin-top: 0;
+  margin-left: 1.25rem;
+}
+
+.toc > ul > li {
+  list-style: none;
+}
+
+.toc > ul > li > a {
+  display: none;
+}
+
+html.dark .toc {
+  border-color: #4a4a4a;
+}
+
+@media screen and (max-width: 768px) {
+  .toc {
+    float: none;
+    max-width: none;
+    margin: 0 0 1.5rem;
+  }
+}
+
 .theme-toggle {
   --icon-fill: var(--nvnmos-green);
   --icon-fill-hover: var(--nvnmos-link);

--- a/rust/nvnmos-rpc/proto/sabledocs.toml
+++ b/rust/nvnmos-rpc/proto/sabledocs.toml
@@ -4,7 +4,7 @@
 module-title = "NvNmos Daemon gRPC API"
 main-page-content-file = "../../nvnmosd/README.md"
 member-ordering = "preserve"
-markdown-extensions = ["fenced_code", "tables"]
+markdown-extensions = ["fenced_code", "tables", "toc"]
 
 repository-type = "github"
 repository-url = "https://github.com/NVIDIA/nvnmos"

--- a/rust/nvnmosd/README.md
+++ b/rust/nvnmosd/README.md
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # nvnmosd
 
+[TOC]
+
 Linux-first NMOS daemon: one process hosts multiple NMOS **Nodes** (by `node_seed`),
 **sessions** (gRPC clients), and session-linked NMOS **Senders/Receivers** backed by
 [`libnvnmos`](https://nvidia.github.io/nvnmos/nvnmos_8h.html). Clients talk to it
@@ -20,7 +22,26 @@ documents the no-FFI-under-`state` invariant.
 This documentation describes the **as-built** daemon surface for operators and
 client authors.
 
-## Minimal Client Sequence
+## Using the gRPC API
+
+**Node flavours:**
+
+- **Session-refcounted** (default): created on first `OpenSession` for a
+  `node_seed`; destroyed when the last session on that node closes.
+- **Persistent**: created with `AddNode`; survives until `RemoveNode`.
+
+Many sessions may attach to the same Node (same `node_seed`). Each session owns
+the resources it registers; activations are routed to the session that added the
+resource.
+
+| Area | RPCs |
+|------|------|
+| Node lifecycle | `AddNode`, `RemoveNode`, `OpenSession`, `CloseSession` |
+| Resources | `AddSender`, `AddReceiver`, `RemoveResource` |
+| IS-05 activation | `SubscribeActivations` (server stream), `AckActivation` |
+| Out-of-band sync | `SyncResourceState` |
+
+### Minimal Client Sequence
 
 Most clients use a session-refcounted Node:
 
@@ -61,7 +82,7 @@ cargo build --bin nvnmosd
 cargo run --bin nvnmosd -- --uds /tmp/nvnmosd.sock
 ```
 
-## Command Line
+### Command Line
 
 | Flag / env | Default | Meaning |
 |------------|---------|---------|
@@ -69,41 +90,12 @@ cargo run --bin nvnmosd -- --uds /tmp/nvnmosd.sock
 
 Logging uses `tracing`; set `RUST_LOG` as usual (e.g. `RUST_LOG=info`).
 
-## gRPC API (Summary)
-
-| Area | RPCs |
-|------|------|
-| Node lifecycle | `AddNode`, `RemoveNode`, `OpenSession`, `CloseSession` |
-| Resources | `AddSender`, `AddReceiver`, `RemoveResource` |
-| IS-05 activation | `SubscribeActivations` (server stream), `AckActivation` |
-| Out-of-band sync | `SyncResourceState` |
-
-**Session contract (enforced when session GC is on, default):**
-
-1. Call `SubscribeActivations` promptly after `OpenSession`, **before**
-   `AddSender` / `AddReceiver`.
-2. To keep a session alive after dropping `SubscribeActivations`, call it
-   again within the resubscribe timeout.
-3. Call `CloseSession` for a clean shutdown.
-
-Missed deadlines trigger implicit `CloseSession` (same teardown as the RPC).
-Details and env vars are below; see the
-[gRPC API reference](https://nvidia.github.io/nvnmos/grpc/) for per-RPC
-contracts.
-
-**Node flavours:**
-
-- **Session-refcounted** (default): created on first `OpenSession` for a
-  `node_seed`; destroyed when the last session on that node closes.
-- **Persistent**: created with `AddNode`; survives until `RemoveNode`.
-
-Many sessions may attach to the same Node (same `node_seed`). Each session owns
-the resources it registers; activations are routed to the session that added the
-resource.
-
 ## Environment Variables
 
-### Session Liveness (Implicit `CloseSession`)
+### Session Liveness
+
+These settings control when the daemon implicitly closes a session whose
+activation subscription is missing or interrupted.
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
@@ -120,7 +112,7 @@ resource.
 
 When `NodeConfig.http_port` is **`0`**, the daemon picks the first port in `[MIN, MAX]` that is not already used by another Node and that the host can bind. When **`http_port` is non-zero**, the client chooses the port; the daemon rejects the create if that port is already taken by another Node or unavailable on the host.
 
-### glibc Heap Trim (Linux)
+### Linux glibc Heap Trimming
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
@@ -150,3 +142,13 @@ See the [Rust workspace smoke test](https://github.com/NVIDIA/nvnmos/blob/main/r
 (`--interface-ip`, `--hold-secs`, Connection API PATCH round-trip).
 
 [Scale benchmark guide](https://github.com/NVIDIA/nvnmos/blob/main/doc/designs/nvnmosd/scale-smoke.md).
+
+## Other Ways to Use NvNmos
+
+Use the [C API](https://nvidia.github.io/nvnmos/) to embed the NMOS control
+plane directly in a Media Node application.
+
+Use the
+[GStreamer elements](https://nvidia.github.io/nvnmos/gstreamer/) — `nmossrc`
+and `nmossink` — to connect GStreamer pipelines to `nvnmosd` and configure the
+data plane.


### PR DESCRIPTION
## Summary
- add reciprocal links from the daemon/gRPC guide to the C API and GStreamer documentation
- generate and style a compact responsive contents panel for the Sabledocs landing page
- streamline the gRPC API overview and align the GitHub navigation label with the other documentation sites

## Test plan
- [x] Generate `descriptor.pb` with `protoc`
- [x] Render the Sabledocs site locally
- [x] Verify the TOC hierarchy, reciprocal links, and `View on GitHub` label in generated HTML
- [x] Run `git diff --check`