### PR TITLE
gst-nmos-rs: add Node metadata properties

### DIFF
--- a/doc/designs/gst-nmos-rs-mutable-ready-audit.md
+++ b/doc/designs/gst-nmos-rs-mutable-ready-audit.md
@@ -55,7 +55,8 @@ PLAYING
 | inner build  | `mutable_ready()` — **NULL/READY** before PLAYING                               | same (`mxl-domain-path`, `transport-properties`, `depay-properties` only) |
 
 
-**`*-properties` (current choice, may revisit):** `mutable_ready()` only, not `mutable_playing()`. Bags apply on the **next** inner build so PLAYING-time sets are rejected. Revisit if applications need to tune them during the PLAYING wait or between real→real activation-event swaps.
+- **`node-properties`:** Consumed during NULL→READY when the element opens its session.
+- **`transport-properties`, `pay-properties`, and `depay-properties` (current choice, may revisit):** `mutable_ready()` only, not `mutable_playing()`. These bags apply on the **next** inner build, so PLAYING-time sets are rejected. Revisit if applications need to tune them during the PLAYING wait or between real→real activation-event swaps.
 
 **gst-launch:** sets props in NULL before READY — NULL-only pspec is enough for typical lines.
 
@@ -69,6 +70,7 @@ PLAYING
 | `node-seed` | open-session |
 | `http-port` | open-session |
 | `host-name` | open-session |
+| `node-properties` | open-session |
 | `domain` | open-session |
 | `registration-url` | open-session |
 | `system-url` | open-session |
@@ -102,6 +104,7 @@ PLAYING
 | `node-seed` | open-session |
 | `http-port` | open-session |
 | `host-name` | open-session |
+| `node-properties` | open-session |
 | `domain` | open-session |
 | `registration-url` | open-session |
 | `system-url` | open-session |

--- a/rust/docs/gstreamer/plugins/gst_plugins_cache.json
+++ b/rust/docs/gstreamer/plugins/gst_plugins_cache.json
@@ -575,6 +575,17 @@
                         "type": "gchararray",
                         "writable": true
                     },
+                    "node-properties": {
+                        "blurb": "Node and Device metadata. Supported fields are `label`, `description`, `manufacturer`, `product`, `instance-id`, and `functions`; the asset fields must be supplied together. For example `properties,label=Studio-A,manufacturer=Acme,product=(string)\"Widget Pro\",instance-id=XYZ123-456789,functions=(string)<Encoder,Decoder>`. Only the first element to create the Node controls this value.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "GstStructure",
+                        "writable": true
+                    },
                     "node-seed": {
                         "blurb": "Caller-chosen seed for the NMOS Node. Elements using the same seed with one daemon join the same Node. Use a globally unique seed for each Node. It determines stable NMOS resource IDs. It is required.",
                         "conditionally-available": false,
@@ -976,6 +987,17 @@
                         "mutable": "null",
                         "readable": true,
                         "type": "gchararray",
+                        "writable": true
+                    },
+                    "node-properties": {
+                        "blurb": "Node and Device metadata. Supported fields are `label`, `description`, `manufacturer`, `product`, `instance-id`, and `functions`; the asset fields must be supplied together. For example `properties,label=Studio-A,manufacturer=Acme,product=(string)\"Widget Pro\",instance-id=XYZ123-456789,functions=(string)<Encoder,Decoder>`. Only the first element to create the Node controls this value.",
+                        "conditionally-available": false,
+                        "construct": false,
+                        "construct-only": false,
+                        "controllable": false,
+                        "mutable": "null",
+                        "readable": true,
+                        "type": "GstStructure",
                         "writable": true
                     },
                     "node-seed": {

--- a/rust/gst-nmos-rs/configuration.md
+++ b/rust/gst-nmos-rs/configuration.md
@@ -58,7 +58,7 @@ which properties matter for a task:
 | RTP/UDP | Sender: `source-ip`, `source-port`, `destination-ip`, `destination-port`; Receiver: `source-ip`, `interface-ip`, `multicast-ip`, `destination-port`; both: `transport-caps`, `format-bit-rate`, `transport-bit-rate` | Configure SDP and IS-05 endpoint values for `udp`, `udp2`, and `nvdsudp`; the bit-rate properties apply to JPEG XS on `udp` / `udp2` |
 | MXL | `mxl-domain-path`, `mxl-domain-id`, `mxl-flow-id` | Select the local MXL domain and flow for `transport=mxl` |
 | Human-readable metadata | `label`, `description`, `group-hint` | Set human-readable labels, descriptions, and grouping metadata for NMOS resources |
-| Node and session | `daemon-uri`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url` | Connect to the daemon and configure the NMOS Node; Node properties are taken from the first session that creates a shared `node-seed` |
+| Node and session | `daemon-uri`, `http-port`, `host-name`, `node-properties`, `domain`, `registration-url`, `system-url` | Connect to the daemon and configure the NMOS Node; Node properties are taken from the first session that creates a shared `node-seed` |
 | Inner-element overrides | `transport-properties`, `pay-properties`, `depay-properties` | Pass advanced properties to generated inner elements; payloader and depayloader overrides apply only to `udp` / `udp2` |
 
 The `source-ip` and `destination-port` properties follow the corresponding IS-05
@@ -66,6 +66,35 @@ transport parameter semantics, so their Sender and Receiver meanings differ.
 For a Sender, `source-ip` is the local egress address and
 `destination-port` is remote. For a Receiver, `source-ip` is an optional remote
 source-specific multicast filter and `destination-port` is the local listen port.
+
+### Node and Device Metadata
+
+`node-properties` is a `GstStructure` containing optional metadata for the
+NMOS Node and Device. It supports these fields:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `label` | string | IS-04 label for the Node and Device |
+| `description` | string | IS-04 description for the Node and Device |
+| `manufacturer` | string | BCP-002-02 asset manufacturer |
+| `product` | string | BCP-002-02 asset product name |
+| `instance-id` | string | BCP-002-02 asset instance identifier |
+| `functions` | string or string array | One or more BCP-002-02 asset functions |
+
+The four asset fields must be supplied together and must be non-empty. When
+asset information is supplied without an explicit `label` or `description`,
+libnvnmos synthesises those values from the asset information.
+
+For example:
+
+```text
+node-properties="properties,label=Studio-A,description=Primary-encoder,\
+manufacturer=Acme,product=(string)\"Widget Pro\",\
+instance-id=XYZ123-456789,functions=(string)<Encoder,Decoder>"
+```
+
+Only the first session to create a shared `node-seed` controls this metadata;
+later sessions attach to the existing Node without changing it.
 
 ### Supported Caps Essence Shapes
 
@@ -103,7 +132,7 @@ these rules to construct the configuring transport file sent to the daemon:
 | Bit rates | `format-bit-rate`, `transport-bit-rate` | **Cross-check or apply property values.** A missing bit rate is approximated separately for the SDP and property values. If the SDP and properties both specify bit rates, the resulting values must agree; if only the properties do, the property-derived values are applied. |
 | RTP parameters | `transport-caps` | **Cross-check or apply property values.** Dynamic payload type, audio clock rate, and `a-ptime` / `a-maxptime` are applied to the configuring SDP. The remaining RTP and essence-shape fields must agree with the supplied SDP. |
 | Activation policy | `auto-activate` | **Not in the configuring transport file.** Selects self-starting or Controller-managed activation. |
-| Other configuration | `daemon-uri`, `node-seed`, `http-port`, `host-name`, `domain`, `registration-url`, `system-url`, `transport`, `mxl-domain-path`, `transport-properties`, `pay-properties`, `depay-properties` | **Not in the configuring transport file.** Node properties configure the NMOS Node; when sessions share a `node-seed`, the first session to create the Node determines those settings. The remaining properties control the daemon connection or configure the local data plane and its inner GStreamer elements. |
+| Other configuration | `daemon-uri`, `node-seed`, `http-port`, `host-name`, `node-properties`, `domain`, `registration-url`, `system-url`, `transport`, `mxl-domain-path`, `transport-properties`, `pay-properties`, `depay-properties` | **Not in the configuring transport file.** Node properties configure the NMOS Node; when sessions share a `node-seed`, the first session to create the Node determines those settings. The remaining properties control the daemon connection or configure the local data plane and its inner GStreamer elements. |
 
 Bit rates are in kilobits per second and correspond to NMOS Flow and Sender
 `bit_rate`. SDP may carry the transport rate in `b=AS:` and either rate in the

--- a/rust/gst-nmos-rs/src/channel_mapping_session.rs
+++ b/rust/gst-nmos-rs/src/channel_mapping_session.rs
@@ -70,13 +70,14 @@ impl ChannelMappingSession {
         settings: &ChannelMappingSettings,
         activation_handler: ChannelMappingActivationHandler,
     ) -> Result<Self, DaemonError> {
+        let node_config = settings.node.to_node_config()?;
         let uds_path = parse_unix_uri(&settings.daemon_uri)?;
         let channel = connect_uds(uds_path).await?;
         let mut client = NvnmosDaemonClient::new(channel.clone());
 
         let resp = client
             .open_session(OpenSessionRequest {
-                node_config: Some(settings.node.to_node_config()),
+                node_config: Some(node_config),
             })
             .await?
             .into_inner();

--- a/rust/gst-nmos-rs/src/daemon.rs
+++ b/rust/gst-nmos-rs/src/daemon.rs
@@ -121,6 +121,8 @@ pub(crate) enum DaemonError {
     Transport(#[from] Box<tonic::transport::Error>),
     #[error("RPC error: {0}")]
     Rpc(#[from] Box<tonic::Status>),
+    #[error("invalid node-properties: {0}")]
+    NodeProperties(#[from] crate::session::node::NodePropertiesError),
     #[error("session already has a resource added; deferred AddSender is a one-shot operation")]
     AlreadyAdded,
     #[error(
@@ -171,13 +173,14 @@ impl Session {
         transport_file: Option<&str>,
         activation_handler: ActivationHandler,
     ) -> Result<Self, DaemonError> {
+        let node_config = settings.node.to_node_config()?;
         let uds_path = parse_unix_uri(daemon_uri)?;
         let channel = connect_uds(uds_path).await?;
         let mut client = NvnmosDaemonClient::new(channel.clone());
 
         let resp = client
             .open_session(OpenSessionRequest {
-                node_config: Some(settings.node.to_node_config()),
+                node_config: Some(node_config),
             })
             .await?
             .into_inner();

--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -566,10 +566,10 @@ pub(crate) fn from_caps(input: &FlowDefBuildInput<'_>) -> Result<String, FlowDef
     // `label` is `field_as_string` (required) in nmos-cpp — empty
     // would be accepted as long as the key is present, but a more
     // helpful default is the resource name.
-    let label = if input.label.is_empty() {
-        input.name
-    } else {
+    let label = if !input.label.is_empty() {
         input.label
+    } else {
+        input.name
     };
     let format_urn = format
         .as_format_urn()

--- a/rust/gst-nmos-rs/src/network_services.rs
+++ b/rust/gst-nmos-rs/src/network_services.rs
@@ -136,7 +136,7 @@ mod tests {
             domain: "local".to_owned(),
             ..NodeSettings::default()
         };
-        let config = node.to_node_config();
+        let config = node.to_node_config().unwrap();
         assert_eq!(config.seed, "seed-a");
         assert_eq!(config.host_name, "studio-a");
         let ns = config
@@ -153,7 +153,7 @@ mod tests {
             system_url: "http://sys:10641/x-nmos/system/v1.0".to_owned(),
             ..NodeSettings::default()
         };
-        let config = node.to_node_config();
+        let config = node.to_node_config().unwrap();
         let ns = config
             .network_services
             .expect("urls should populate network_services");

--- a/rust/gst-nmos-rs/src/nmosaudiochannelmap/imp.rs
+++ b/rust/gst-nmos-rs/src/nmosaudiochannelmap/imp.rs
@@ -74,6 +74,7 @@ impl From<&Settings> for ChannelMappingSettings {
                 node_seed: s.node_seed.clone(),
                 http_port: s.http_port,
                 host_name: s.host_name.clone(),
+                node_properties: None,
                 domain: s.domain.clone(),
                 registration_url: s.registration_url.clone(),
                 system_url: s.system_url.clone(),

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -53,6 +53,7 @@ struct Settings {
     node_seed: String,
     http_port: u16,
     host_name: String,
+    node_properties: Option<gst::Structure>,
     domain: String,
     registration_url: String,
     system_url: String,
@@ -99,6 +100,7 @@ impl Default for Settings {
             node_seed: String::new(),
             http_port: 0,
             host_name: String::new(),
+            node_properties: None,
             domain: String::new(),
             registration_url: String::new(),
             system_url: String::new(),
@@ -170,6 +172,10 @@ impl ObjectImpl for NmosSink {
                 glib::ParamSpecString::builder("host-name")
                     .nick("Host Name")
                     .blurb(crate::session::HOST_NAME_BLURB)
+                    .build(),
+                glib::ParamSpecBoxed::builder::<gst::Structure>("node-properties")
+                    .nick("Node Properties")
+                    .blurb(crate::session::NODE_PROPERTIES_BLURB)
                     .build(),
                 glib::ParamSpecString::builder("domain")
                     .nick("NMOS DNS Domain")
@@ -355,6 +361,9 @@ impl ObjectImpl for NmosSink {
             "host-name" => {
                 settings.host_name = string_or_empty(value);
             }
+            "node-properties" => {
+                settings.node_properties = value.get().expect("type checked upstream");
+            }
             "domain" => {
                 settings.domain = string_or_empty(value);
             }
@@ -440,6 +449,7 @@ impl ObjectImpl for NmosSink {
             "node-seed" => settings.node_seed.to_value(),
             "http-port" => u32::from(settings.http_port).to_value(),
             "host-name" => settings.host_name.to_value(),
+            "node-properties" => settings.node_properties.to_value(),
             "domain" => settings.domain.to_value(),
             "registration-url" => settings.registration_url.to_value(),
             "system-url" => settings.system_url.to_value(),
@@ -1099,6 +1109,7 @@ impl From<Settings> for CommonSettings {
                 node_seed: s.node_seed,
                 http_port: s.http_port,
                 host_name: s.host_name,
+                node_properties: s.node_properties,
                 domain: s.domain,
                 registration_url: s.registration_url,
                 system_url: s.system_url,

--- a/rust/gst-nmos-rs/src/nmossink/mod.rs
+++ b/rust/gst-nmos-rs/src/nmossink/mod.rs
@@ -77,9 +77,10 @@
  * Sessions that share a `node-seed` contribute to the same NMOS Node, so one
  * host can present many Senders, Receivers and channel maps under a single
  * Node simply by reusing the seed. The Node identity properties — `host-name`,
- * `domain`, `registration-url`, `system-url` and `http-port` — are taken from
- * whichever session first creates the Node and ignored by later sessions that
- * attach to it.
+ * `node-properties`, `domain`, `registration-url`, `system-url` and
+ * `http-port` — are taken from whichever session first creates the Node and
+ * ignored by later sessions that attach to it. `node-properties` groups the
+ * Node and Device label, description, and BCP-002-02 asset information.
  *
  * ## Transport
  *

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -54,6 +54,7 @@ struct Settings {
     node_seed: String,
     http_port: u16,
     host_name: String,
+    node_properties: Option<gst::Structure>,
     domain: String,
     registration_url: String,
     system_url: String,
@@ -103,6 +104,7 @@ impl Default for Settings {
             node_seed: String::new(),
             http_port: 0,
             host_name: String::new(),
+            node_properties: None,
             domain: String::new(),
             registration_url: String::new(),
             system_url: String::new(),
@@ -175,6 +177,10 @@ impl ObjectImpl for NmosSrc {
                 glib::ParamSpecString::builder("host-name")
                     .nick("Host Name")
                     .blurb(crate::session::HOST_NAME_BLURB)
+                    .build(),
+                glib::ParamSpecBoxed::builder::<gst::Structure>("node-properties")
+                    .nick("Node Properties")
+                    .blurb(crate::session::NODE_PROPERTIES_BLURB)
                     .build(),
                 glib::ParamSpecString::builder("domain")
                     .nick("NMOS DNS Domain")
@@ -352,6 +358,9 @@ impl ObjectImpl for NmosSrc {
             "host-name" => {
                 settings.host_name = string_or_empty(value);
             }
+            "node-properties" => {
+                settings.node_properties = value.get().expect("type checked upstream");
+            }
             "domain" => {
                 settings.domain = string_or_empty(value);
             }
@@ -439,6 +448,7 @@ impl ObjectImpl for NmosSrc {
             "node-seed" => settings.node_seed.to_value(),
             "http-port" => u32::from(settings.http_port).to_value(),
             "host-name" => settings.host_name.to_value(),
+            "node-properties" => settings.node_properties.to_value(),
             "domain" => settings.domain.to_value(),
             "registration-url" => settings.registration_url.to_value(),
             "system-url" => settings.system_url.to_value(),
@@ -1131,6 +1141,7 @@ impl From<Settings> for CommonSettings {
                 node_seed: s.node_seed,
                 http_port: s.http_port,
                 host_name: s.host_name,
+                node_properties: s.node_properties,
                 domain: s.domain,
                 registration_url: s.registration_url,
                 system_url: s.system_url,

--- a/rust/gst-nmos-rs/src/nmossrc/mod.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/mod.rs
@@ -76,9 +76,10 @@
  * Sessions that share a `node-seed` contribute to the same NMOS Node, so one
  * host can present many Senders, Receivers and channel maps under a single
  * Node simply by reusing the seed. The Node identity properties — `host-name`,
- * `domain`, `registration-url`, `system-url` and `http-port` — are taken from
- * whichever session first creates the Node and ignored by later sessions that
- * attach to it.
+ * `node-properties`, `domain`, `registration-url`, `system-url` and
+ * `http-port` — are taken from whichever session first creates the Node and
+ * ignored by later sessions that attach to it. `node-properties` groups the
+ * Node and Device label, description, and BCP-002-02 asset information.
  *
  * ## Transport
  *

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -1612,8 +1612,8 @@ pub(crate) struct SdpBuildInput<'a> {
     /// Empty omits the attribute (libnvnmos then falls back to
     /// the `s=` value at `get_session_description_resource_name`).
     pub name: &'a str,
-    /// NMOS resource label → SDP `s=` line. Empty falls back to
-    /// `"nvnmos"`; RFC 4566 §5.3 requires `s=` to be non-empty.
+    /// NMOS resource label → SDP `s=` line. Empty falls back to the resource
+    /// name, then `"nvnmos"`; RFC 4566 §5.3 requires `s=` to be non-empty.
     pub label: &'a str,
     /// NMOS resource description → SDP `i=` line. Empty omits
     /// the `i=` line.
@@ -1750,7 +1750,11 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
     };
 
     let session_name = if input.label.is_empty() {
-        "nvnmos"
+        if input.name.is_empty() {
+            "nvnmos"
+        } else {
+            input.name
+        }
     } else {
         input.label
     };
@@ -6272,11 +6276,25 @@ mod tests {
     }
 
     #[test]
-    fn from_caps_empty_label_falls_back_to_nvnmos() {
+    fn from_caps_empty_label_falls_back_to_resource_name() {
         init_gst();
         let essence = raw_audio_caps("S24BE", 48_000, 2);
         let mut input = build_input(&essence, Side::Sender, None);
         input.label = "";
+        let text = from_caps(&input).expect("synth");
+        assert!(
+            text.contains("s=test-name"),
+            "default session name:\n{text}"
+        );
+    }
+
+    #[test]
+    fn from_caps_empty_label_and_name_falls_back_to_nvnmos() {
+        init_gst();
+        let essence = raw_audio_caps("S24BE", 48_000, 2);
+        let mut input = build_input(&essence, Side::Sender, None);
+        input.label = "";
+        input.name = "";
         let text = from_caps(&input).expect("synth");
         assert!(text.contains("s=nvnmos"), "default session name:\n{text}");
     }

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -1612,8 +1612,9 @@ pub(crate) struct SdpBuildInput<'a> {
     /// Empty omits the attribute (libnvnmos then falls back to
     /// the `s=` value at `get_session_description_resource_name`).
     pub name: &'a str,
-    /// NMOS resource label → SDP `s=` line. Empty falls back to the resource
-    /// name, then `"nvnmos"`; RFC 4566 §5.3 requires `s=` to be non-empty.
+    /// NMOS resource label → SDP `s=` line. Empty falls back to
+    /// the resource name, then `"nvnmos"`; RFC 4566 §5.3 requires
+    /// `s=` to be non-empty.
     pub label: &'a str,
     /// NMOS resource description → SDP `i=` line. Empty omits
     /// the `i=` line.
@@ -1739,39 +1740,35 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         bit_rates,
     };
 
-    let origin_address = if input.interface_ip.is_empty() {
-        if input.source_ip.is_empty() {
-            defaults::UNSPECIFIED_ADDRESS
-        } else {
-            input.source_ip
-        }
-    } else {
+    let origin_address = if !input.interface_ip.is_empty() {
         input.interface_ip
+    } else if !input.source_ip.is_empty() {
+        input.source_ip
+    } else {
+        defaults::UNSPECIFIED_ADDRESS
     };
 
-    let session_name = if input.label.is_empty() {
-        if input.name.is_empty() {
-            "nvnmos"
-        } else {
-            input.name
-        }
-    } else {
+    let session_name = if !input.label.is_empty() {
         input.label
-    };
-    let description = if input.description.is_empty() {
-        None
+    } else if !input.name.is_empty() {
+        input.name
     } else {
+        "nvnmos"
+    };
+    let description = if !input.description.is_empty() {
         Some(input.description)
-    };
-    let name = if input.name.is_empty() {
-        None
     } else {
+        None
+    };
+    let name = if !input.name.is_empty() {
         Some(input.name)
-    };
-    let group_hint = if input.group_hint.is_empty() {
-        None
     } else {
+        None
+    };
+    let group_hint = if !input.group_hint.is_empty() {
         Some(input.group_hint)
+    } else {
+        None
     };
 
     let origin_session_id = stable_origin_session_id(input.node_seed, input.side, input.name);
@@ -1926,10 +1923,10 @@ fn udp_leg_from_input(input: &SdpBuildInput<'_>) -> UdpLeg {
     } else {
         input.destination_port
     };
-    let source_ip = if input.source_ip.is_empty() {
-        None
-    } else {
+    let source_ip = if !input.source_ip.is_empty() {
         Some(input.source_ip.to_owned())
+    } else {
+        None
     };
     let interface_ip = match input.side {
         // Sender: the egress NIC IP comes in via `source_ip`
@@ -1941,10 +1938,10 @@ fn udp_leg_from_input(input: &SdpBuildInput<'_>) -> UdpLeg {
         // Receiver: `interface_ip` is the join NIC, a distinct
         // GObject property from `source_ip`.
         Side::Receiver => {
-            if input.interface_ip.is_empty() {
-                None
-            } else {
+            if !input.interface_ip.is_empty() {
                 Some(input.interface_ip.to_owned())
+            } else {
+                None
             }
         }
     };
@@ -1955,10 +1952,10 @@ fn udp_leg_from_input(input: &SdpBuildInput<'_>) -> UdpLeg {
     // Unset `destination-ip` / `multicast-ip`: emit
     // [`defaults::UNSPECIFIED_ADDRESS`] on the `c=` line (synthesis
     // only — passthrough SDPs are never rewritten here).
-    let destination_ip = if input.destination_ip.is_empty() {
-        defaults::UNSPECIFIED_ADDRESS.to_owned()
-    } else {
+    let destination_ip = if !input.destination_ip.is_empty() {
         input.destination_ip.to_owned()
+    } else {
+        defaults::UNSPECIFIED_ADDRESS.to_owned()
     };
     UdpLeg {
         destination_ip,

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -77,6 +77,14 @@ pub(crate) const HOST_NAME_BLURB: &str = "\
     Host name advertised by the NMOS Node. Empty autodetects it. Only the \
     first element to create the Node controls this value.";
 
+pub(crate) const NODE_PROPERTIES_BLURB: &str = "\
+    Node and Device metadata. Supported fields are `label`, `description`, \
+    `manufacturer`, `product`, `instance-id`, and `functions`; the asset \
+    fields must be supplied together. For example \
+    `properties,label=Studio-A,manufacturer=Acme,product=(string)\"Widget Pro\",\
+    instance-id=XYZ123-456789,functions=(string)<Encoder,Decoder>`. Only the \
+    first element to create the Node controls this value.";
+
 pub(crate) const DOMAIN_BLURB: &str = "\
     DNS domain used to discover NMOS services. Use `local` for mDNS. Empty \
     selects automatic discovery. Only the first element to create the Node \

--- a/rust/gst-nmos-rs/src/session/node.rs
+++ b/rust/gst-nmos-rs/src/session/node.rs
@@ -5,7 +5,8 @@
 //! `AddNode` (the `NodeConfig` protobuf message).
 
 use gstreamer as gst;
-use nvnmos_rpc::v1::{NetworkServicesConfig, NodeConfig};
+use nvnmos_rpc::v1::{AssetConfig, NetworkServicesConfig, NodeConfig};
+use thiserror::Error;
 
 use crate::CAT;
 use crate::network_services::parse_nmos_url;
@@ -16,9 +17,26 @@ pub(crate) struct NodeSettings {
     pub node_seed: String,
     pub http_port: u16,
     pub host_name: String,
+    pub node_properties: Option<gst::Structure>,
     pub domain: String,
     pub registration_url: String,
     pub system_url: String,
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum NodePropertiesError {
+    #[error("unknown node-properties field `{0}`")]
+    UnknownField(String),
+    #[error("node-properties field `{field}` must be {expected}")]
+    InvalidType {
+        field: &'static str,
+        expected: &'static str,
+    },
+    #[error(
+        "node-properties asset information requires non-empty `manufacturer`, \
+         `product`, `instance-id`, and `functions` fields"
+    )]
+    IncompleteAsset,
 }
 
 impl NodeSettings {
@@ -26,14 +44,20 @@ impl NodeSettings {
     ///
     /// Invalid `registration-url` / `system-url` values are logged and omitted;
     /// other fields are still forwarded.
-    pub(crate) fn to_node_config(&self) -> NodeConfig {
-        NodeConfig {
+    pub(crate) fn to_node_config(&self) -> Result<NodeConfig, NodePropertiesError> {
+        let mut config = NodeConfig {
             seed: self.node_seed.clone(),
             host_name: self.host_name.clone(),
             http_port: u32::from(self.http_port),
             network_services: self.build_network_services(),
             ..NodeConfig::default()
+        };
+
+        if let Some(properties) = self.node_properties.as_ref() {
+            apply_node_properties(properties, &mut config)?;
         }
+
+        Ok(config)
     }
 
     fn build_network_services(&self) -> Option<NetworkServicesConfig> {
@@ -86,5 +110,228 @@ impl NodeSettings {
         } else {
             None
         }
+    }
+}
+
+fn apply_node_properties(
+    properties: &gst::StructureRef,
+    config: &mut NodeConfig,
+) -> Result<(), NodePropertiesError> {
+    const FIELDS: &[&str] = &[
+        "label",
+        "description",
+        "manufacturer",
+        "product",
+        "instance-id",
+        "functions",
+    ];
+
+    for field in properties.fields() {
+        if !FIELDS.contains(&field.as_str()) {
+            return Err(NodePropertiesError::UnknownField(field.to_string()));
+        }
+    }
+
+    config.label = optional_string(properties, "label")?.unwrap_or_default();
+    config.description = optional_string(properties, "description")?.unwrap_or_default();
+
+    let manufacturer = optional_string(properties, "manufacturer")?;
+    let product = optional_string(properties, "product")?;
+    let instance_id = optional_string(properties, "instance-id")?;
+    let functions = optional_functions(properties)?;
+    let has_asset_field =
+        manufacturer.is_some() || product.is_some() || instance_id.is_some() || functions.is_some();
+
+    if has_asset_field {
+        let asset = AssetConfig {
+            manufacturer: manufacturer.unwrap_or_default(),
+            product: product.unwrap_or_default(),
+            instance_id: instance_id.unwrap_or_default(),
+            functions: functions.unwrap_or_default(),
+        };
+        if asset.manufacturer.is_empty()
+            || asset.product.is_empty()
+            || asset.instance_id.is_empty()
+            || asset.functions.is_empty()
+            || asset.functions.iter().any(String::is_empty)
+        {
+            return Err(NodePropertiesError::IncompleteAsset);
+        }
+        config.asset_tags = Some(asset);
+    }
+
+    Ok(())
+}
+
+fn optional_string(
+    properties: &gst::StructureRef,
+    field: &'static str,
+) -> Result<Option<String>, NodePropertiesError> {
+    if !properties.has_field(field) {
+        return Ok(None);
+    }
+    properties
+        .get::<String>(field)
+        .map(Some)
+        .map_err(|_| NodePropertiesError::InvalidType {
+            field,
+            expected: "a string",
+        })
+}
+
+fn optional_functions(
+    properties: &gst::StructureRef,
+) -> Result<Option<Vec<String>>, NodePropertiesError> {
+    const FIELD: &str = "functions";
+    if !properties.has_field(FIELD) {
+        return Ok(None);
+    }
+    if let Ok(function) = properties.get::<String>(FIELD) {
+        return Ok(Some(vec![function]));
+    }
+    if let Ok(functions) = properties.get::<gst::Array>(FIELD) {
+        return functions
+            .iter()
+            .map(|value| {
+                value
+                    .get::<String>()
+                    .map_err(|_| NodePropertiesError::InvalidType {
+                        field: FIELD,
+                        expected: "a string or an array of strings",
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some);
+    }
+    if let Ok(functions) = properties.get::<gst::List>(FIELD) {
+        return functions
+            .iter()
+            .map(|value| {
+                value
+                    .get::<String>()
+                    .map_err(|_| NodePropertiesError::InvalidType {
+                        field: FIELD,
+                        expected: "a string or an array of strings",
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(Some);
+    }
+    Err(NodePropertiesError::InvalidType {
+        field: FIELD,
+        expected: "a string or an array of strings",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(properties: gst::Structure) -> NodeSettings {
+        NodeSettings {
+            node_seed: "node-a".to_owned(),
+            node_properties: Some(properties),
+            ..NodeSettings::default()
+        }
+    }
+
+    #[test]
+    fn node_properties_forwards_label_and_description() {
+        crate::test_support::init_gst();
+        let properties = gst::Structure::builder("properties")
+            .field("label", "Studio encoder")
+            .field("description", "Primary UHD encoder")
+            .build();
+        let config = settings(properties).to_node_config().unwrap();
+        assert_eq!(config.label, "Studio encoder");
+        assert_eq!(config.description, "Primary UHD encoder");
+        assert!(config.asset_tags.is_none());
+    }
+
+    #[test]
+    fn node_properties_forwards_asset_information() {
+        crate::test_support::init_gst();
+        let functions = gst::Array::new([
+            "Meow".to_owned(),
+            "Purr".to_owned(),
+            "Hiss".to_owned(),
+            "Yowl".to_owned(),
+        ]);
+        let properties = gst::Structure::builder("properties")
+            .field("manufacturer", "Felis")
+            .field("product", "catus")
+            .field("instance-id", "Puss")
+            .field("functions", functions)
+            .build();
+        let config = settings(properties).to_node_config().unwrap();
+        let asset = config.asset_tags.expect("asset tags");
+        assert_eq!(asset.manufacturer, "Felis");
+        assert_eq!(asset.product, "catus");
+        assert_eq!(asset.instance_id, "Puss");
+        assert_eq!(asset.functions, ["Meow", "Purr", "Hiss", "Yowl"]);
+    }
+
+    #[test]
+    fn node_properties_accepts_single_function_string() {
+        crate::test_support::init_gst();
+        let properties = gst::Structure::builder("properties")
+            .field("manufacturer", "Felis")
+            .field("product", "catus")
+            .field("instance-id", "Puss")
+            .field("functions", "Meow")
+            .build();
+        let config = settings(properties).to_node_config().unwrap();
+        assert_eq!(config.asset_tags.expect("asset tags").functions, ["Meow"]);
+    }
+
+    #[test]
+    fn node_properties_accepts_documented_structure_syntax() {
+        crate::test_support::init_gst();
+        let properties = "properties,label=Studio-A,description=Primary-encoder,\
+                          manufacturer=Acme,product=(string)\"Widget Pro\",\
+                          instance-id=XYZ123-456789,functions=(string)<Encoder,Decoder>"
+            .parse::<gst::Structure>()
+            .unwrap();
+        let functions = properties
+            .get::<gst::Array>("functions")
+            .expect("functions should be a GstValueArray");
+        assert_eq!(functions.len(), 2);
+        assert_eq!(
+            functions
+                .iter()
+                .map(|value| value.get::<String>().unwrap())
+                .collect::<Vec<_>>(),
+            ["Encoder", "Decoder"]
+        );
+        let config = settings(properties).to_node_config().unwrap();
+        assert_eq!(config.label, "Studio-A");
+        assert_eq!(
+            config.asset_tags.expect("asset tags").functions,
+            ["Encoder", "Decoder"]
+        );
+    }
+
+    #[test]
+    fn node_properties_rejects_partial_asset_information() {
+        crate::test_support::init_gst();
+        let properties = gst::Structure::builder("properties")
+            .field("manufacturer", "NVIDIA")
+            .build();
+        assert!(matches!(
+            settings(properties).to_node_config(),
+            Err(NodePropertiesError::IncompleteAsset)
+        ));
+    }
+
+    #[test]
+    fn node_properties_rejects_unknown_fields() {
+        crate::test_support::init_gst();
+        let properties = gst::Structure::builder("properties")
+            .field("lable", "typo")
+            .build();
+        assert!(matches!(
+            settings(properties).to_node_config(),
+            Err(NodePropertiesError::UnknownField(field)) if field == "lable"
+        ));
     }
 }


### PR DESCRIPTION
Expose Node and Device labels, descriptions, and BCP-002-02 asset information through a shared GstStructure property.