### PR TITLE
ci/docker: bump gst-plugins-rs pin to tip with rtpjxsv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,14 +132,14 @@ jobs:
 
       # Build the gst-plugins-rs elements the sync tests need — st2038extractor /
       # st2038combiner (closedcaption), rtpsmpte291pay / rtpsmpte291depay (rtp) and
-      # udpsrc2 (udp) — at a pinned main commit that carries the st2038combiner skew
-      # and rtpsmpte291depay multi-ANC fixes (and, unlike the 0.15 branch, udpsrc2),
-      # and put them on GST_PLUGIN_PATH so the udp av_sync case (and udp2 tests) run
-      # here instead of self-skipping. The mxl and nvdsudp cases still self-skip
-      # (no libmxl / DeepStream on the runner).
+      # udpsrc2 / rtpjxsv — pinned main commit that carries udpsrc2, rtpjxsv
+      # pay/depay, the st2038combiner skew fix, and rtpsmpte291depay multi-ANC
+      # fixes; put them on GST_PLUGIN_PATH so the udp av_sync case (and udp2 /
+      # jxsv tests) run here instead of self-skipping. The mxl and nvdsudp cases
+      # still self-skip (no libmxl / DeepStream on the runner).
       - name: Build gst-plugins-rs plugins (pinned)
         env:
-          GST_PLUGINS_RS_REF: 8d5c60f0a67d3aa8120bf940b46fc3c18209661c
+          GST_PLUGINS_RS_REF: 0332d3d2084df7bae6dbd3c924a2bb62c2e56e89
           RUSTUP_TOOLCHAIN: "1.92"
         run: |
           git init "${RUNNER_TEMP}/gst-plugins-rs"

--- a/docker/gst-nmos-rs/Dockerfile
+++ b/docker/gst-nmos-rs/Dockerfile
@@ -36,7 +36,7 @@ ARG RUST_TOOLCHAIN=1.92
 ARG MXL_REPO=https://github.com/dmf-mxl/mxl.git
 ARG MXL_REF=81738a15adb55119a6855343bc1053a4389bf6df
 ARG GST_PLUGINS_RS_REPO=https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
-ARG GST_PLUGINS_RS_REF=8d5c60f0a67d3aa8120bf940b46fc3c18209661c
+ARG GST_PLUGINS_RS_REF=0332d3d2084df7bae6dbd3c924a2bb62c2e56e89
 
 # Final image arguments
 ARG NVNMOS_UID=10001

--- a/docker/gst-nmos-rs/README.md
+++ b/docker/gst-nmos-rs/README.md
@@ -34,7 +34,7 @@ The nvnmos tree is taken from the build context (`COPY src/`, `COPY rust/` via t
 | `MXL_REPO` | `https://github.com/dmf-mxl/mxl.git` | MXL source repository (`libmxl`, `gst-mxl-rs`). |
 | `MXL_REF` | `81738a15adb55119a6855343bc1053a4389bf6df` | Pinned MXL commit (`81738a1`, tip of `release/v1.1` at time of writing). Use a full 40-character SHA or a branch/tag name. |
 | `GST_PLUGINS_RS_REPO` | `https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git` | gst-plugins-rs source for `transport=udp2`. |
-| `GST_PLUGINS_RS_REF` | `8d5c60f0a67d3aa8120bf940b46fc3c18209661c` | Pinned gst-plugins-rs commit on `main` (`udpsrc2` is main-only; this commit also carries the `st2038combiner` skew and `rtpsmpte291depay` multi-ANC fixes). Builds `gst-plugin-udp` + `gst-plugin-rtp`. Use a full 40-character SHA or a branch/tag name. |
+| `GST_PLUGINS_RS_REF` | `0332d3d2084df7bae6dbd3c924a2bb62c2e56e89` | Pinned gst-plugins-rs commit on `main` (`udpsrc2`, `rtpjxsv` pay/depay, `st2038combiner` skew and `rtpsmpte291depay` multi-ANC fixes). Builds `gst-plugin-udp` + `gst-plugin-rtp`. Use a full 40-character SHA or a branch/tag name. |
 | `NVNMOS_UID` | `10001` | Fixed runtime user UID (`nvnmos`). |
 | `NVNMOS_GID` | `10001` | Fixed runtime group GID (`nvnmos`). |
 | `EXTRA_APT_PACKAGES` | *(empty)* | Optional space-separated apt package names added in the final image stage (e.g. `gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly`). Installed to the default GStreamer plugin path. |


### PR DESCRIPTION
## Summary
- Bump `GST_PLUGINS_RS_REF` to `0332d3d2084df7bae6dbd3c924a2bb62c2e56e89` (tip of gst-plugins-rs `main`) in CI and the gst-nmos-rs Docker image/docs.
- That commit includes merged [gst-plugins-rs !3166](https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/merge_requests/3166) (`rtpjxsv` pay/depay), so images and CI actually build the tip JPEG XS elements that [PR #101](https://github.com/NVIDIA/nvnmos/pull/101) already aligned gst-nmos-rs against.

## Test plan
- [x] Build `gst-plugin-rtp` / `gst-plugin-udp` / `gst-plugin-closedcaption` at the new pin
- [x] `gst-inspect-1.0`: `rtpjxsvpay`, `rtpjxsvdepay`, `udpsrc2`, `rtpsmpte291depay`, `st2038combiner`/`extractor` present; pay/depay are `image/x-jxsc` only
- [x] Upstream `gst-plugin-rtp` jxsv tests (31) pass at the pin
- [x] gst-nmos-rs `sdp::tests::*` (196) and all `jxsv` lib tests including chain construction (16) pass with the new plugins on `GST_PLUGIN_PATH`
- [ ] CI on this PR