### PR TITLE
gst-nmos-rs: expose activation state

### DIFF
--- a/rust/gst-nmos-rs/configuration.md
+++ b/rust/gst-nmos-rs/configuration.md
@@ -128,8 +128,9 @@ an activation carrying audio.
 | --- | --- |
 | NULL→READY | Connect to the daemon and, if the element can prepare the configuring transport file, add the NMOS Sender or Receiver |
 | READY→PAUSED | For a deferred `nmossink`, derive the configuring transport file from upstream caps and add the Sender |
-| IS-05 activation | Build or replace the inner transport elements using the effective SDP or MXL flow definition delivered for activation |
-| READY→NULL | Remove the Sender or Receiver and close the daemon session |
+| Resource addition with `auto-activate=true` | Build the real inner transport, synchronize the NMOS active state, set read-only `active` to true, and post a `nmos-activation` element message; occurs during NULL→READY or deferred `nmossink` READY→PAUSED |
+| IS-05 activation | Build or replace the inner transport elements using the effective SDP or MXL flow definition delivered for activation; update read-only `active` and post a `nmos-activation` element message on the bus |
+| READY→NULL | Remove the Sender or Receiver and close the daemon session; `active` becomes false |
 
 When neither `transport-file*` nor `caps` is set, `nmossink` defers
 configuration until it can query upstream caps at READY→PAUSED. `nmossrc`

--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -484,6 +484,13 @@ gst-launch pipelines, then drops into a menu that PATCHes the
 IS-05 endpoints so you can exercise activation paths against a
 live pipeline.
 
+The demo runs each pipeline with `gst-launch-1.0 -m`, so its log includes
+`nmos-activation` element messages whenever an `nmossink` Sender or `nmossrc`
+Receiver is activated, reactivated, or deactivated. The message fields include
+the new `active` value, resource name, and activation reason. Applications can
+also query the elements' read-only `active` property for the current state or
+connect to `notify::active` for property-change notifications.
+
 ### Three-Node Pipeline Diagrams
 
 Each Node runs its own `gst-launch-1.0` process (Node 3 uses two:

--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -139,6 +139,11 @@ _demo_line_buffered() {
     fi
 }
 
+# Run every demo pipeline with orderly EOS handling and bus-message logging.
+_demo_gst_launch() {
+    _demo_line_buffered gst-launch-1.0 -e -m "$@"
+}
+
 # Return 0 when ss reports a LISTEN socket on path (another nvnmosd up).
 # No listener / missing path in ss → return 1.
 _uds_socket_listening() {
@@ -648,7 +653,7 @@ launch_node1() {
     _rotate_log "$LOG_DIR/node1-producer.log"
     pipeline_dots_prepare_launch node1
     GST_DEBUG=${GST_DEBUG:-nmossink:3} \
-        _demo_line_buffered gst-launch-1.0 -e \
+        _demo_gst_launch \
             videotestsrc pattern=smpte horizontal-speed=2 is-live=true ! \
                 $VIDEO_CAPS ! \
                 nmossink \
@@ -695,7 +700,7 @@ launch_node4() {
     _rotate_log "$LOG_DIR/node4-producer.log"
     pipeline_dots_prepare_launch node4
     GST_DEBUG=${GST_DEBUG:-nmossink:3} \
-        _demo_line_buffered gst-launch-1.0 -e \
+        _demo_gst_launch \
             videotestsrc pattern=snow is-live=true ! \
                 $VIDEO_CAPS_ALT ! \
                 nmossink \
@@ -758,7 +763,7 @@ launch_node3_video() {
     _rotate_log "$LOG_DIR/node3-video.log"
     pipeline_dots_prepare_launch node3-video
     GST_DEBUG=${GST_DEBUG:-nmossrc:3,nmossink:3} \
-        _demo_line_buffered gst-launch-1.0 -e \
+        _demo_gst_launch \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
                 transport="$DEMO_TRANSPORT" \
@@ -796,7 +801,7 @@ launch_node3_audio() {
     _rotate_log "$LOG_DIR/node3-audio.log"
     pipeline_dots_prepare_launch node3-audio
     GST_DEBUG=${GST_DEBUG:-nmossrc:3,nmossink:3,nmosaudiochannelmap:3} \
-        _demo_line_buffered gst-launch-1.0 -e \
+        _demo_gst_launch \
             nmosaudiochannelmap name=map \
                 daemon-uri="unix:$SOCK" \
                 node-seed="$NODE3_SEED" \
@@ -881,7 +886,7 @@ launch_node2() {
     _rotate_log "$LOG_DIR/node2-consumer.log"
     pipeline_dots_prepare_launch node2
     GST_DEBUG=${GST_DEBUG:-nmossrc:3} \
-        _demo_line_buffered gst-launch-1.0 -e \
+        _demo_gst_launch \
             nmossrc \
                 daemon-uri="unix:$SOCK" \
                 transport="$DEMO_TRANSPORT" \
@@ -940,7 +945,7 @@ launch_bare_preview() {
     _rotate_log "$LOG_DIR/bare-preview.log"
     pipeline_dots_prepare_launch bare-preview
     GST_DEBUG=${GST_DEBUG:-mxlsrc:5,basesrc:4} \
-        _demo_line_buffered gst-launch-1.0 -e \
+        _demo_gst_launch \
             mxlsrc \
                 domain="$DEMO_MXL_DOMAIN_PATH" \
                 video-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" \

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -130,6 +130,8 @@ impl Default for Settings {
 #[derive(Default)]
 pub struct NmosSink {
     settings: Mutex<Settings>,
+    /// Whether the real inner transport chain is installed.
+    active: Mutex<bool>,
     session: Mutex<Option<Session>>,
     /// Ghost pad that hides the current inner chain behind the bin.
     /// Created at `constructed`; the chain behind it swaps between
@@ -219,6 +221,12 @@ impl ObjectImpl for NmosSink {
                     .blurb(crate::session::AUTO_ACTIVATE_BLURB)
                     .default_value(false)
                     .mutable_ready()
+                    .build(),
+                glib::ParamSpecBoolean::builder("active")
+                    .nick("Sender Active")
+                    .blurb(crate::session::ACTIVE_BLURB)
+                    .default_value(false)
+                    .read_only()
                     .build(),
                 glib::ParamSpecString::builder("label")
                     .nick("IS-04 Label")
@@ -441,6 +449,7 @@ impl ObjectImpl for NmosSink {
             "mxl-domain-path" => settings.mxl_domain_path.to_value(),
             "mxl-flow-id" => settings.mxl_flow_id.to_value(),
             "auto-activate" => settings.auto_activate.to_value(),
+            "active" => self.active.lock().unwrap().to_value(),
             "label" => settings.label.to_value(),
             "description" => settings.description.to_value(),
             "group-hint" => settings.group_hint.to_value(),
@@ -558,6 +567,18 @@ impl ElementImpl for NmosSink {
 impl BinImpl for NmosSink {}
 
 impl NmosSink {
+    // Locks `settings`; must not be called while that mutex is held.
+    fn set_connection_active(&self, new_active: bool, reason: &'static str) {
+        let resource_name = self.settings.lock().unwrap().sender_name.clone();
+        crate::session::connection_active::set_connection_active(
+            self.obj().upcast_ref(),
+            &self.active,
+            new_active,
+            &resource_name,
+            reason,
+        );
+    }
+
     fn open_session(&self) -> Result<(), anyhow::Error> {
         let snapshot = self.settings.lock().unwrap().clone();
         let bin = self.obj();
@@ -583,8 +604,10 @@ impl NmosSink {
     fn activate_inner(&self, bin: &gst::Bin, outcome: &InnerConfig) -> Result<(), anyhow::Error> {
         match outcome {
             InnerConfig::Real(transport) => {
-                let settings = self.settings.lock().unwrap();
-                let new_inner = build_real_sink(transport, &settings)?;
+                let new_inner = {
+                    let settings = self.settings.lock().unwrap();
+                    build_real_sink(transport, &settings)?
+                };
                 self.swap_inner(bin, &new_inner)?;
                 // Reaching the `Real` branch at NULL→READY / READY→PAUSED
                 // implies `auto-activate=true` (the `validate_and_open` and
@@ -604,6 +627,9 @@ impl NmosSink {
                     // failure as a warning so it shows up in logs.
                     gst::warning!(CAT, "nmossink auto-activate sync failed: {e:#}");
                 }
+                // Must not hold `settings` here — `set_connection_active`
+                // locks it again for the resource name.
+                self.set_connection_active(true, "auto-activate");
             }
             InnerConfig::Fake { .. } => {
                 self.upgrade_fake_chain_from_settings(bin)?;
@@ -614,6 +640,7 @@ impl NmosSink {
 
     fn close_session(&self) {
         crate::session::close(&CAT, "nmossink", &self.session);
+        self.set_connection_active(false, "deactivate");
         let bin = self.obj();
         let bin_ref: &gst::Bin = bin.upcast_ref();
         let snapshot = self.settings.lock().unwrap().clone();
@@ -910,7 +937,12 @@ impl NmosSink {
             };
         }
         match &plan.ack {
-            ActivationAck::Success => ActivationOutcome::Applied,
+            ActivationAck::Success => {
+                let new_active = matches!(plan.inner, InnerConfig::Real(_));
+                let reason = if new_active { "activate" } else { "deactivate" };
+                self.set_connection_active(new_active, reason);
+                ActivationOutcome::Applied
+            }
             ActivationAck::Failure { reason } => ActivationOutcome::Failed {
                 reason: reason.clone(),
             },
@@ -1105,6 +1137,21 @@ mod tests {
     use super::*;
     use crate::session::CommonSettings;
     use crate::test_support::init_gst;
+
+    #[test]
+    fn active_property_is_read_only_and_defaults_false() {
+        init_gst();
+        // auto-activate is a NULL→READY policy only; active stays false until then.
+        let element = glib::Object::builder::<crate::nmossink::NmosSink>()
+            .property("auto-activate", true)
+            .build();
+
+        assert!(!element.property::<bool>("active"));
+        let pspec = element.find_property("active").expect("active property");
+        assert!(pspec.flags().contains(glib::ParamFlags::READABLE));
+        assert!(!pspec.flags().contains(glib::ParamFlags::WRITABLE));
+        assert_eq!(pspec.nick(), "Sender Active");
+    }
 
     /// Pins the IS-05 Sender `transport_params` → `CommonSettings`
     /// mapping. `nmossink` populates the sender-side slots

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -135,6 +135,8 @@ impl Default for Settings {
 #[derive(Default)]
 pub struct NmosSrc {
     settings: Mutex<Settings>,
+    /// Whether the real inner transport chain is installed.
+    active: Mutex<bool>,
     session: Mutex<Option<Session>>,
     /// Ghost pad that hides the current inner chain behind the bin.
     /// Created at `constructed`; the chain behind it swaps between
@@ -220,6 +222,12 @@ impl ObjectImpl for NmosSrc {
                     .nick("Auto-Activate")
                     .blurb(crate::session::AUTO_ACTIVATE_BLURB)
                     .default_value(false)
+                    .build(),
+                glib::ParamSpecBoolean::builder("active")
+                    .nick("Receiver Active")
+                    .blurb(crate::session::ACTIVE_BLURB)
+                    .default_value(false)
+                    .read_only()
                     .build(),
                 glib::ParamSpecString::builder("label")
                     .nick("IS-04 Label")
@@ -440,6 +448,7 @@ impl ObjectImpl for NmosSrc {
             "mxl-domain-path" => settings.mxl_domain_path.to_value(),
             "mxl-flow-id" => settings.mxl_flow_id.to_value(),
             "auto-activate" => settings.auto_activate.to_value(),
+            "active" => self.active.lock().unwrap().to_value(),
             "label" => settings.label.to_value(),
             "description" => settings.description.to_value(),
             "group-hint" => settings.group_hint.to_value(),
@@ -532,6 +541,18 @@ impl ElementImpl for NmosSrc {
 impl BinImpl for NmosSrc {}
 
 impl NmosSrc {
+    // Locks `settings`; must not be called while that mutex is held.
+    fn set_connection_active(&self, new_active: bool, reason: &'static str) {
+        let resource_name = self.settings.lock().unwrap().receiver_name.clone();
+        crate::session::connection_active::set_connection_active(
+            self.obj().upcast_ref(),
+            &self.active,
+            new_active,
+            &resource_name,
+            reason,
+        );
+    }
+
     fn open_session(&self) -> Result<(), anyhow::Error> {
         let snapshot = self.settings.lock().unwrap().clone();
         let bin = self.obj();
@@ -638,6 +659,7 @@ impl NmosSrc {
                 ) {
                     gst::warning!(CAT, "nmossrc auto-activate sync failed: {e:#}");
                 }
+                self.set_connection_active(true, "auto-activate");
             }
             InnerConfig::Fake { .. } => {
                 self.upgrade_fake_chain_from_settings(bin)?;
@@ -648,6 +670,7 @@ impl NmosSrc {
 
     fn close_session(&self) {
         crate::session::close(&CAT, "nmossrc", &self.session);
+        self.set_connection_active(false, "deactivate");
         let bin = self.obj();
         let bin_ref: &gst::Bin = bin.upcast_ref();
         // The bin is heading back to NULL, so caps aren't strictly
@@ -952,7 +975,12 @@ impl NmosSrc {
             };
         }
         match &plan.ack {
-            ActivationAck::Success => ActivationOutcome::Applied,
+            ActivationAck::Success => {
+                let new_active = matches!(plan.inner, InnerConfig::Real(_));
+                let reason = if new_active { "activate" } else { "deactivate" };
+                self.set_connection_active(new_active, reason);
+                ActivationOutcome::Applied
+            }
             ActivationAck::Failure { reason } => ActivationOutcome::Failed {
                 reason: reason.clone(),
             },
@@ -1144,6 +1172,21 @@ mod tests {
     };
     use crate::test_support::init_gst;
     use crate::types::FlowFormat;
+
+    #[test]
+    fn active_property_is_read_only_and_defaults_false() {
+        init_gst();
+        // auto-activate is a NULL→READY policy only; active stays false until then.
+        let element = glib::Object::builder::<crate::nmossrc::NmosSrc>()
+            .property("auto-activate", true)
+            .build();
+
+        assert!(!element.property::<bool>("active"));
+        let pspec = element.find_property("active").expect("active property");
+        assert!(pspec.flags().contains(glib::ParamFlags::READABLE));
+        assert!(!pspec.flags().contains(glib::ParamFlags::WRITABLE));
+        assert_eq!(pspec.nick(), "Receiver Active");
+    }
 
     /// Pins the IS-05 Receiver `transport_params` →
     /// `CommonSettings` mapping. `nmossrc` populates the

--- a/rust/gst-nmos-rs/src/session/connection_active.rs
+++ b/rust/gst-nmos-rs/src/session/connection_active.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! NMOS activation observability for `nmossrc` / `nmossink`.
+//!
+//! Updates the read-only `active` property and posts an element message on
+//! the pipeline bus when the data plane becomes live or dormant.
+
+use std::sync::{LazyLock, Mutex};
+
+use gstreamer as gst;
+use gstreamer::prelude::*;
+
+static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
+    gst::DebugCategory::new(
+        "nmos-connection-active",
+        gst::DebugColorFlags::empty(),
+        Some("NMOS connection-active observability"),
+    )
+});
+
+const MESSAGE_STRUCTURE: &str = "nmos-activation";
+
+/// Set connection-active state and report the transition to the application.
+///
+/// Updates the `active` property when the boolean changes and always posts a
+/// `nmos-activation` element message (including real→real reconfigurations
+/// where `active` stays true).
+pub(crate) fn set_connection_active(
+    element: &gst::Element,
+    active: &Mutex<bool>,
+    new_active: bool,
+    resource_name: &str,
+    reason: &'static str,
+) {
+    let notify = {
+        let mut stored = active.lock().expect("connection active lock");
+        let changed = *stored != new_active;
+        *stored = new_active;
+        changed
+    };
+    if notify && element.find_property("active").is_some() {
+        element.notify("active");
+    }
+
+    let structure = gst::Structure::builder(MESSAGE_STRUCTURE)
+        .field("active", new_active)
+        .field("resource-name", resource_name)
+        .field("reason", reason)
+        .build();
+    let message = gst::message::Element::builder(structure)
+        .src(element)
+        .build();
+    if let Err(e) = element.post_message(message) {
+        gst::warning!(
+            CAT,
+            obj = element,
+            "failed to post {MESSAGE_STRUCTURE} element message \
+             (active={new_active}, resource-name={resource_name}, reason={reason}): {e}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::init_gst;
+
+    #[test]
+    fn posts_each_nmos_activation_element_message() {
+        init_gst();
+        let pipeline = gst::Pipeline::default();
+        let sink = gst::ElementFactory::make("fakesink")
+            .build()
+            .expect("fakesink");
+        pipeline.add(&sink).expect("add fakesink");
+        let bus = pipeline.bus().expect("pipeline bus");
+
+        let active = Mutex::new(false);
+        set_connection_active(sink.upcast_ref(), &active, true, "video-a", "activate");
+        assert!(*active.lock().unwrap());
+        set_connection_active(sink.upcast_ref(), &active, true, "video-a", "activate");
+        assert!(*active.lock().unwrap());
+        set_connection_active(sink.upcast_ref(), &active, false, "video-a", "deactivate");
+        assert!(!*active.lock().unwrap());
+
+        for (expected_active, expected_reason) in [
+            (true, "activate"),
+            (true, "activate"),
+            (false, "deactivate"),
+        ] {
+            let msg = bus
+                .timed_pop(gst::ClockTime::from_seconds(1))
+                .expect("bus message");
+            let gst::MessageView::Element(element_msg) = msg.view() else {
+                panic!("expected Element message, got {:?}", msg.type_());
+            };
+            let structure = element_msg.structure().expect("structure");
+            assert_eq!(structure.name(), MESSAGE_STRUCTURE);
+            assert_eq!(structure.get::<bool>("active").ok(), Some(expected_active));
+            assert_eq!(structure.get::<&str>("resource-name").ok(), Some("video-a"));
+            assert_eq!(structure.get::<&str>("reason").ok(), Some(expected_reason));
+        }
+        assert!(bus.timed_pop(gst::ClockTime::ZERO).is_none());
+    }
+}

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -26,6 +26,7 @@ use crate::types::{CapsMode, DEFAULT_DAEMON_URI, FlowFormat, Transport};
 const OPEN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) mod channel_mapping;
+pub(crate) mod connection_active;
 pub(crate) mod node;
 pub(crate) mod types;
 
@@ -187,8 +188,13 @@ pub(crate) const DEPAY_PROPERTIES_BLURB: &str = "\
     Receiver data plane is built. Used only with RTP/UDP.";
 
 pub(crate) const AUTO_ACTIVATE_BLURB: &str = "\
-    Activate the configured data path without waiting for an IS-05 controller. \
+    Activate the configured data plane without waiting for an IS-05 controller. \
     This property does not change the GStreamer pipeline state. Default: false.";
+
+pub(crate) const ACTIVE_BLURB: &str = "\
+    Whether the data plane is currently active (real inner transport chain). \
+    Orthogonal to GStreamer pipeline state: the pipeline may be PLAYING while \
+    this property is false when waiting for activation.";
 
 /// Snapshot of the properties needed to open a session, taken under
 /// the per-element settings lock so the lock isn't held over the

--- a/rust/gst-nmos-rs/tests/connection_active.rs
+++ b/rust/gst-nmos-rs/tests/connection_active.rs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression: auto-activate must not deadlock NULL→READY.
+//!
+//! `nmossink::activate_inner` used to hold the `settings` mutex across
+//! `set_connection_active`, which locks `settings` again for the resource
+//! name — a same-thread deadlock that wedged `av_sync_via_udp` in CI. This
+//! test drives one auto-activating `nmossink` through NULL→READY with a
+//! watchdog so a hang aborts instead of stalling the suite.
+
+mod common;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use common::{DaemonGuard, init, nvnmosd_skip_reason, require_factories};
+use gst::prelude::*;
+use gstreamer as gst;
+use test_skip::skip;
+
+const HANG_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn nic_ip() -> String {
+    if let Ok(ip) = std::env::var("NVNMOS_TEST_NIC_IP") {
+        return ip;
+    }
+    let out = std::process::Command::new("ip")
+        .args(["-4", "-o", "addr", "show"])
+        .output();
+    if let Ok(out) = out {
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            let f: Vec<&str> = line.split_whitespace().collect();
+            if f.len() >= 4 && f[1] != "lo" {
+                if let Some(ip) = f[3].split('/').next() {
+                    return ip.to_owned();
+                }
+            }
+        }
+    }
+    "127.0.0.1".to_owned()
+}
+
+#[test]
+fn auto_activate_null_to_ready_does_not_hang() {
+    init();
+    if let Some(why) = nvnmosd_skip_reason() {
+        skip!(why);
+    }
+    require_factories(&["nmossink", "udpsink", "rtpvrawpay"]);
+
+    let pid = std::process::id();
+    let now_nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let socket = PathBuf::from(format!("/tmp/nvnmos_conn_active_{pid}_{now_nanos}.sock"));
+    let _daemon = DaemonGuard::new(socket);
+    let uri = _daemon.uri();
+    let nic = nic_ip();
+
+    // GStreamer state changes must run on this thread; the watchdog only
+    // converts a wedged transition into a hard failure for CI.
+    let finished = Arc::new(AtomicBool::new(false));
+    {
+        let finished = Arc::clone(&finished);
+        std::thread::spawn(move || {
+            std::thread::sleep(HANG_TIMEOUT);
+            if !finished.load(Ordering::SeqCst) {
+                eprintln!(
+                    "nmossink NULL→READY with auto-activate hung for {HANG_TIMEOUT:?} — \
+                     likely settings mutex re-lock in set_connection_active"
+                );
+                std::process::abort();
+            }
+        });
+    }
+
+    let desc = format!(
+        "nmossink name=s daemon-uri=\"{uri}\" transport=udp \
+         node-seed=conn-active-test sender-name=video-a auto-activate=true \
+         caps=\"video/x-raw,format=UYVP,width=192,height=4,framerate=25/1\" \
+         destination-ip={nic} destination-port=15040 source-ip={nic}"
+    );
+    // Single-element launch returns the element itself, not a Pipeline.
+    let sink = gst::parse::launch(&desc).expect("parse nmossink");
+    let pipeline = gst::Pipeline::default();
+    pipeline.add(&sink).expect("add nmossink");
+    let bus = pipeline.bus().expect("bus");
+
+    pipeline.set_state(gst::State::Ready).expect("NULL→READY");
+    let (res, ..) = pipeline.state(gst::ClockTime::from_seconds(10));
+    res.expect("reached READY");
+
+    assert!(
+        sink.property::<bool>("active"),
+        "auto-activate READY must set active=true"
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut saw_activation = false;
+    while std::time::Instant::now() < deadline {
+        let Some(msg) = bus.timed_pop(gst::ClockTime::from_mseconds(200)) else {
+            continue;
+        };
+        let gst::MessageView::Element(element_msg) = msg.view() else {
+            continue;
+        };
+        let Some(structure) = element_msg.structure() else {
+            continue;
+        };
+        if structure.name() != "nmos-activation" {
+            continue;
+        }
+        assert_eq!(structure.get::<bool>("active").ok(), Some(true));
+        assert_eq!(structure.get::<&str>("resource-name").ok(), Some("video-a"));
+        assert_eq!(structure.get::<&str>("reason").ok(), Some("auto-activate"));
+        saw_activation = true;
+        break;
+    }
+    assert!(
+        saw_activation,
+        "expected nmos-activation element message on auto-activate"
+    );
+
+    pipeline.set_state(gst::State::Null).expect("READY→NULL");
+    finished.store(true, Ordering::SeqCst);
+}


### PR DESCRIPTION
## Summary
- Add a read-only `active` property and `nmos-activation` bus messages on `nmossink` / `nmossrc` so applications can track NMOS data-plane activation independently of GStreamer pipeline state (TR-1001-style resume bookkeeping).
- Document the lifecycle transitions and demo `-m` bus logging; centralize demo `gst-launch` flags in `_demo_gst_launch`.

## Test plan
- [x] `cargo fmt -p gst-nmos-rs -- --check`
- [x] `cargo clippy -p gst-nmos-rs --all-targets -- -D warnings`
- [x] `cargo test -p gst-nmos-rs --lib` (520 passed)
- [x] `bash -n rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh`
- [ ] Optional: run `./scripts/gst-nmos-rs-demo.sh` and confirm `nmos-activation` messages appear in pipeline logs on IS-05 enable/disable