### PR TITLE
Drop -dev from IS-05 v1.2 and BCP-007-03 v1.0 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ See the [container definitions](https://github.com/NVIDIA/nvnmos/tree/main/docke
 
 The NvNmos library supports the following specifications, using the [Sony nmos-cpp](https://github.com/sony/nmos-cpp) implementation internally:
 - [AMWA IS-04 NMOS Discovery and Registration Specification](https://specs.amwa.tv/is-04/) v1.3
-- [AMWA IS-05 NMOS Device Connection Management Specification](https://specs.amwa.tv/is-05/) v1.1 and v1.2-dev (for MXL)
+- [AMWA IS-05 NMOS Device Connection Management Specification](https://specs.amwa.tv/is-05/) v1.2
 - [AMWA IS-09 NMOS System Parameters Specification](https://specs.amwa.tv/is-09/) v1.0
 - [AMWA BCP-002-01 Natural Grouping of NMOS Resources](https://specs.amwa.tv/bcp-002-01/) v1.0
 - [AMWA BCP-002-02 NMOS Asset Distinguishing Information](https://specs.amwa.tv/bcp-002-02/) v1.0
 - [AMWA BCP-004-01 NMOS Receiver Capabilities](https://specs.amwa.tv/bcp-004-01/) v1.0
 - [AMWA BCP-006-01 NMOS With JPEG XS](https://specs.amwa.tv/bcp-006-01/) v1.0
-- [AMWA BCP-007-03 NMOS With MXL](https://specs.amwa.tv/bcp-007-03/) v1.0-dev
+- [AMWA BCP-007-03 NMOS With MXL](https://specs.amwa.tv/bcp-007-03/) v1.0
 - Session Description Protocol conforming to SMPTE ST 2110-20, -22, -30, -40, and ST 2022-7
 - MXL flow definition JSON as consumed by the [MXL SDK](https://github.com/dmf-mxl/mxl)
 

--- a/rust/gst-nmos-rs/src/domain.rs
+++ b/rust/gst-nmos-rs/src/domain.rs
@@ -10,7 +10,7 @@
 //! `mxl-domain-path` GObject properties surface the two facets
 //! independently.
 //!
-//! AMWA BCP-007-03 (work-in-progress) further says every MXL Domain
+//! AMWA BCP-007-03 further says every MXL Domain
 //! holds a `domain_def.json` file in its host directory whose `id`
 //! field is the Domain's authoritative UUID. This module reads that
 //! file when present and cross-checks it against the user-supplied

--- a/rust/gst-nmos-rs/src/flow_def.rs
+++ b/rust/gst-nmos-rs/src/flow_def.rs
@@ -407,7 +407,7 @@ pub(crate) struct FlowDefOverrides<'a> {
 /// does not have to special-case them — pass `None` when the
 /// property is empty.
 ///
-/// libnvnmos's [BCP-007-03 WIP] reading rule for the caps tag is
+/// libnvnmos's BCP-007-03 reading rule for the caps tag is
 /// "present + non-empty array means unconstrained"; `CapsMode::Unconstrained` writes
 /// `[""]` to satisfy that rule, `CapsMode::Constrained` removes the tag,
 /// and `CapsMode::Auto` leaves the file's existing presence alone.

--- a/rust/gst-nmos-rs/src/session/mod.rs
+++ b/rust/gst-nmos-rs/src/session/mod.rs
@@ -224,7 +224,7 @@ pub(crate) struct CommonSettings {
     /// MXL Domain identifier (UUID) included as
     /// `urn:x-nvnmos:tag:mxl-domain-id` in the flow_def. If
     /// `mxl_domain_path` is also set and contains a `domain_def.json`
-    /// (AMWA BCP-007-03 WIP), the file's `id` is cross-checked
+    /// (AMWA BCP-007-03), the file's `id` is cross-checked
     /// against this property — see [`crate::domain`].
     pub(crate) mxl_domain_id: String,
     /// Local filesystem path identifying the MXL Domain on this host.

--- a/src/nvnmos.h
+++ b/src/nvnmos.h
@@ -48,13 +48,13 @@
  *
  * The NvNmos library supports the following specifications, using the <a href="https://github.com/sony/nmos-cpp">Sony nmos-cpp</a> implementation:
  * - <a href="https://specs.amwa.tv/is-04/">AMWA IS-04 NMOS Discovery and Registration Specification</a> v1.3
- * - <a href="https://specs.amwa.tv/is-05/">AMWA IS-05 NMOS Device Connection Management Specification</a> v1.1 and v1.2-dev (for MXL)
+ * - <a href="https://specs.amwa.tv/is-05/">AMWA IS-05 NMOS Device Connection Management Specification</a> v1.2
  * - <a href="https://specs.amwa.tv/is-09/">AMWA IS-09 NMOS System Parameters Specification</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-002-01/">AMWA BCP-002-01 Natural Grouping of NMOS Resources</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-002-02/">AMWA BCP-002-02 NMOS Asset Distinguishing Information</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-004-01/">AMWA BCP-004-01 NMOS Receiver Capabilities</a> v1.0
  * - <a href="https://specs.amwa.tv/bcp-006-01/">AMWA BCP-006-01 NMOS With JPEG XS</a> v1.0
- * - <a href="https://specs.amwa.tv/bcp-007-03/">AMWA BCP-007-03 NMOS With MXL</a> v1.0-dev
+ * - <a href="https://specs.amwa.tv/bcp-007-03/">AMWA BCP-007-03 NMOS With MXL</a> v1.0
  * - Session Description Protocol conforming to SMPTE ST 2110-20, -22, -30, -40, and ST 2022-7
  * - MXL flow definition JSON as consumed by the <a href="https://github.com/dmf-mxl/mxl">MXL SDK</a>
  *


### PR DESCRIPTION
## Summary
- Document IS-05 v1.2 and BCP-007-03 v1.0 now that those specs have published patch branches.
- Drop WIP wording in gst-nmos-rs comments.

## Test plan
- [x] Docs-only: confirm README and `nvnmos.h` version lines look right in the rendered API docs.