### PR TITLE
docs: fix unconstrained MXL audio media type

### DIFF
--- a/doc/user/transport-files.md
+++ b/doc/user/transport-files.md
@@ -148,7 +148,7 @@ Compare with `minimal-video.mxl.json.in`, which also needs `grain_rate`, `frame_
 {
   "label": "@LABEL@",
   "description": "",
-  "media_type": "audio/L24",
+  "media_type": "audio/float32",
   "tags": {
     "urn:x-nvnmos:tag:name": ["@NAME@"],
     "urn:x-nvnmos:tag:caps": [""]

--- a/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-unconstrained-audio.mxl.json.in
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/fixtures/minimal-unconstrained-audio.mxl.json.in
@@ -1,7 +1,7 @@
 {
   "label": "@LABEL@",
   "description": "",
-  "media_type": "audio/L24",
+  "media_type": "audio/float32",
   "tags": {
     "urn:x-nvnmos:tag:name": ["@NAME@"],
     "urn:x-nvnmos:tag:caps": [""]


### PR DESCRIPTION
## Summary
- correct the minimal unconstrained MXL audio example to use the `audio/float32` media type instead of the RTP/UDP `audio/L24`
- apply the same fix to the matching transport-file documentation example

Thanks to Adam Wiewiorka, BBC, for the spot!