### PR TITLE
scripts: fail-fast on ss/curl/jq; drop ripgrep; document tools

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -38,8 +38,12 @@ sudo apt-get install --no-install-recommends -y \
   build-essential cmake python3 python3-venv \
   clang \
   libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-  gstreamer1.0-plugins-base gstreamer1.0-plugins-good
+  gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+  iproute2 curl jq
 ```
+
+`iproute2` (for `ss`), `curl`, and `jq` are only required by the example
+pipeline scripts and the interactive demo.
 
 CMake must be **3.17+**. Ubuntu 24.04's `cmake` package is sufficient; on older
 distros use `pip install cmake~=3.17` inside the venv below (see

--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -63,6 +63,13 @@ is not supported on `transport=nvdsudp`.
 Pipelines below use `daemon-uri=$DEMO_DAEMON_URI` (default
 `unix:/tmp/nvnmosd.sock`) unless noted.
 
+**Tools** — example pipeline scripts need `ss` (from `iproute2`) to check
+that `nvnmosd` is running. The interactive demo also needs `curl` and `jq`
+for IS-04 / IS-05 / IS-08 HTTP requests. Missing tools fail fast with an
+install hint (`require_cmd` in `env.sh`). Exporting pipeline diagrams
+additionally needs `dot` (from `graphviz`); that is optional and checked
+only when you use that action.
+
 **MXL domain** — example scripts call `bootstrap_mxl_domain` (from
 [`env.sh`](https://github.com/NVIDIA/nvnmos/blob/main/rust/gst-nmos-rs/scripts/env.sh)), which creates `domain_def.json` on first use
 or reuses the `id` already stored under `DEMO_MXL_DOMAIN_PATH`. Override the

--- a/rust/gst-nmos-rs/scripts/env.sh
+++ b/rust/gst-nmos-rs/scripts/env.sh
@@ -195,11 +195,34 @@ is_udp_transport() {
     esac
 }
 
+# Fail-fast if a required tool is missing. Args: command [package-name]
+# (package defaults to the command name).
+require_cmd() {
+    local cmd=$1
+    local pkg=${2:-$1}
+    command -v "$cmd" >/dev/null 2>&1 || {
+        echo "[error] required command '$cmd' not found (install the $pkg package)" >&2
+        exit 1
+    }
+}
+
+# Example pipelines prerequisites.
 require_nvnmosd() {
-    if ! ss -xlpn 2>/dev/null | rg -F "LISTEN" | rg -qF "$DEMO_DAEMON_SOCK"; then
+    require_cmd ss iproute2
+    if ! ss -xlpn 2>/dev/null | grep -F "LISTEN" | grep -qF "$DEMO_DAEMON_SOCK"; then
         echo "[error] $DEMO_DAEMON_SOCK is not listening — start nvnmosd first" >&2
         exit 1
     fi
+}
+
+# Interactive demo prerequisites.
+require_demo_tools() {
+    # for daemon socket checks
+    require_cmd ss iproute2
+    # for making IS-04/IS-05/IS-08 HTTP requests
+    require_cmd curl curl
+    # for JSON body parsing/creation
+    require_cmd jq jq
 }
 
 bootstrap_mxl_domain() {

--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -107,6 +107,7 @@ DEMO_MXL_DOMAIN_PATH=${DEMO_MXL_DOMAIN_PATH:-/dev/shm/gst-nmos-rs-demo}
 # Shared flow identity, caps, NIC, and UDP multicast defaults.
 # shellcheck source=env.sh
 source "$_SCRIPT_DIR/env.sh"
+require_demo_tools
 
 # `libnvnmos.so` (consumed by nvnmosd) and the gst-mxl-rs plugin +
 # libmxl.so runtime (required for the MXL inner transport chain).
@@ -148,15 +149,13 @@ _demo_gst_launch() {
 # No listener / missing path in ss → return 1.
 _uds_socket_listening() {
     local path=$1
-    command -v ss >/dev/null 2>&1 || return 1
-    ss -xlpn 2>/dev/null | rg -F "LISTEN" | rg -qF "$path"
+    ss -xlpn 2>/dev/null | grep -F "LISTEN" | grep -qF "$path"
 }
 
 # Return 0 when ss reports pid is listening on the socket path.
 _uds_listener_owned_by_pid() {
     local pid=$1 path=$2
-    command -v ss >/dev/null 2>&1 || return 0
-    ss -xlpn 2>/dev/null | rg -F "$path" | rg -q "pid=$pid[,)]"
+    ss -xlpn 2>/dev/null | grep -F "$path" | grep -qE "pid=$pid[,)]"
 }
 
 # Fail if more than one nvnmosd was started with this --uds path.
@@ -506,7 +505,7 @@ if ! _uds_socket_listening "$SOCK"; then
 fi
 if ! _uds_listener_owned_by_pid "$DAEMON_PID" "$SOCK"; then
     echo "[daemon] $SOCK is not owned by nvnmosd pid $DAEMON_PID"
-    ss -xlpn 2>/dev/null | rg 'gst-nmos-rs-demo\.sock' || true
+    ss -xlpn 2>/dev/null | grep -F 'gst-nmos-rs-demo.sock' || true
     pgrep -af "nvnmosd --uds $SOCK" 2>/dev/null || true
     cat "$DAEMON_LOG"
     exit 1
@@ -987,11 +986,7 @@ sleep 1
 # non-deterministic order, so we don't rely on daemon-log line order.
 # Instead query each Node's IS-04 senders/receivers endpoints and
 # match by `tags["urn:x-nvnmos:tag:name"]` (which gst-nmos-rs sets
-# from sender-name / receiver-name). Requires `jq`.
-
-if ! command -v jq >/dev/null 2>&1; then
-    echo "[warn] 'jq' not found; the URL discovery and example PATCHes will be incomplete."
-fi
+# from sender-name / receiver-name).
 
 # curl defaults to no timeout at all, which can wedge the whole demo
 # script if the daemon's IS-04 / IS-05 HTTP server is briefly slow
@@ -2234,14 +2229,6 @@ menu_is08_unrouted() {
 }
 
 interactive_loop() {
-    if ! command -v jq >/dev/null 2>&1; then
-        echo
-        echo "[warn] 'jq' not found; the interactive menu builds JSON via jq."
-        echo "        Install jq or use the copy/paste curl recipes above."
-        echo "        Falling through to bare \`wait\` — Ctrl+C to quit."
-        wait
-        return
-    fi
     local ans
     while true; do
         echo


### PR DESCRIPTION
## Summary
- Add `require_cmd` / `require_demo_tools` so missing `ss` (`iproute2`), `curl`, and `jq` fail fast with package hints instead of misleading "socket not listening" / soft-warn paths.
- Replace `rg` with `grep` in the demo and `require_nvnmosd` (no ripgrep dependency).
- Document those tools in the Rust quick start and pipeline-examples; note optional `graphviz` (for `dot`) for menu diagram export.

## Test plan
- [x] `require_nvnmosd` without `ss` → install-hint error (not "not listening")
- [x] `require_nvnmosd` with `ss` but no daemon → existing "not listening" message
- [x] `require_demo_tools` without `jq` / without `curl` → fail-fast with package hints
- [x] `require_demo_tools` with tools present → OK
- [x] grep patterns for LISTEN / pid ownership / diagnostic sock filter
- [x] `pipeline_dots_require_graphviz` without `dot` → soft-fail install hint (`return 1`)
- [ ] Optional: full interactive demo smoke with tools present