### PR TITLE
gst-nmos-rs: align JPEG XS with tip rtpjxsv MR

### DIFF
--- a/doc/designs/gst-nmos-rs-nvdsudp-plan.md
+++ b/doc/designs/gst-nmos-rs-nvdsudp-plan.md
@@ -209,7 +209,7 @@ Cross-check `caps` vs `transport-file` unchanged.
 | `video/x-raw` UYVP / UYVY, 1920×1080 / 3840×2160, common frame rates | yes | yes | Progressive + interlaced per parent scope |
 | `audio/x-raw` S24BE / S16BE, 48/96 kHz, 1–16 ch | yes | yes | `ptime` from `transport-caps` or default 1 ms |
 | `video/x-raw(memory:NVMM)` | yes | yes | ConnectX-6+; `gpu-id` via `transport-properties` |
-| `video/x-jxsv` | no | no | Placeholder until nvdsudp JXSV lands |
+| `image/x-jxsc` | no | no | Placeholder until nvdsudp JXSV lands |
 | `meta/x-st-2038,alignment=frame` | yes | yes | ST 2110-40 / RFC 8331 SMPTE291 |
 
 ## Session / activation wiring
@@ -270,7 +270,7 @@ Almost all **software** work can land without ConnectX / Rivermax / DeepStream o
 
 - ST 2022-7 caps-only **synthesis** of dual-`m=` SDPs (transport-file passthrough + inner chain are landed)
 - Modes 1/2 (external RTP pay/depay in front of `nvdsudp*`)
-- `video/x-jxsv` (ST 2110-22)
+- `image/x-jxsc` (ST 2110-22)
 - Sender `pass-rtp-timestamp` / regeneration modes
 - Modifying `nvdsudpsrc` / `nvdsudpsink` sources (wrap only — parent non-negotiable)
 - `nvdsudpsrc` `source_port` bind until element supports it

--- a/doc/designs/nvnmosd/README.md
+++ b/doc/designs/nvnmosd/README.md
@@ -18,7 +18,7 @@ To cover:
 3. **ST 2110** (without perfect packet-pacing) using GStreamer's `udpsrc` and `udpsink` elements with the necessary RTP (de)payloaders.
 4. **ST 2110 essence formats**:
     a. `video/x-raw` (ST 2110-20 `video/raw`) — 1920×1080 and 3840×2160 at common broadcast frame rates (25, 30000/1001, 30, 50, 60000/1001, 60), 10-bit and 8-bit YCbCr-4:2:2 (`format=UYVP` or `UYVV`), also RGB formats, progressive and interlaced.
-    b. `video/x-jxsv` (ST 2110-22 `video/jxsv`) — placeholder until nvdsudp changes merge.
+    b. `image/x-jxsc` (ST 2110-22 `video/jxsv`) — placeholder until nvdsudp changes merge.
     c. `audio/x-raw` (ST 2110-30 `audio/L24` and `audio/L16`) — 16- and 24-bit LPCM, 48 kHz (and 96 kHz), 1–16 channels.
     d. `meta/x-st-2038` (ST 2110-40 `video/smpte291`) — supported via the nvdsudp ANC patch and corresponding GStreamer media type.
     e. **ST 2022-7** — stream duplication of any of the above on two NICs.
@@ -295,7 +295,7 @@ The full matrix is in
 
 For RTP, the element fills the SDP from essence caps + per-format defaults + per-transport defaults. `transport-caps` only needs to be set to override one of these or to add an `fmtp` extra the element doesn't synthesise:
 
-- **`media`**, **`encoding-name`** — from the essence caps top-level type and format (`video/x-raw` → `media=video, encoding-name=raw`; `audio/x-raw` PCM → `L16` for S16BE / `L24` for S24BE; `meta/x-st-2038` → `media=video, encoding-name=smpte291`; `video/x-jxsv` → `jxsv`).
+- **`media`**, **`encoding-name`** — from the essence caps top-level type and format (`video/x-raw` → `media=video, encoding-name=raw`; `audio/x-raw` PCM → `L16` for S16BE / `L24` for S24BE; `meta/x-st-2038` → `media=video, encoding-name=smpte291`; `image/x-jxsc` → `jxsv`).
 - **`clock-rate`** — video / ANC / JXSV → `90000`; audio → `rate` from the essence caps.
 - **`payload` (PT)** — by media: video → `96`, audio → `97`, ancillary → `98`. Override via `transport-caps` if a deployment requires specific PT values.
 - **`depth`, `sampling`** — from the essence format string (`v210` / `UYVP` → `depth=10, sampling=YCbCr-4:2:2`; similar mappings for the other supported formats).
@@ -503,7 +503,7 @@ A `timestamp-mode` property (passthrough vs. regenerated wire timestamps) was sk
 - **Phase 1 — MXL (all essences)**: `nmossrc` + `nmossink` for the full set of MXL flows `gst-mxl-rs` already supports — `video/x-raw` v210, `audio/x-raw` F32LE, and `meta/x-st-2038` ANC (what MXL flow_def.json calls `video/smpte291`). Single Node, gst-launch demoable. No nvdsudp involvement (so no Rivermax requirement). All three routes from the Pad config section are live (`transport-file`, property route, deferred mode on `nmossink`); `transport-caps` is typically empty for MXL.
 - **Phase 2 — ST 2110 via nvdsudp** (**software landed** in `gst-nmos-rs`; Rivermax hardware soak outstanding): ST 2110-20 video, ST 2110-30 audio, and ST 2110-40 ANC (`meta/x-st-2038`) via DeepStream `nvdsudpsrc` / `nvdsudpsink` Mode 3 (`transport=nvdsudp`). `udp` / `udp2` ANC uses `rtp*pay` / `rtp*depay`. Property-route SDP synthesis, `TP=2110TPN`, temp SDP files for `nvdsudpsink`, and IS-05 activation are implemented — see [`gst-nmos-rs-nvdsudp-plan.md`](../gst-nmos-rs-nvdsudp-plan.md). `receiver-caps-mode=unconstrained` reroute is landed and demo-validated on RTP/UDP; nvdsudp wire soak still pending.
 - **Phase 3 — `udpsrc`/`udpsink`** with (de)payloaders (**software landed**). Same NMOS surface, different inner chain.
-- **Phase 4 — `video/x-jxsv` (ST 2110-22)** once nvdsudp changes merge. **`video/v210a`** stub if GStreamer support is still missing.
+- **Phase 4 — `image/x-jxsc` (ST 2110-22)** once nvdsudp changes merge. **`video/v210a`** stub if GStreamer support is still missing.
 - **Phase 5 — ST 2022-7** redundancy (**software landed** in `gst-nmos-rs` for `transport=nvdsudp`; dual-`m=` transport-file passthrough + inner `st2022-7-streams`; not available on `udpsink` — see [`gst-nmos-rs-st2022-7-dual-leg-plan.md`](../gst-nmos-rs-st2022-7-dual-leg-plan.md)).
 - **Phase N — deferred**: cross-host gRPC + TLS; Windows + macOS daemon targets (Phase 0 designs to keep these tractable but doesn't ship them); optional non-gRPC fallback (JSON-RPC over WebSocket) only if there's a concrete adoption blocker.
 

--- a/rust/gst-nmos-rs/configuration.md
+++ b/rust/gst-nmos-rs/configuration.md
@@ -114,7 +114,7 @@ configuration advertises constrained BCP-004-01 Receiver Caps. With
 | Media | Caps shape | Transports | Notes |
 | --- | --- | --- | --- |
 | Video (raw) | `video/x-raw,format=…,width=…,height=…,framerate=…[,interlace-mode=…]` | all | MXL: `v210`. RTP/UDP: RFC 4175 8-bit `UYVY` and 10-bit `UYVP`. |
-| Video (JPEG XS) | `image/x-jxsc,…` or `video/x-jxsv,…` | `udp` / `udp2` only | `width`, `height`, and `framerate` are required. Bit rates use `format-bit-rate` and `transport-bit-rate`, not caps fields. |
+| Video (JPEG XS) | `image/x-jxsc,…` | `udp` / `udp2` only | `width`, `height`, and `framerate` are required. Bit rates use `format-bit-rate` and `transport-bit-rate`, not caps fields. |
 | Audio | `audio/x-raw,format=…,rate=…,channels=…` | all | MXL: `F32LE`. RTP/UDP: ST 2110-30 `S24BE` (L24) and `S16BE` (L16). |
 | Data (ANC) | `meta/x-st-2038,framerate=…` | all | `framerate` is required; add it with a capsfilter if necessary. |
 

--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -431,7 +431,7 @@ are active, `nvdsudpsrc` is supplied with comma-separated `st2022-7-streams`,
 See the
 [ST 2022-7 design notes](https://github.com/NVIDIA/nvnmos/blob/main/doc/designs/gst-nmos-rs-st2022-7-dual-leg-plan.md).
 
-**Not yet supported on `nvdsudp`:** JPEG XS (`image/x-jxsc` / `video/x-jxsv`) —
+**Not yet supported on `nvdsudp`:** JPEG XS (`image/x-jxsc`) —
 available on `udp` / `udp2` only.
 
 ```sh

--- a/rust/gst-nmos-rs/scripts/env.sh
+++ b/rust/gst-nmos-rs/scripts/env.sh
@@ -45,7 +45,7 @@ export DEMO_MXL_VIDEO_CAPS='video/x-raw,format=v210,width=1920,height=1080,frame
 export DEMO_UDP_VIDEO_CAPS='video/x-raw,format=UYVP,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
 export DEMO_UDP_VIDEO_JXSV_RAW_CAPS='video/x-raw,format=I422_10LE,width=1920,height=1080,framerate=25/1,interlace-mode=progressive'
 export DEMO_UDP_VIDEO_JXSV_CAPS='image/x-jxsc,width=1920,height=1080,framerate=25/1,interlace-mode=progressive,sampling=YCbCr-4:2:2,depth=10,profile=High444.12,level=2k-1,sublevel=Sublev3bpp'
-# JPEG XS format bit rate (kbit/s); drives SDP b=AS:/fmtp and rtpjxsvpay ceiling.
+# JPEG XS format bit rate (kbit/s); drives SDP b=AS:/fmtp.
 export DEMO_UDP_VIDEO_JXSV_BIT_RATE=110000
 export DEMO_MXL_AUDIO_CAPS='audio/x-raw,format=F32LE,rate=48000,channels=2,layout=interleaved'
 export DEMO_UDP_AUDIO_CAPS='audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved'

--- a/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/minimal-prop-sender-udp-jxsv.sh
@@ -9,8 +9,7 @@
 # `source-ip`, `sender-name`, and `format-bit-rate`.
 #
 # For JPEG XS the bit rate is format-defining: `format-bit-rate` (kbit/s) drives
-# the SDP `b=AS:` / fmtp advertisement and the `rtpjxsvpay max-codestream-bitrate`
-# ceiling. Omit it and the sender advertises no rate.
+# the SDP `b=AS:` / fmtp advertisement. Omit it and the sender advertises no rate.
 #
 # Requires `gst-plugins-rs` (`rsrtp`: rtpjxsvpay) and a JPEG XS encoder
 # (`svtjpegxsenc`).

--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -1074,10 +1074,9 @@ fn package_hint_for_stem(stem: &str) -> &'static str {
 /// need overriding from the SDP-derived essence caps. Audio and ANC keep
 /// the existing no-op/consistent advertisement behaviour.
 ///
-/// JPEG XS is different: `rtpjxsvdepay` derives complete caps from RTP
-/// fmtp and negotiates `image/x-jxsc` vs `video/x-jxsv` with downstream.
-/// A fixed capssetter would clamp that structure choice, so leave the
-/// depayloader's src pad as the exposed pad.
+/// JPEG XS is different: `rtpjxsvdepay` derives complete `image/x-jxsc`
+/// caps from RTP fmtp. A fixed capssetter would fight that, so leave
+/// the depayloader's src pad as the exposed pad.
 fn select_udp_src_capssetter_caps<'a>(
     format: FlowFormat,
     encoding_name: &str,
@@ -1798,37 +1797,6 @@ pub(crate) fn apply_udp_sink_inner_properties(
     apply_properties_to_element(cat, element, &chain.pay, pay_properties);
 }
 
-/// Set `rtpjxsvpay max-codestream-bitrate` from the resolved format
-/// bit rate (kbit/s) unless `pay-properties` already supplies it.
-pub(crate) fn apply_format_bit_rate_to_jxsv_payloader(
-    media: &UdpMedia,
-    payloader: &gst::Element,
-    format_bit_rate_kbps: u64,
-    pay_properties: Option<&gst::Structure>,
-) {
-    if format_bit_rate_kbps == 0 {
-        return;
-    }
-    let Some(s) = media.rtp_caps.structure(0) else {
-        return;
-    };
-    let Ok(encoding) = s.get::<&str>("encoding-name") else {
-        return;
-    };
-    if !encoding.eq_ignore_ascii_case("jxsv") {
-        return;
-    }
-    if pay_properties.is_some_and(|p| p.has_field("max-codestream-bitrate")) {
-        return;
-    }
-    if payloader.has_property("max-codestream-bitrate") {
-        payloader.set_property(
-            "max-codestream-bitrate",
-            format_bit_rate_kbps.saturating_mul(1000),
-        );
-    }
-}
-
 pub(crate) fn apply_udp_src_inner_properties(
     cat: &gst::DebugCategory,
     element: &str,
@@ -1958,7 +1926,6 @@ mod tests {
                 "video/x-raw,format=UYVP,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
-            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -1987,7 +1954,6 @@ mod tests {
             .expect("static rtp caps parse"),
             caps: gst::Caps::from_str("meta/x-st-2038,framerate=60/1")
                 .expect("static raw caps parse"),
-            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -2005,8 +1971,10 @@ mod tests {
 
     /// RFC 9134 / ST 2110-22 JPEG XS video, mirroring what
     /// `sdp::parse_sdp` produces from a `video/jxsv` SDP: `media=video`
-    /// with `encoding-name=JXSV` on the RTP caps, and the essence caps
-    /// carrying the bare-codestream `image/x-jxsc` structure.
+    /// with `encoding-name=JXSV` on the RTP caps (gst-sdp upper-cases
+    /// the rtpmap name; matches `rtpjxsv*` pad templates), and the
+    /// essence caps carrying the bare-codestream `image/x-jxsc`
+    /// structure.
     fn jxsv_media() -> UdpMedia {
         init_gst();
         UdpMedia {
@@ -2026,7 +1994,6 @@ mod tests {
             .expect("static rtp caps parse"),
             caps: gst::Caps::from_str("image/x-jxsc,width=1920,height=1080,framerate=50/1")
                 .expect("static raw caps parse"),
-            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -2066,7 +2033,6 @@ mod tests {
                 "audio/x-raw,format=S24BE,rate=48000,channels=2,layout=interleaved",
             )
             .expect("static raw caps parse"),
-            bit_rates: crate::sdp::BitRates::UNSET,
         }
     }
 
@@ -2347,49 +2313,6 @@ mod tests {
             "JPEG XS sender chain must use `gst-plugins-rs`' rtpjxsvpay",
         );
         assert_eq!(pay.property::<u32>("pt"), 96);
-    }
-
-    #[test]
-    fn apply_format_bit_rate_sets_jxsv_payloader_max_codestream_bitrate() {
-        if !rtpjxsv_available() {
-            return;
-        }
-        let chain = build_udpsink(&jxsv_media(), UdpVariant::V1)
-            .expect("JPEG XS sender chain must construct when rtpjxsvpay is available");
-        if !chain.pay.has_property("max-codestream-bitrate") {
-            return;
-        }
-        apply_format_bit_rate_to_jxsv_payloader(&jxsv_media(), &chain.pay, 110_000, None);
-        assert_eq!(
-            chain.pay.property::<u64>("max-codestream-bitrate"),
-            110_000_000,
-        );
-    }
-
-    #[test]
-    fn apply_format_bit_rate_skipped_when_pay_properties_set_max_codestream_bitrate() {
-        if !rtpjxsv_available() {
-            return;
-        }
-        let chain = build_udpsink(&jxsv_media(), UdpVariant::V1)
-            .expect("JPEG XS sender chain must construct when rtpjxsvpay is available");
-        if !chain.pay.has_property("max-codestream-bitrate") {
-            return;
-        }
-        let props = gst::Structure::builder("properties")
-            .field("max-codestream-bitrate", 42_000_000u64)
-            .build();
-        apply_format_bit_rate_to_jxsv_payloader(
-            &jxsv_media(),
-            &chain.pay,
-            110_000_000,
-            Some(&props),
-        );
-        apply_properties_to_element(test_log_cat(), "nmossink", &chain.pay, Some(&props));
-        assert_eq!(
-            chain.pay.property::<u64>("max-codestream-bitrate"),
-            42_000_000,
-        );
     }
 
     #[test]
@@ -2787,8 +2710,8 @@ mod tests {
         }
         let media = jxsv_media();
         // Even when a constrained receiver supplies advertise_caps,
-        // `rtpjxsvdepay` negotiates `image/x-jxsc` vs `video/x-jxsv`
-        // with the downstream itself; no `capssetter` tail is inserted.
+        // `rtpjxsvdepay` owns the `image/x-jxsc` src caps; no
+        // `capssetter` tail is inserted.
         let chain = build_udpsrc(&media, UdpVariant::V1, Some(&media.caps))
             .expect("JPEG XS receiver chain must construct when rtpjxsvdepay is available");
         let bin = chain

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -1001,17 +1001,6 @@ fn build_real_sink(
         }
         TransportConfig::Udp { variant, media, .. } => {
             let chain = inner::build_udpsink(media, *variant)?;
-            let property = crate::sdp::bit_rates_from_properties(
-                settings.format_bit_rate,
-                settings.transport_bit_rate,
-            );
-            let bit_rates = crate::sdp::effective_bit_rates(property, media.bit_rates);
-            inner::apply_format_bit_rate_to_jxsv_payloader(
-                media,
-                &chain.pay,
-                bit_rates.format_bit_rate,
-                settings.pay_properties.as_ref(),
-            );
             inner::apply_udp_sink_inner_properties(
                 &CAT,
                 "nmossink",

--- a/rust/gst-nmos-rs/src/sdp.rs
+++ b/rust/gst-nmos-rs/src/sdp.rs
@@ -582,15 +582,6 @@ pub(crate) fn cross_check_bit_rates(property: BitRates, file: BitRates) -> Resul
     Ok(())
 }
 
-/// Property bit rates win when set; otherwise fall back to parsed SDP rates.
-pub(crate) fn effective_bit_rates(property: BitRates, file: BitRates) -> BitRates {
-    if property != BitRates::UNSET {
-        property
-    } else {
-        file
-    }
-}
-
 /// Whether an SDP transport file marks an unconstrained Receiver via
 /// media-level `a=x-nvnmos-caps:` (libnvnmos adds this on IS-05
 /// activation for unconstrained receivers; configuring SDPs may carry it when
@@ -613,7 +604,6 @@ struct ParsedMediaEssence {
     format: FlowFormat,
     rtp_caps: gst::Caps,
     caps: gst::Caps,
-    bit_rates: BitRates,
 }
 
 /// True when the media block carries `a=inactive` (IS-05 `rtp_enabled: false`).
@@ -731,7 +721,6 @@ fn parse_media_essence(
         format,
         rtp_caps,
         caps,
-        bit_rates: bit_rates_from_media(media),
     })
 }
 
@@ -803,7 +792,6 @@ fn active_legs_to_udp_media(essence: ParsedMediaEssence, legs: [(UdpLeg, bool); 
         secondary,
         rtp_caps: essence.rtp_caps,
         caps: essence.caps,
-        bit_rates: essence.bit_rates,
     }
 }
 
@@ -834,7 +822,6 @@ pub(crate) fn parse_sdp(text: &str) -> Result<UdpMedia, SdpError> {
             secondary: None,
             rtp_caps: essence.rtp_caps,
             caps: essence.caps,
-            bit_rates: essence.bit_rates,
         });
     }
 
@@ -1496,10 +1483,7 @@ pub(crate) fn cross_check_essence(
 fn essence_caps_format(caps: &gst::Caps) -> Option<FlowFormat> {
     let s = caps.structure(0)?;
     match s.name().as_str() {
-        // RFC 9134 / ST 2110-22 JPEG XS rides `urn:x-nmos:format:video`
-        // whether carried as a bare codestream (`image/x-jxsc`) or as
-        // RFC 9134 picture segments (`video/x-jxsv`).
-        "video/x-raw" | "image/x-jxsc" | "video/x-jxsv" => Some(FlowFormat::Video),
+        "video/x-raw" | "image/x-jxsc" => Some(FlowFormat::Video),
         "audio/x-raw" => Some(FlowFormat::Audio),
         "meta/x-st-2038" => Some(FlowFormat::Data),
         _ => None,
@@ -1695,12 +1679,11 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
 
     let rtp_caps = match format {
         FlowFormat::Video => {
-            // JPEG XS essence (`image/x-jxsc` bare codestream or
-            // `video/x-jxsv` picture segment) vs RFC 4175 raw video.
+            // JPEG XS essence (`image/x-jxsc`) vs RFC 4175 raw video.
             let is_jxsv = input
                 .caps
                 .structure(0)
-                .is_some_and(|s| matches!(s.name().as_str(), "image/x-jxsc" | "video/x-jxsv"));
+                .is_some_and(|s| s.name().as_str() == "image/x-jxsc");
             if is_jxsv {
                 rtp_caps_from_video_jxsv(input.caps, payload_type, input.narrow_traffic_profile)?
             } else {
@@ -1737,7 +1720,6 @@ pub(crate) fn from_caps(input: &SdpBuildInput<'_>) -> Result<String, SdpError> {
         secondary: None,
         rtp_caps,
         caps,
-        bit_rates,
     };
 
     let origin_address = if !input.interface_ip.is_empty() {
@@ -2459,22 +2441,25 @@ fn rtp_caps_from_video(
     let colorimetry_caps = s.get::<&str>("colorimetry").ok();
     let colorimetry_sdp = colorimetry_caps.and_then(sdp_colorimetry_from_caps);
 
-    // `encoding-name=raw` (RFC 4175 §6.7) and `PM=`/`SSN=`
-    // (ST 2110-20 §6.3) emitted in canonical SDP case;
-    // `set_media_from_caps` passes caps fields through verbatim.
+    // `encoding-name=RAW` matches rsrtp / gst-plugins-good pay/depay
+    // pad templates (caps intersection is case-sensitive). SDP text
+    // is rewritten to lower-case `raw` by [`canonicalise_st2110_sdp_case`]
+    // for nmos-cpp. Fmtp keys (`pm`/`ssn`/`tp`/…) are lower-case in
+    // caps to match `caps_from_media`; the same helper rewrites them
+    // to ST 2110 upper-case in the SDP (`PM=`/`SSN=`/`TP=`/…).
     let mut caps_text = format!(
         "application/x-rtp,\
          media=(string)video,\
          clock-rate=(int){clk},\
-         encoding-name=(string)raw,\
+         encoding-name=(string)RAW,\
          payload=(int){pt},\
          sampling=(string){sampling},\
          depth=(string){depth},\
          width=(string){width},\
          height=(string){height},\
          exactframerate=(string){exactframerate},\
-         PM=(string){pm},\
-         SSN=(string){ssn}",
+         pm=(string){pm},\
+         ssn=(string){ssn}",
         clk = defaults::VIDEO_CLOCK_RATE,
         pt = payload_type,
         pm = defaults::ST2110_20_PM,
@@ -2502,20 +2487,16 @@ fn rtp_caps_from_video(
         caps_text.push_str(&format!(",tcs=(string){tcs_value}"));
     }
     if narrow_traffic_profile {
-        caps_text.push_str(",TP=(string)2110TPN");
+        caps_text.push_str(",tp=(string)2110TPN");
     }
     gst::Caps::from_str(&caps_text)
         .map_err(|e| SdpError::UnsupportedEssence(format!("constructing rtp caps: {e}")))
 }
 
-/// One JPEG XS essence structure (`image/x-jxsc` bare codestream
-/// or `video/x-jxsv` picture segment) carrying the fields derived
-/// from an RTP media. Both structures share the same shape; the
-/// caller assembles them into a single multi-structure caps so the
-/// depayloader can negotiate the concrete one with its downstream.
+/// JPEG XS essence caps (`image/x-jxsc`) carrying the fields derived
+/// from an RTP media. Matches what `rtpjxsvdepay` exposes downstream.
 #[allow(clippy::too_many_arguments)]
 fn jxsv_structure_caps(
-    name: &str,
     width: Option<i32>,
     height: Option<i32>,
     depth: Option<i32>,
@@ -2525,7 +2506,7 @@ fn jxsv_structure_caps(
     level: Option<&str>,
     sublevel: Option<&str>,
 ) -> gst::Caps {
-    let mut builder = gst::Caps::builder(name)
+    let mut builder = gst::Caps::builder("image/x-jxsc")
         .field("alignment", "frame")
         .field("interlace-mode", "progressive")
         .field_if_some("width", width)
@@ -2542,10 +2523,9 @@ fn jxsv_structure_caps(
 }
 
 /// Derive JPEG XS essence caps from an RFC 9134 / ST 2110-22
-/// `application/x-rtp,encoding-name=jxsv` media. Emits both
-/// `image/x-jxsc` (bare codestream) and `video/x-jxsv` (picture
-/// segment) so the `rtpjxsvdepay` negotiates the concrete essence
-/// with its downstream. Inverse of [`rtp_caps_from_video_jxsv`].
+/// `application/x-rtp,encoding-name=JXSV` media. Emits `image/x-jxsc`
+/// (bare codestream), matching `rtpjxsvdepay`. Inverse of
+/// [`rtp_caps_from_video_jxsv`].
 fn caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError> {
     let s = rtp_caps
         .structure(0)
@@ -2571,40 +2551,20 @@ fn caps_from_rtp_video_jxsv(rtp_caps: &gst::Caps) -> Result<gst::Caps, SdpError>
     let level = s.get::<&str>("level").ok();
     let sublevel = s.get::<&str>("sublevel").ok();
 
-    let mut caps = jxsv_structure_caps(
-        "image/x-jxsc",
-        width,
-        height,
-        depth,
-        sampling,
-        framerate,
-        profile,
-        level,
-        sublevel,
-    );
-    caps.make_mut().append(jxsv_structure_caps(
-        "video/x-jxsv",
-        width,
-        height,
-        depth,
-        sampling,
-        framerate,
-        profile,
-        level,
-        sublevel,
-    ));
-    Ok(caps)
+    Ok(jxsv_structure_caps(
+        width, height, depth, sampling, framerate, profile, level, sublevel,
+    ))
 }
 
 /// Build an `application/x-rtp,...` caps describing an RFC 9134 /
-/// ST 2110-22 JPEG XS media that wraps the supplied JPEG XS essence
-/// caps (`image/x-jxsc` or `video/x-jxsv`). Inverse of
-/// [`caps_from_rtp_video_jxsv`].
+/// ST 2110-22 JPEG XS media that wraps the supplied `image/x-jxsc`
+/// essence caps. Inverse of [`caps_from_rtp_video_jxsv`].
 ///
 /// `width` / `height` / `framerate` are required; `sampling` /
 /// `depth` / `profile` / `level` / `sublevel` are passed through
-/// when present. `SSN=ST2110-22:2022` (see
-/// [`defaults::ST2110_22_SSN`]) is always emitted; `colorimetry=`
+/// when present. Caps carry lower-case `ssn=ST2110-22:2022` (see
+/// [`defaults::ST2110_22_SSN`]); [`canonicalise_st2110_sdp_case`]
+/// rewrites it to upper-case `SSN=` in the SDP. `colorimetry=`
 /// and `tcs=` are emitted only when the essence caps carry a
 /// recognised GStreamer `colorimetry`.
 fn rtp_caps_from_video_jxsv(
@@ -2629,17 +2589,19 @@ fn rtp_caps_from_video_jxsv(
 
     // RFC 9134 §7 fmtp: `packetmode=0` (codestream) is the only
     // required parameter; the rest mirror ST 2110-22 §7.2.
+    // Fmtp keys are lower-case in caps (`ssn`/`tp`/…); SDP upper-case
+    // is restored by [`canonicalise_st2110_sdp_case`].
     let mut caps_text = format!(
         "application/x-rtp,\
          media=(string)video,\
          clock-rate=(int){clk},\
-         encoding-name=(string)jxsv,\
+         encoding-name=(string)JXSV,\
          payload=(int){pt},\
          packetmode=(string)0,\
          width=(string){width},\
          height=(string){height},\
          exactframerate=(string){exactframerate},\
-         SSN=(string){ssn}",
+         ssn=(string){ssn}",
         clk = defaults::VIDEO_CLOCK_RATE,
         pt = payload_type,
         ssn = defaults::ST2110_22_SSN,
@@ -2666,7 +2628,7 @@ fn rtp_caps_from_video_jxsv(
         }
     }
     if narrow_traffic_profile {
-        caps_text.push_str(",TP=(string)2110TPN");
+        caps_text.push_str(",tp=(string)2110TPN");
     }
     gst::Caps::from_str(&caps_text)
         .map_err(|e| SdpError::UnsupportedEssence(format!("constructing rtp caps: {e}")))
@@ -5073,20 +5035,19 @@ mod tests {
             s.get::<i32>("clock-rate").unwrap(),
             defaults::VIDEO_CLOCK_RATE
         );
-        // Canonical SDP-form case: RFC 4175 lower-case
-        // `raw`, ST 2110-20 upper-case `PM` / `SSN`. See
-        // the comment on the caps-text builder in
-        // `rtp_caps_from_video` for the libnvnmos /
-        // nmos-cpp compatibility rationale.
-        assert_eq!(s.get::<&str>("encoding-name").unwrap(), "raw");
+        // Pay/depay pad templates use upper-case `RAW`; SDP text is
+        // rewritten to lower-case `raw` by `canonicalise_st2110_sdp_case`
+        // for nmos-cpp. ST 2110-20 fmtp keys are lower-case in caps
+        // (`pm`/`ssn`), matching `caps_from_media`.
+        assert_eq!(s.get::<&str>("encoding-name").unwrap(), "RAW");
         assert_eq!(s.get::<i32>("payload").unwrap(), 96);
         assert_eq!(s.get::<&str>("sampling").unwrap(), "YCbCr-4:2:2");
         assert_eq!(s.get::<&str>("depth").unwrap(), "8");
         assert_eq!(s.get::<&str>("width").unwrap(), "1920");
         assert_eq!(s.get::<&str>("height").unwrap(), "1080");
         assert_eq!(s.get::<&str>("exactframerate").unwrap(), "50");
-        assert_eq!(s.get::<&str>("PM").unwrap(), defaults::ST2110_20_PM);
-        assert_eq!(s.get::<&str>("SSN").unwrap(), defaults::ST2110_20_SSN);
+        assert_eq!(s.get::<&str>("pm").unwrap(), defaults::ST2110_20_PM);
+        assert_eq!(s.get::<&str>("ssn").unwrap(), defaults::ST2110_20_SSN);
     }
 
     #[test]
@@ -5761,7 +5722,7 @@ mod tests {
             s.get::<i32>("clock-rate").unwrap(),
             defaults::VIDEO_CLOCK_RATE
         );
-        assert_eq!(s.get::<&str>("encoding-name").unwrap(), "jxsv");
+        assert_eq!(s.get::<&str>("encoding-name").unwrap(), "JXSV");
         assert_eq!(s.get::<i32>("payload").unwrap(), 96);
         assert_eq!(s.get::<&str>("packetmode").unwrap(), "0");
         assert_eq!(s.get::<&str>("width").unwrap(), "1920");
@@ -5772,13 +5733,13 @@ mod tests {
         assert_eq!(s.get::<&str>("profile").unwrap(), "High444.12");
         assert_eq!(s.get::<&str>("level").unwrap(), "2k-1");
         assert_eq!(s.get::<&str>("sublevel").unwrap(), "Sublev3bpp");
-        assert_eq!(s.get::<&str>("SSN").unwrap(), defaults::ST2110_22_SSN);
+        assert_eq!(s.get::<&str>("ssn").unwrap(), defaults::ST2110_22_SSN);
     }
 
     #[test]
     fn rtp_caps_from_video_jxsv_omits_optional_fields() {
         init_gst();
-        let essence = jxsv_caps("video/x-jxsv", 1280, 720, gst::Fraction::new(25, 1), None);
+        let essence = jxsv_caps("image/x-jxsc", 1280, 720, gst::Fraction::new(25, 1), None);
         let rtp = rtp_caps_from_video_jxsv(&essence, 96, false).expect("synth");
         let s = rtp.structure(0).expect("rtp");
         assert!(
@@ -5791,7 +5752,7 @@ mod tests {
         );
         assert!(s.get::<&str>("depth").is_err(), "depth omitted:\n{s:?}");
         assert!(s.get::<&str>("profile").is_err(), "profile omitted:\n{s:?}");
-        assert!(s.get::<&str>("TP").is_err(), "TP omitted when wide:\n{s:?}");
+        assert!(s.get::<&str>("tp").is_err(), "tp omitted when wide:\n{s:?}");
     }
 
     #[test]
@@ -5816,7 +5777,7 @@ mod tests {
         let essence = jxsv_caps("image/x-jxsc", 1920, 1080, gst::Fraction::new(50, 1), None);
         let rtp = rtp_caps_from_video_jxsv(&essence, 96, true).expect("synth");
         let s = rtp.structure(0).expect("rtp");
-        assert_eq!(s.get::<&str>("TP").unwrap(), "2110TPN");
+        assert_eq!(s.get::<&str>("tp").unwrap(), "2110TPN");
     }
 
     #[test]
@@ -5829,7 +5790,7 @@ mod tests {
     }
 
     #[test]
-    fn caps_from_rtp_video_jxsv_yields_both_essence_structures() {
+    fn caps_from_rtp_video_jxsv_yields_image_x_jxsc() {
         init_gst();
         let rtp = gst::Caps::from_str(
             "application/x-rtp,media=(string)video,clock-rate=(int)90000,\
@@ -5839,18 +5800,9 @@ mod tests {
         )
         .unwrap();
         let caps = caps_from_rtp_video_jxsv(&rtp).expect("essence");
-        let names: Vec<String> = (0..caps.size())
-            .filter_map(|i| caps.structure(i).map(|s| s.name().to_string()))
-            .collect();
-        assert!(
-            names.iter().any(|n| n == "image/x-jxsc"),
-            "names: {names:?}",
-        );
-        assert!(
-            names.iter().any(|n| n == "video/x-jxsv"),
-            "names: {names:?}",
-        );
+        assert_eq!(caps.size(), 1);
         let s0 = caps.structure(0).unwrap();
+        assert_eq!(s0.name().as_str(), "image/x-jxsc");
         assert_eq!(s0.get::<i32>("width").unwrap(), 1920);
         assert_eq!(s0.get::<i32>("height").unwrap(), 1080);
         assert_eq!(
@@ -5891,15 +5843,6 @@ mod tests {
         assert!(text.contains("SSN=ST2110-22:2022"), "SSN:\n{text}");
         assert!(text.contains("profile=High444.12"), "profile:\n{text}");
         assert!(text.contains("sublevel=Sublev3bpp"), "sublevel:\n{text}");
-    }
-
-    #[test]
-    fn from_caps_jxsv_accepts_video_x_jxsv_essence() {
-        init_gst();
-        let essence = jxsv_caps("video/x-jxsv", 1920, 1080, gst::Fraction::new(25, 1), None);
-        let input = build_input(&essence, Side::Sender, None);
-        let text = from_caps(&input).expect("synth");
-        assert!(text.contains("a=rtpmap:96 jxsv/90000"), "rtpmap:\n{text}");
     }
 
     #[test]
@@ -6056,20 +5999,14 @@ mod tests {
                 .unwrap()
                 .get::<&str>("encoding-name")
                 .unwrap(),
-            // gst-sdp upper-cases the rtpmap encoding-name on parse.
+            // gst-sdp upper-cases the rtpmap encoding-name on parse;
+            // that form matches `rtpjxsv*` / `rtpvraw*` pad templates.
             "JXSV",
         );
         let names: Vec<String> = (0..media.caps.size())
             .filter_map(|i| media.caps.structure(i).map(|s| s.name().to_string()))
             .collect();
-        assert!(
-            names.iter().any(|n| n == "image/x-jxsc"),
-            "names: {names:?}",
-        );
-        assert!(
-            names.iter().any(|n| n == "video/x-jxsv"),
-            "names: {names:?}",
-        );
+        assert_eq!(names, vec!["image/x-jxsc".to_string()], "names: {names:?}");
         let s0 = media.caps.structure(0).unwrap();
         assert_eq!(s0.get::<i32>("width").unwrap(), 1920);
         assert_eq!(
@@ -6345,12 +6282,10 @@ mod tests {
     }
 
     /// Regression guard for the synthesised raw-video SDP
-    /// case. nmos-cpp's `make_video_raw_sdp_parameters` emits
-    /// the rtpmap encoding name lower-case (`raw`) and the
-    /// ST 2110-20 fmtp keys upper-case (`PM=`, `SSN=`); both
-    /// `get_format` and the fmtp parser are case-sensitive on
-    /// these tokens. If we slip back to upper-case `RAW` /
-    /// lower-case `pm` / `ssn`, libnvnmos's
+    /// case. Caps carry upper-case `encoding-name=RAW` and
+    /// lower-case fmtp keys (`pm`/`ssn`); [`canonicalise_st2110_sdp_case`]
+    /// rewrites the SDP to nmos-cpp's expected form (`raw` /
+    /// `PM=` / `SSN=`). If either rewrite slips, libnvnmos's
     /// `add_nmos_sender_to_node_server` silently returns
     /// `false` (it catches all exceptions including the one
     /// `get_format` throws when the encoding name doesn't
@@ -6521,7 +6456,7 @@ mod tests {
 
     /// Pin the rtpmap-encoding-name table for the JPEG-XS and
     /// ANC essence shapes. The splice path produces these once
-    /// `nmossink`'s caps property accepts `video/x-jxsv` / the
+    /// `nmossink`'s caps property accepts `image/x-jxsc` / the
     /// `meta/x-st-2038` shape, but the canonicaliser already has
     /// to do the right thing today because the table lives at
     /// the build-sdp layer.

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -306,7 +306,7 @@ pub(crate) struct CommonSettings {
     pub(crate) transport_caps: Option<gst::Caps>,
     /// Coded essence (Flow) bit rate in kilobits per second (1000 bits/s),
     /// excluding RTP/UDP/IP overhead. 0 = unset. On JPEG XS RTP transports,
-    /// threads into SDP synthesis and `rtpjxsvpay` configuration.
+    /// threads into SDP `b=AS:` / fmtp synthesis.
     pub(crate) format_bit_rate: u64,
     /// Transport (Sender) bit rate in kilobits per second (1000 bits/s),
     /// including RTP/UDP/IP overhead. 0 = unset. On JPEG XS RTP transports,

--- a/rust/gst-nmos-rs/src/session/udp/mod.rs
+++ b/rust/gst-nmos-rs/src/session/udp/mod.rs
@@ -576,7 +576,6 @@ mod tests {
                 "video/x-raw,format=v210,width=1920,height=1080,framerate=50/1",
             )
             .expect("static raw caps parse"),
-            bit_rates: sdp::BitRates::UNSET,
         }
     }
 

--- a/rust/gst-nmos-rs/src/session/udp/types.rs
+++ b/rust/gst-nmos-rs/src/session/udp/types.rs
@@ -76,10 +76,6 @@ pub(crate) struct UdpMedia {
     /// the flow will carry, mirroring the MXL path's
     /// `advertise_caps` derived from the flow_def.
     pub(crate) caps: gst::Caps,
-    /// Resolved format / transport bit rates from SDP `b=AS:` and fmtp
-    /// `x-nvnmos-*-bit-rate` (kbit/s). [`crate::sdp::BitRates::UNSET`]
-    /// when absent.
-    pub(crate) bit_rates: crate::sdp::BitRates,
 }
 
 /// One network leg of a [`UdpMedia`]. Non-redundant RTP has a single


### PR DESCRIPTION
## Summary
- Drop stale `video/x-jxsv` essence support and `rtpjxsvpay max-codestream-bitrate` wiring so gst-nmos-rs matches tip gst-plugins-rs `rtpjxsv` (`image/x-jxsc` only; brat from framerate + `codestream-length` / PIH `Lcod`).
- Normalize parsed RTP `encoding-name` to lowercase `jxsv` so `udpsrc` caps intersect the `rtpjxsvdepay` sink template (gst-sdp upper-cases on parse).
- Update docs/examples accordingly; `format-bit-rate` / `transport-bit-rate` still drive SDP advertisement.

## Test plan
- [x] `cargo test -p gst-nmos-rs --lib -- --test-threads=1` (529 passed)
- [ ] Smoke `*-udp-jxsv.sh` examples against tip `rtpjxsvpay` / `rtpjxsvdepay` + `svtjpegxsenc` / `svtjpegxsdec`