### PR TITLE
docs: clarify GStreamer configuration

### DIFF
--- a/doc/designs/gst-nmos-rs-mutable-ready-audit.md
+++ b/doc/designs/gst-nmos-rs-mutable-ready-audit.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 `mutable_ready()` lets `g_object_set()` run in **NULL or READY**; it does **not** mean the element re-reads the property on every READY-time set. Values are taken from `Settings` only when a **lifecycle step** runs (below).
 
-Override vs cross-check rules for transport-file interaction: [configuration guide](../../rust/gst-nmos-rs/configuration.md#property-interaction-with-transport-files). This doc covers **when** each property must be set and which outer pspec flags apply.
+Property combination rules: [configuration guide](../../rust/gst-nmos-rs/configuration.md#how-properties-are-combined). This doc covers **when** each property must be set and which outer pspec flags apply.
 
 ## Lifecycle steps
 

--- a/doc/designs/nvnmosd/README.md
+++ b/doc/designs/nvnmosd/README.md
@@ -288,7 +288,8 @@ There are three ways to fully describe a sender or receiver. Each is sufficient 
 - **Identity, human-readable metadata, and Receiver capability properties** (`sender-name` / `receiver-name`, `mxl-flow-id`, `mxl-domain-id`, `label`, `description`, `receiver-caps-mode`) — **override** the matching field/tag in the file. This is the natural "I have a template SDP or flow_def, but the per-instance bits (`sender-name` or `receiver-name`, `source-ip` or `interface-ip`, port, label, ...) change" workflow, and nvdsnmosbin already worked this way.
 - **Essence-shape properties** (`caps`, `transport-caps`) — **cross-check** against the file's shape. Mismatch is a hard error at NULL→READY; the application is asked to align the two rather than have one silently win over the other.
 
-The full matrix (including which properties have no transport file interaction at all) lives in the gst-nmos-rs crate README under "Property Interaction With Transport Files".
+The full matrix is in
+[How Properties Are Combined](../../../rust/gst-nmos-rs/configuration.md#how-properties-are-combined).
 
 #### Defaults the element synthesises
 

--- a/rust/gst-nmos-rs/configuration.md
+++ b/rust/gst-nmos-rs/configuration.md
@@ -5,14 +5,16 @@ SPDX-License-Identifier: Apache-2.0
 
 # Configuration
 
-Choose how the GStreamer element is activated and where its configuring
-transport file comes from, then set the properties for the selected transport
-and essence.
+Each element creates its NMOS Sender or Receiver from a
+[configuring transport file](https://nvidia.github.io/nvnmos/concepts.html#configuring-transport-files):
+SDP for RTP/UDP or an MXL flow definition. The element can obtain this file
+from `transport-file*`, synthesise it from other properties, or, for `nmossink`,
+derive it from upstream caps.
 
 ## Configuration Choices
 
-Activation policy and the source of the configuring transport file are
-independent choices.
+You can choose the activation policy separately from how the element obtains
+the configuring transport file.
 
 ### Activation Policy
 
@@ -21,13 +23,13 @@ independent choices.
 | Controller-managed | Leave `auto-activate=false` (the default) | Production systems where an IS-05 Controller decides when the data plane becomes active |
 | Self-starting | Set `auto-activate=true` | Development and fixed pipelines that should begin processing without a Controller |
 
-### Configuring Transport File Source
+### How the Configuring Transport File Is Obtained
 
 | Source | Set initially | Intended use |
 | --- | --- | --- |
-| Supplied file | `transport-file-path` or `transport-file` | Use an existing SDP or MXL flow definition with [NvNmos extensions](https://nvidia.github.io/nvnmos/transport-files.html#nvnmos-extensions-to-the-transport-file) |
+| Supplied transport file | `transport-file-path` or `transport-file` | Use an existing SDP or MXL flow definition with [NvNmos extensions](https://nvidia.github.io/nvnmos/transport-files.html#nvnmos-extensions-to-the-transport-file) |
 | Synthesised from properties | `caps` plus the relevant RTP/UDP endpoints or MXL identifiers | Build the configuring SDP or MXL flow definition from element configuration |
-| Upstream caps (`nmossink` only) | Omit `caps` and `transport-file*` | Defer synthesis until upstream caps arrive during preroll |
+| Upstream caps (`nmossink` only) | Omit `caps` and `transport-file*` | Defer until upstream caps arrive during preroll |
 
 `transport` defaults to `udp`. Set `transport=mxl`, `udp2`, or `nvdsudp`
 explicitly when selecting another transport implementation.
@@ -35,7 +37,7 @@ explicitly when selecting another transport implementation.
 `transport-file` and `transport-file-path` are mutually exclusive. Explicit
 element properties override corresponding values in a supplied transport file;
 essence `caps` are cross-checked rather than substituted silently. See
-[Property Interaction With Transport Files](#property-interaction-with-transport-files)
+[How Properties Are Combined](#how-properties-are-combined)
 for the complete rules.
 
 ## Property Groups
@@ -54,12 +56,13 @@ which properties matter for a task:
 | --- | --- | --- |
 | Essential | `node-seed`, `sender-name` / `receiver-name`, `transport`, `caps` or `transport-file*`, `receiver-caps-mode`, `auto-activate` | Identify the Node and Sender or Receiver, choose the data plane, describe the essence and Receiver capabilities, and choose Controller-managed or self-starting activation |
 | RTP/UDP | Sender: `source-ip`, `source-port`, `destination-ip`, `destination-port`; Receiver: `source-ip`, `interface-ip`, `multicast-ip`, `destination-port`; both: `transport-caps`, `format-bit-rate`, `transport-bit-rate` | Configure SDP and IS-05 endpoint values for `udp`, `udp2`, and `nvdsudp`; the bit-rate properties apply to JPEG XS on `udp` / `udp2` |
-| MXL | `mxl-domain-path`, `mxl-domain-id`, `mxl-flow-id` | Select the local MXL Domain and flow for `transport=mxl` |
+| MXL | `mxl-domain-path`, `mxl-domain-id`, `mxl-flow-id` | Select the local MXL domain and flow for `transport=mxl` |
 | Human-readable metadata | `label`, `description`, `group-hint` | Set human-readable labels, descriptions, and grouping metadata for NMOS resources |
-| Node and session | `daemon-uri`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url` | Connect to `nvnmosd` and configure the NMOS Node; Node properties are taken from the first session that creates a shared `node-seed` |
+| Node and session | `daemon-uri`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url` | Connect to the daemon and configure the NMOS Node; Node properties are taken from the first session that creates a shared `node-seed` |
 | Inner-element overrides | `transport-properties`, `pay-properties`, `depay-properties` | Pass advanced properties to generated inner elements; payloader and depayloader overrides apply only to `udp` / `udp2` |
 
-The Sender and Receiver meanings of `source-ip` and `destination-port` differ.
+The `source-ip` and `destination-port` properties follow the corresponding IS-05
+transport parameter semantics, so their Sender and Receiver meanings differ.
 For a Sender, `source-ip` is the local egress address and
 `destination-port` is remote. For a Receiver, `source-ip` is an optional remote
 source-specific multicast filter and `destination-port` is the local listen port.
@@ -67,7 +70,7 @@ source-specific multicast filter and `destination-port` is the local listen port
 ### Supported Caps Essence Shapes
 
 When `transport-file*` is unset, `caps` drives synthesis of the configuring
-transport file:
+transport file sent to the daemon:
 
 - `transport=mxl` produces an MXL flow definition and also requires
   `mxl-flow-id`.
@@ -86,41 +89,46 @@ configuration advertises constrained BCP-004-01 Receiver Caps. With
 | Audio | `audio/x-raw,format=…,rate=…,channels=…` | all | MXL: `F32LE`. RTP/UDP: ST 2110-30 `S24BE` (L24) and `S16BE` (L16). |
 | Data (ANC) | `meta/x-st-2038,framerate=…` | all | `framerate` is required; add it with a capsfilter if necessary. |
 
-### Property Interaction With Transport Files
+### How Properties Are Combined
 
-When a `transport-file` (literal or path) and an overlapping property
-are both set, the resulting transport file handed to the daemon is
-built with these rules:
+When `transport-file*` is set alongside other properties, the element applies
+these rules to construct the configuring transport file sent to the daemon:
 
-| Group         | Properties | Rule when both set |
+| Group         | Properties | Combination rule |
 | ------------- | ---------- | ------------------ |
-| Identity | `sender-name` / `receiver-name`, `mxl-flow-id`, `mxl-domain-id` | **Property overrides file.** The element rewrites the file's matching field/tag before the daemon sees it. |
-| Human-readable metadata | `label`, `description`, `group-hint` | **Property overrides file.** The element rewrites the file's matching field/tag before the daemon sees it. |
-| Receiver capabilities | `receiver-caps-mode` | **Property overrides file.** The element rewrites the file's Receiver Caps marker before the daemon sees it. |
-| Essence shape | `caps`, `transport-caps` | **Cross-check.** Property must agree with the file's shape (today: `caps` first structure name vs `format`). Mismatch is a hard error at NULL→READY. |
-| Bit rates | `format-bit-rate`, `transport-bit-rate` | **Cross-check when both declare a rate; splice when only the property is set.** Values are kilobits per second (matching NMOS `bit_rate`, SDP `b=AS:`, and fmtp `x-nvnmos-*-bit-rate` per AMWA BCP-006-01 / RFC 9134 / ST 2110-22). When the supplied SDP omits bit rates, non-zero properties are written into the configuring SDP before the daemon sees it. |
-| Activation gate | `auto-activate` | Does not appear in the transport file. Controls whether the data plane starts when configuration is resolved or waits for an IS-05 activation. Independent of the configuration source. |
-| No interaction | `daemon-uri`, `node-seed`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url`, `transport`, `mxl-domain-path`, `transport-properties`, `pay-properties`, `depay-properties` | These don't appear in the transport file at all. Node-identity properties (`host-name`, `domain`, `registration-url`, `system-url`, `http-port`) are forwarded to `OpenSession` as `node_config` and honoured only when that session creates the Node (first opener for a given `node-seed`). `transport-properties` / `pay-properties` / `depay-properties` tune the inner GStreamer elements at chain-build time instead. |
+| Identity | `sender-name` / `receiver-name`, `mxl-flow-id`, `mxl-domain-id` | **Apply property value.** The element writes the property value into the configuring transport file, replacing the supplied value if present. |
+| Human-readable metadata | `label`, `description`, `group-hint` | **Apply property value.** The element writes the property value into the configuring transport file, replacing the supplied value if present. |
+| Receiver capabilities | `receiver-caps-mode` | **Apply property value.** The element writes the selected Receiver Caps marker into the configuring transport file, replacing the supplied marker if present. |
+| Essence shape | `caps` | **Cross-check.** The caps must be compatible with the supplied file's essence. For MXL, the format family must agree; for RTP/UDP, the caps must intersect the SDP essence shape. Mismatch is a hard error at NULL→READY. |
+| Bit rates | `format-bit-rate`, `transport-bit-rate` | **Cross-check or apply property values.** A missing bit rate is approximated separately for the SDP and property values. If the SDP and properties both specify bit rates, the resulting values must agree; if only the properties do, the property-derived values are applied. |
+| RTP parameters | `transport-caps` | **Cross-check or apply property values.** Dynamic payload type, audio clock rate, and `a-ptime` / `a-maxptime` are applied to the configuring SDP. The remaining RTP and essence-shape fields must agree with the supplied SDP. |
+| Activation policy | `auto-activate` | **Not in the configuring transport file.** Selects self-starting or Controller-managed activation. |
+| Other configuration | `daemon-uri`, `node-seed`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url`, `transport`, `mxl-domain-path`, `transport-properties`, `pay-properties`, `depay-properties` | **Not in the configuring transport file.** Node properties configure the NMOS Node; when sessions share a `node-seed`, the first session to create the Node determines those settings. The remaining properties control the daemon connection or configure the local data plane and its inner GStreamer elements. |
 
-`mxl-domain-id` is in the override group for the file tag, but is
+Bit rates are in kilobits per second and correspond to NMOS Flow and Sender
+`bit_rate`. SDP may carry the transport rate in `b=AS:` and either rate in the
+NvNmos extension `fmtp` parameters `x-nvnmos-format-bit-rate` and
+`x-nvnmos-transport-bit-rate`.
+
+`mxl-domain-id` is in the override group for the supplied file's tag, but is
 still **cross-checked** against `<mxl-domain-path>/domain_def.json`
-because that file describes which Domain identity belongs to this
-local mount — a different ID would be a host-level misconfiguration,
-not a labelling choice.
+because that file identifies the MXL domain mounted at this path; a different
+ID would be a host configuration error, not a value that can be overridden.
 
-At IS-05 activation time the daemon's transport file is authoritative
-for the override groups (an IS-05 PATCH legitimately replaces the
-configured-at-startup flow id); the essence-shape cross-check
-still applies, so an activation that asks an `nmossrc` configured for
-v210 video to receive an audio flow is ack-failed.
+IS-05 activation values take precedence over corresponding start-up
+configuration. For a Sender, active `transport_params` are reflected in its
+`/transportfile`. For a Receiver, a Controller may also supply a
+`transport_file`. In either case, the active essence must remain compatible
+with `caps`; for example, an `nmossrc` configured for `v210` video rejects
+an activation carrying audio.
 
 ## Lifecycle, Activation, and Property Changes
 
 | Transition or event | User-visible effect |
 | --- | --- |
-| NULL→READY | Connect to `nvnmosd` and add the NMOS Sender or Receiver when its configuring transport file can be resolved |
-| READY→PAUSED | For a deferred `nmossink`, derive configuration from upstream caps and add the Sender |
-| IS-05 activation | Build or replace the inner transport elements using the active transport file |
+| NULL→READY | Connect to the daemon and, if the element can prepare the configuring transport file, add the NMOS Sender or Receiver |
+| READY→PAUSED | For a deferred `nmossink`, derive the configuring transport file from upstream caps and add the Sender |
+| IS-05 activation | Build or replace the inner transport elements using the effective SDP or MXL flow definition delivered for activation |
 | READY→NULL | Remove the Sender or Receiver and close the daemon session |
 
 When neither `transport-file*` nor `caps` is set, `nmossink` defers
@@ -130,8 +138,9 @@ has no deferred mode; set `caps` or `transport-file*` before READY.
 The element separates NMOS resource visibility from an active data plane. With
 the default `auto-activate=false`, the Sender or Receiver is visible but waits
 for an IS-05 activation before starting its data plane. With
-`auto-activate=true`, it starts the data plane as soon as configuration is
-available. This property does not change the GStreamer pipeline state.
+`auto-activate=true`, the element starts the data plane as soon as it has
+prepared the configuring transport file. This property does not change the
+GStreamer pipeline state.
 
 Set configuration properties while the element is in NULL unless the element
 reference marks them as changeable in READY. A property that can be set in

--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -270,20 +270,20 @@ before the flipper script.
 ./scripts/example-pipelines/1080p25-flipper-udp.sh
 ```
 
-For IS-05-gated activation (resources visible on IS-04 before the data
-path goes live), omit `auto-activate=true` and PATCH
+For Controller-managed IS-05 activation (resources visible on IS-04 before the
+data path goes live), omit `auto-activate=true` and PATCH
 `/single/{senders,receivers}/{id}/staged` — demo **Node 3** exercises
 this; example scripts use `auto-activate=true` for simplicity.
 
-### Deferred AddSender
+### Deferred Sender Creation
 
 [`1080p25-deferred-sender-mxl.sh`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-mxl.sh) ·
 [`1080p25-deferred-sender-udp.sh`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-udp.sh)
 
-When neither `transport-file*` nor `caps=` is set on `nmossink`, AddSender
-runs at **READY→PAUSED** from upstream peer caps. Transport-specific identity
-props must still be set (MXL domain + `mxl-flow-id`, or UDP destination
-multicast + `source-ip`).
+When neither `transport-file*` nor `caps` is set, `nmossink` derives the
+configuring transport file from upstream peer caps and adds the Sender at
+**READY→PAUSED**. Transport-specific identity properties must still be set
+(MXL domain + `mxl-flow-id`, or UDP destination multicast + `source-ip`).
 
 **MXL:**
 
@@ -318,14 +318,14 @@ JSON; UDP synthesises configuring SDP).
 [`minimal-file-sender-udp-jxsv.sh`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-sender-udp-jxsv.sh) ·
 [`minimal-file-receiver-udp-jxsv.sh`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/scripts/example-pipelines/minimal-file-receiver-udp-jxsv.sh)
 
-Smallest NULL→READY AddSender / AddReceiver paths with
+Smallest NULL→READY Sender and Receiver creation paths with
 `auto-activate=false`. Resources become visible through IS-04 at READY; the
 controller PATCHes `/single/{senders,receivers}/{id}/staged` to bring the data
 plane live.
 
 **Properties-driven (`minimal-prop-*`)** — `sender-name` / `receiver-name`
 plus `caps` (and `source-ip` / `interface-ip` for RTP/UDP, or
-`mxl-domain-*` for MXL) synthesise the configuring transport at NULL→READY.
+`mxl-domain-*` for MXL) synthesise the configuring transport file at NULL→READY.
 
 **MXL:**
 
@@ -422,10 +422,12 @@ covers the usual setup).
 
 **ST 2022-7 (dual-leg):** supported on `transport=nvdsudp` when configuring
 SDP has two same-essence `m=` lines (separate destination addresses).
-Inactive legs (`rtp_enabled: false` → `a=inactive`) are gated
-at activation; `nvdsudpsrc` uses comma-separated `st2022-7-streams`,
-`local-iface-ip`, and `source-address`. Dual-leg transport files on
-`udp` / `udp2` are rejected. Caps-only synthesis still emits one `m=`.
+IS-05 `rtp_enabled: false` appears as `a=inactive` in the effective SDP. The
+element omits inactive legs when configuring the inner transport elements; if
+all legs are inactive, the data plane remains dormant. When both Receiver legs
+are active, `nvdsudpsrc` is supplied with comma-separated `st2022-7-streams`,
+`local-iface-ip`, and `source-address` values. Dual-leg transport files on
+`udp` / `udp2` are rejected. Caps-only synthesis only emits one leg (`m=`).
 See the
 [ST 2022-7 design notes](https://github.com/NVIDIA/nvnmos/blob/main/doc/designs/gst-nmos-rs-st2022-7-dual-leg-plan.md).
 


### PR DESCRIPTION
## Summary
- clarify configuring transport file terminology and property combination rules
- document IS-05 Sender/Receiver transport semantics and activation behavior
- refine deferred configuration and ST 2022-7 guidance, updating related design links

## Validation
- GStreamer Hotdoc generation (warning set matches `origin/main`)
- Doxygen generation (no warnings)
- `cargo fmt -- --check`