### PR TITLE
ci: pin Meson <1.12 when building Hotdoc

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -64,7 +64,16 @@ jobs:
           libjson-glib-dev flex
         python3 -m venv .venv-hotdoc
         . .venv-hotdoc/bin/activate
-        pip install "hotdoc~=0.18.0"
+        # Hotdoc's bootstrap theme passes hotdoc/less into the theme subproject
+        # via depend_files; Meson 1.12+ treats that as a sandbox violation.
+        # pip build isolation would pull latest Meson, so pin <1.12 and install
+        # without isolation (runtime deps listed so the sdist can build).
+        pip install \
+          "meson>=1.0,<1.12" "meson-python>=0.14" ninja \
+          pkgconfig "lxml>=5.4" "PyYAML>=6.0.2" "schema>=0.7.7" \
+          "toposort>=1.10" "wheezy.template>=3.2.3" "appdirs>=1.4.4" \
+          "feedgen>=1.0.0" "networkx>=3.4" "dbus-deviation>=0.6.1"
+        pip install --no-build-isolation "hotdoc~=0.18.0"
         echo "$PWD/.venv-hotdoc/bin" >> "$GITHUB_PATH"
 
     - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606

--- a/rust/docs/gstreamer/README.md
+++ b/rust/docs/gstreamer/README.md
@@ -16,6 +16,7 @@ alongside the Doxygen C API.
 | Component | Pin | Notes |
 | --------- | --- | ----- |
 | Hotdoc | `~=0.18.0` | Enforced in `meson.build` and CI |
+| Meson (for Hotdoc sdist) | `>=1.0,<1.12` | Meson 1.12+ sandbox-rejects Hotdoc's theme `less_include_path`; CI installs Hotdoc with `--no-build-isolation` |
 | Lumen theme | 0.16 (sha256 in `meson.build`) | Downloaded at build time |
 | Plugin scanner | GStreamer **1.24.2** (`tools/`) | Vendored; newer scanner needs newer GStreamer API |
 | Sitemap generator | gst-docs **1.26.0** (`scripts/generate_sitemap.py`) | See below |
@@ -37,12 +38,19 @@ sudo apt-get install -y \
   libjson-glib-dev flex
 ```
 
-Hotdoc (virtualenv recommended):
+Hotdoc (virtualenv recommended). Match CI: pin Meson below 1.12 and install
+Hotdoc without build isolation so pip does not fetch Meson 1.12+ into an
+isolated build env:
 
 ```sh
 python3 -m venv .venv-hotdoc
 . .venv-hotdoc/bin/activate
-pip install "hotdoc~=0.18.0"
+pip install \
+  "meson>=1.0,<1.12" "meson-python>=0.14" ninja \
+  pkgconfig "lxml>=5.4" "PyYAML>=6.0.2" "schema>=0.7.7" \
+  "toposort>=1.10" "wheezy.template>=3.2.3" "appdirs>=1.4.4" \
+  "feedgen>=1.0.0" "networkx>=3.4" "dbus-deviation>=0.6.1"
+pip install --no-build-isolation "hotdoc~=0.18.0"
 ```
 
 Meson then runs `scripts/patch_hotdoc_gtk_doc_hrefs.py` against the installed


### PR DESCRIPTION
## Summary
- Meson 1.12 treats Hotdoc's theme `less_include_path` `depend_files` as a subproject sandbox violation, so `pip install hotdoc~=0.18` fails under build isolation (broke Pages deploy after Meson 1.12 hit PyPI on 10 Aug).
- Install Meson `>=1.0,<1.12` and Hotdoc with `--no-build-isolation`, and document the same in `rust/docs/gstreamer/README.md`.

## Test plan
- [ ] PR **Deploy Documentation** workflow `build` job (paths include `.github/workflows/pages.yml`) — confirm Hotdoc installs and GStreamer docs build
- [ ] After merge, confirm Pages deploy on `main` succeeds