### PR TITLE
gst-nmos-rs: wait for stable IS-08 test tones

### DIFF
--- a/rust/gst-nmos-rs/tests/is08_audio_channelmap.rs
+++ b/rust/gst-nmos-rs/tests/is08_audio_channelmap.rs
@@ -107,46 +107,76 @@ fn pull_mono_samples(appsink: &gst_app::AppSink, timeout: Duration) -> Vec<f32> 
     mono
 }
 
-fn sample_has_signal(sample: &gst::Sample) -> bool {
-    let Some(buffer) = sample.buffer() else {
-        return false;
-    };
-    let Ok(map) = buffer.map_readable() else {
-        return false;
-    };
-
-    map.as_slice().chunks_exact(4).any(|sample| {
-        let sample = f32::from_le_bytes(sample.try_into().unwrap());
-        sample != 0.0
-    })
+/// True when one of the two test tones clearly dominates (same 4x bar as the
+/// routing assertions), without caring which tone.
+fn has_dominant_tone(samples: &[f32]) -> bool {
+    let p_low = common::goertzel_power(samples, SAMPLE_RATE as f32, A4_HZ);
+    let p_high = common::goertzel_power(samples, SAMPLE_RATE as f32, perfect_fifth_hz(A4_HZ));
+    p_low > p_high * 4.0 || p_high > p_low * 4.0
 }
 
-/// Pull and drop samples from each appsink until it has yielded non-silence, so
-/// the caller measures steady-state output rather than the startup transient
-/// where audiomixer can emit silence for an input leg that has not delivered yet.
+/// Pull and drop samples from each appsink until every output shows a clearly
+/// dominant single tone. Waiting only for non-zero is not enough: before both
+/// mixer input legs are active and routed cleanly, an output can carry a mix of
+/// both tones (or silence). Poll concurrently so neither appsink stalls the
+/// other while `drop=true` keeps queues at the newest buffers.
 fn settle(appsinks: &[(&str, &gst_app::AppSink)], timeout: Duration) {
-    for (name, appsink) in appsinks {
-        let deadline = std::time::Instant::now() + timeout;
-        let mut saw_signal = false;
-        loop {
-            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-            let remaining_ms = u64::try_from(remaining.as_millis()).unwrap_or(0);
-            if remaining_ms == 0 {
-                break;
-            }
-            let Some(sample) = appsink.try_pull_sample(gst::ClockTime::from_mseconds(remaining_ms))
-            else {
-                std::thread::sleep(Duration::from_millis(5));
-                continue;
-            };
-            if sample_has_signal(&sample) {
-                saw_signal = true;
-                break;
+    let min_frames = SAMPLE_RATE as usize / 20;
+    let max_frames = SAMPLE_RATE as usize / 5;
+    let deadline = std::time::Instant::now() + timeout;
+    let mut ready = vec![false; appsinks.len()];
+    let mut acc = vec![Vec::<f32>::new(); appsinks.len()];
+
+    while !ready.iter().all(|&r| r) {
+        if deadline
+            .saturating_duration_since(std::time::Instant::now())
+            .is_zero()
+        {
+            break;
+        }
+        let mut got_any = false;
+        for (i, (_name, appsink)) in appsinks.iter().enumerate() {
+            while let Some(sample) = appsink.try_pull_sample(gst::ClockTime::ZERO) {
+                got_any = true;
+                let Some(buffer) = sample.buffer() else {
+                    continue;
+                };
+                let Ok(map) = buffer.map_readable() else {
+                    continue;
+                };
+                if ready[i] {
+                    continue;
+                }
+                // Mixer silence for an inactive input is exact F32 zero samples.
+                let silent = map
+                    .as_slice()
+                    .chunks_exact(4)
+                    .all(|word| f32::from_le_bytes(word.try_into().unwrap()) == 0.0);
+                if silent {
+                    acc[i].clear();
+                    continue;
+                }
+                acc[i].extend(common::stereo_f32le_to_mono(map.as_slice()));
+                if acc[i].len() > max_frames {
+                    let drain = acc[i].len() - min_frames;
+                    acc[i].drain(..drain);
+                }
+                if acc[i].len() >= min_frames && has_dominant_tone(&acc[i]) {
+                    ready[i] = true;
+                    acc[i].clear();
+                }
             }
         }
+        if !got_any {
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    for (i, (name, _)) in appsinks.iter().enumerate() {
         assert!(
-            saw_signal,
-            "{name}: did not produce non-silent audio during settle"
+            ready[i],
+            "{name}: did not settle to a dominant tone (acc_frames={})",
+            acc[i].len()
         );
     }
 }
@@ -284,10 +314,10 @@ fn run_routing_case(daemon_uri: &str, node_seed: &str, case: &RoutingCase, decla
 
     set_playing_or_panic(&pipeline);
 
-    // Discard the startup transient before measuring: audiomixer
-    // (ignore-inactive-pads=true) can emit silence for an input leg that has not
-    // delivered yet. Once both outputs have yielded non-silence, the dominance
-    // checks below measure steady-state routing rather than startup timing.
+    // Discard the startup transient before measuring: before both audiomixer
+    // input legs are active and routed cleanly, an output can be silent or carry
+    // a mix of both tones. Wait until each appsink shows a clearly dominant
+    // single tone; the assertions below then check which tone that is.
     settle(
         &[("src_0", &out0), ("src_1", &out1)],
         Duration::from_secs(3),


### PR DESCRIPTION
## Summary
- poll both IS-08 test outputs concurrently during startup
- wait until each output has a clearly dominant test tone before validating routing
- reject silent or mixed startup windows that can make the Goertzel assertion flaky

## Test plan
- [x] Run `is08_audio_channelmap` 12 times with `--test-threads=1`
- [x] Run `is08_audio_channelmap` 8 times with default parallelism
- [x] Verify `cargo fmt -p gst-nmos-rs -- --check`