### PR TITLE
Align .dockerignore with .gitignore exclusions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,17 +1,35 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Same as .gitignore, plus rust/target/ for the Docker build context.
+# Keep in sync with .gitignore where paths overlap. Prefer rooted paths
+# (e.g. src/...) over bare globs: .dockerignore matching is not identical
+# to gitignore (especially with the legacy builder). Avoid **.
+#
+# Plus rust/target/ (see rust/.gitignore /target/) for the build context.
 
 # Python venv (README recommends `.venv` beside the repo)
 .venv/
+.venv-*/
 
 # CMake user presets (machine-specific paths, generators, etc.)
 CMakeUserPresets.json
 
-# Local Conan + CMake output (README layout)
+# Local Conan + CMake output (README layout; root-level only).
+# Use explicit dirs plus hyphenated variants (not build*/ / conan*/) so
+# patterns do not also match files like src/conanfile.txt.
 build/
+build-*/
 src/conan/
+src/conan-*/
+src/.doxygen-markdown/
+
+# Doxygen HTML output (generated into src/ by Doxyfile, then moved by CI/Docker)
+src/html/
+doc/doxygen/__pycache__/
+
+# Generated gRPC documentation
+rust/nvnmos-rpc/proto/descriptor.pb
+rust/nvnmos-rpc/proto/sabledocs_output/
 
 # Rust workspace artifacts
 rust/target/

--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,13 @@
 # CMake user presets (machine-specific paths, generators, etc.)
 CMakeUserPresets.json
 
-# Local Conan + CMake output (README layout)
-build*/
-src/conan*/
+# Local Conan + CMake output (README layout).
+# Use explicit dirs plus hyphenated variants (not build*/ / conan*/) so
+# .dockerignore does not also match files like src/conanfile.txt.
+build/
+build-*/
+src/conan/
+src/conan-*/
 src/.doxygen-markdown/
 
 # Doxygen HTML output (generated into src/ by Doxyfile, then moved by CI/Docker)


### PR DESCRIPTION
## Summary
- Bring `.dockerignore` in line with the local-artifact exclusions already listed in `.gitignore` (venvs, Conan/CMake outputs, generated Doxygen/Hotdoc/Sabledocs paths), while keeping `rust/target/`.
- Comment notes that `.dockerignore` matching is not identical to gitignore, so patterns stay rooted where possible.

## Test plan
- [x] Confirmed wildcard patterns (`.venv-*/`, `build*/`, `src/conan*/`) exclude the expected paths with the legacy Docker builder
- [ ] Optional: `docker build -f docker/gst-nmos-rs/Dockerfile …` and confirm context size is no longer dominated by ignored build trees