### PR TITLE
gst-nmos-rs: label example Nodes and pass optional discovery props

### DIFF
--- a/rust/gst-nmos-rs/pipeline-examples.md
+++ b/rust/gst-nmos-rs/pipeline-examples.md
@@ -122,6 +122,9 @@ prefix. Example scripts and the interactive demo both source this file.
 |----------|------|
 | `DEMO_DAEMON_SOCK` | gRPC UDS path for `nvnmosd` (default `/tmp/nvnmosd.sock`) |
 | `DEMO_DAEMON_URI` | `unix:` URI derived from `DEMO_DAEMON_SOCK` (used as `daemon-uri`) |
+| `DEMO_NMOS_DOMAIN` | Optional DNS-SD domain (`local` = mDNS only). Empty omits `domain`, which selects automatic discovery. |
+| `DEMO_REGISTRATION_URL` | Optional IS-04 Registration API URL. Empty omits `registration-url`, which uses DNS-SD. |
+| `DEMO_HOST_NAME` | Optional IS-04 Node `host-name`. Empty omits `host-name`; libnvnmos uses the system hostname (and a domain suffix if the name is not already fully qualified). Must be a DNS name, not an IP address. |
 | `DEMO_NIC_IP` | Local NIC for UDP IS-05 endpoint props and SDP source-filter |
 | `DEMO_UDP_TRANSPORT` | `transport` on example pipelines: `udp`, `udp2`, or `nvdsudp` |
 | `DEMO_MXL_DOMAIN_ID` / `DEMO_MXL_DOMAIN_PATH` | MXL shared-memory domain |

--- a/rust/gst-nmos-rs/scripts/env.sh
+++ b/rust/gst-nmos-rs/scripts/env.sh
@@ -18,6 +18,18 @@
 export DEMO_DAEMON_SOCK=${DEMO_DAEMON_SOCK:-/tmp/nvnmosd.sock}
 export DEMO_DAEMON_URI="unix:${DEMO_DAEMON_SOCK}"
 
+# Optional DNS-SD domain. Set to `local` to use mDNS directly.
+export DEMO_NMOS_DOMAIN=${DEMO_NMOS_DOMAIN:-}
+
+# Optional IS-04 Registration API URL. Empty uses DNS-SD.
+# Example: http://127.0.0.1:3211/x-nmos/registration/v1.3
+export DEMO_REGISTRATION_URL=${DEMO_REGISTRATION_URL:-}
+
+# Optional IS-04 Node host-name. Empty autodetects the system hostname
+# and appends the NMOS domain (typically `.local`) when the name is not
+# already fully-qualified. Must be a DNS name, not an IP address.
+export DEMO_HOST_NAME=${DEMO_HOST_NAME:-}
+
 # Local NIC for RTP/UDP IS-05 endpoint properties and SDP source-filter.
 # Skips loopback (WSL2 can assign a global-scope address on `lo`).
 # Override with DEMO_NIC_IP.
@@ -167,6 +179,25 @@ demo_unconstrained_receiver_to_map() {
     local caps=${1:-${AUDIO_CAPS_ALT:-$DEMO_UDP_AUDIO_CAPS_ALT}}
     local qname=${2:-}
     printf '%s ! %s' "$(demo_unconstrained_audio_map_input "$caps")" "$(demo_audio_queue "$qname")"
+}
+
+# Optional Node network-service and advertised-host properties.
+# Used by non-minimal example pipelines and gst-nmos-rs-demo.sh.
+# Prints nothing when every corresponding DEMO_* variable is empty.
+demo_nmos_node_props() {
+    local -a args=()
+    if [[ -n "${DEMO_NMOS_DOMAIN:-}" ]]; then
+        args+=("domain=${DEMO_NMOS_DOMAIN}")
+    fi
+    if [[ -n "${DEMO_REGISTRATION_URL:-}" ]]; then
+        args+=("registration-url=${DEMO_REGISTRATION_URL}")
+    fi
+    if [[ -n "${DEMO_HOST_NAME:-}" ]]; then
+        args+=("host-name=${DEMO_HOST_NAME}")
+    fi
+    if ((${#args[@]} > 0)); then
+        printf '%s\n' "${args[@]}"
+    fi
 }
 
 udp_video_buffer_props() {

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-mxl.sh
@@ -15,7 +15,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport=mxl \
         node-seed=example-deferred \
+        node-properties="properties,label=deferred" \
         http-port=18103 \
+        $(demo_nmos_node_props) \
         sender-name=video1 \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
         mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-deferred-sender-udp.sh
@@ -14,7 +14,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-deferred \
+        node-properties="properties,label=deferred" \
         http-port=18103 \
+        $(demo_nmos_node_props) \
         sender-name=video1 \
         destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-mxl.sh
@@ -11,7 +11,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport=mxl \
         node-seed=example-flipper \
+        node-properties="properties,label=flipper" \
         http-port=18104 \
+        $(demo_nmos_node_props) \
         receiver-name=video-in \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
         mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
@@ -24,7 +26,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport=mxl \
         node-seed=example-flipper \
+        node-properties="properties,label=flipper" \
         http-port=18104 \
+        $(demo_nmos_node_props) \
         sender-name=video-out \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
         mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-flipper-udp.sh
@@ -13,7 +13,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-flipper \
+        node-properties="properties,label=flipper" \
         http-port=18104 \
+        $(demo_nmos_node_props) \
         receiver-name=video-in \
         multicast-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
@@ -28,7 +30,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-flipper \
+        node-properties="properties,label=flipper" \
         http-port=18104 \
+        $(demo_nmos_node_props) \
         sender-name=video-out \
         destination-ip="$DEMO_UDP_VIDEO_MCAST_IP3" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT3" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-mxl.sh
@@ -11,7 +11,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport=mxl \
         node-seed=example-consumer \
+        node-properties="properties,label=consumer" \
         http-port=18102 \
+        $(demo_nmos_node_props) \
         receiver-name=video2 \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
         mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp-jxsv.sh
@@ -15,7 +15,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-consumer \
+        node-properties="properties,label=consumer" \
         http-port=18102 \
+        $(demo_nmos_node_props) \
         receiver-name=video2 \
         multicast-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-receiver-udp.sh
@@ -10,7 +10,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-consumer \
+        node-properties="properties,label=consumer" \
         http-port=18102 \
+        $(demo_nmos_node_props) \
         receiver-name=video2 \
         multicast-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-mxl.sh
@@ -13,7 +13,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport=mxl \
         node-seed=example-producer \
+        node-properties="properties,label=producer" \
         http-port=18101 \
+        $(demo_nmos_node_props) \
         sender-name=video1 \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" \
         mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp-jxsv.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp-jxsv.sh
@@ -18,7 +18,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-producer \
+        node-properties="properties,label=producer" \
         http-port=18101 \
+        $(demo_nmos_node_props) \
         sender-name=video1 \
         destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/1080p25-sender-udp.sh
@@ -12,7 +12,9 @@ exec gst-launch-1.0 -e \
         daemon-uri="$DEMO_DAEMON_URI" \
         transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-producer \
+        node-properties="properties,label=producer" \
         http-port=18101 \
+        $(demo_nmos_node_props) \
         sender-name=video1 \
         destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" \
         destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \

--- a/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-mxl.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-mxl.sh
@@ -11,14 +11,18 @@ exec gst-launch-1.0 -e \
     videotestsrc is-live=true ! "$DEMO_MXL_VIDEO_CAPS" ! \
     nmossink daemon-uri="$DEMO_DAEMON_URI" transport=mxl \
         node-seed=example-multi sender-name=video1 \
+        node-properties="properties,label=multi" \
         http-port=18105 \
+        $(demo_nmos_node_props) \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
         mxl-flow-id="$DEMO_MXL_VIDEO_FLOW_ID1" caps="$DEMO_MXL_VIDEO_CAPS" \
         label="${DEMO_MXL_VIDEO_LABEL} sender" auto-activate=true \
     audiotestsrc wave=sine freq=440 is-live=true ! "$DEMO_MXL_AUDIO_CAPS" ! \
     nmossink daemon-uri="$DEMO_DAEMON_URI" transport=mxl \
         node-seed=example-multi sender-name=audio1 \
+        node-properties="properties,label=multi" \
         http-port=18105 \
+        $(demo_nmos_node_props) \
         mxl-domain-id="$DEMO_MXL_DOMAIN_ID" mxl-domain-path="$DEMO_MXL_DOMAIN_PATH" \
         mxl-flow-id="$DEMO_MXL_AUDIO_FLOW_ID1" caps="$DEMO_MXL_AUDIO_CAPS" \
         label="${DEMO_MXL_AUDIO_LABEL} sender" auto-activate=true

--- a/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-udp.sh
+++ b/rust/gst-nmos-rs/scripts/example-pipelines/multi-flow-sender-udp.sh
@@ -9,7 +9,9 @@ exec gst-launch-1.0 -e \
     videotestsrc is-live=true ! "$DEMO_UDP_VIDEO_CAPS" ! \
     nmossink daemon-uri="$DEMO_DAEMON_URI" transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-multi sender-name=video1 \
+        node-properties="properties,label=multi" \
         http-port=18105 \
+        $(demo_nmos_node_props) \
         destination-ip="$DEMO_UDP_VIDEO_MCAST_IP1" destination-port="$DEMO_UDP_VIDEO_MCAST_PORT1" \
         source-ip="$DEMO_NIC_IP" $(udp_video_buffer_props) \
         caps="$DEMO_UDP_VIDEO_CAPS" \
@@ -17,7 +19,9 @@ exec gst-launch-1.0 -e \
     audiotestsrc wave=sine freq=440 is-live=true ! "$DEMO_UDP_AUDIO_CAPS" ! \
     nmossink daemon-uri="$DEMO_DAEMON_URI" transport="$DEMO_UDP_TRANSPORT" \
         node-seed=example-multi sender-name=audio1 \
+        node-properties="properties,label=multi" \
         http-port=18105 \
+        $(demo_nmos_node_props) \
         destination-ip="$DEMO_UDP_AUDIO_MCAST_IP1" destination-port="$DEMO_UDP_AUDIO_MCAST_PORT1" \
         source-ip="$DEMO_NIC_IP" caps="$DEMO_UDP_AUDIO_CAPS" \
         label="${DEMO_UDP_AUDIO_LABEL} sender" auto-activate=true

--- a/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
+++ b/rust/gst-nmos-rs/scripts/gst-nmos-rs-demo.sh
@@ -660,6 +660,8 @@ launch_node1() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE1_PORT" \
                     node-seed="$NODE1_SEED" \
+                    node-properties="properties,label=producer" \
+                    $(demo_nmos_node_props) \
                     sender-name=video1 \
                     $(transport_sender_props video1) \
                     $(udp_video_buffer_props) \
@@ -674,6 +676,8 @@ launch_node1() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE1_PORT" \
                     node-seed="$NODE1_SEED" \
+                    node-properties="properties,label=producer" \
+                    $(demo_nmos_node_props) \
                     sender-name=audio1 \
                     $(transport_sender_props audio1) \
                     caps="$AUDIO_CAPS" \
@@ -707,6 +711,8 @@ launch_node4() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE4_PORT" \
                     node-seed="$NODE4_SEED" \
+                    node-properties="properties,label=alt-producer" \
+                    $(demo_nmos_node_props) \
                     sender-name=video4 \
                     $(transport_sender_props video4) \
                     $(udp_video_buffer_props) \
@@ -721,6 +727,8 @@ launch_node4() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE4_PORT" \
                     node-seed="$NODE4_SEED" \
+                    node-properties="properties,label=alt-producer" \
+                    $(demo_nmos_node_props) \
                     sender-name=audio4 \
                     $(transport_sender_props audio4) \
                     $(udp_audio_transport_caps_alt) \
@@ -768,6 +776,8 @@ launch_node3_video() {
                 transport="$DEMO_TRANSPORT" \
                 http-port="$NODE3_PORT" \
                 node-seed="$NODE3_SEED" \
+                node-properties="properties,label=processor" \
+                $(demo_nmos_node_props) \
                 receiver-name=video-in \
                 $(transport_receiver_props video1) \
                 $(udp_video_buffer_props) \
@@ -781,6 +791,8 @@ launch_node3_video() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE3_PORT" \
                     node-seed="$NODE3_SEED" \
+                    node-properties="properties,label=processor" \
+                    $(demo_nmos_node_props) \
                     sender-name=video-out \
                     $(transport_sender_props video-out) \
                     $(udp_video_buffer_props) \
@@ -804,6 +816,8 @@ launch_node3_audio() {
             nmosaudiochannelmap name=map \
                 daemon-uri="unix:$SOCK" \
                 node-seed="$NODE3_SEED" \
+                node-properties="properties,label=processor" \
+                $(demo_nmos_node_props) \
                 http-port="$NODE3_PORT" \
                 channelmapping-name="$IS08_CHANNELMAPPING_NAME" \
                 sink_0::input-id="$IS08_INPUT_0" \
@@ -823,6 +837,8 @@ launch_node3_audio() {
                 transport="$DEMO_TRANSPORT" \
                 http-port="$NODE3_PORT" \
                 node-seed="$NODE3_SEED" \
+                node-properties="properties,label=processor" \
+                $(demo_nmos_node_props) \
                 receiver-name=audio-in0 \
                 $(transport_receiver_props audio1) \
                 caps="$AUDIO_CAPS" \
@@ -834,6 +850,8 @@ launch_node3_audio() {
                 transport="$DEMO_TRANSPORT" \
                 http-port="$NODE3_PORT" \
                 node-seed="$NODE3_SEED" \
+                node-properties="properties,label=processor" \
+                $(demo_nmos_node_props) \
                 receiver-name=audio-in1 \
                 receiver-caps-mode=unconstrained \
                 $(transport_receiver_props audio4) \
@@ -847,6 +865,8 @@ launch_node3_audio() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE3_PORT" \
                     node-seed="$NODE3_SEED" \
+                    node-properties="properties,label=processor" \
+                    $(demo_nmos_node_props) \
                     sender-name=audio-out0 \
                     $(transport_sender_props audio-out0) \
                     caps="$AUDIO_CAPS" \
@@ -858,6 +878,8 @@ launch_node3_audio() {
                     transport="$DEMO_TRANSPORT" \
                     http-port="$NODE3_PORT" \
                     node-seed="$NODE3_SEED" \
+                    node-properties="properties,label=processor" \
+                    $(demo_nmos_node_props) \
                     sender-name=audio-out1 \
                     $(transport_sender_props audio-out1) \
                     caps="$AUDIO_CAPS_ALT" \
@@ -891,6 +913,8 @@ launch_node2() {
                 transport="$DEMO_TRANSPORT" \
                 http-port="$NODE2_PORT" \
                 node-seed="$NODE2_SEED" \
+                node-properties="properties,label=consumer" \
+                $(demo_nmos_node_props) \
                 receiver-name=video2 \
                 receiver-caps-mode="$DEMO_RECEIVER_CAPS_MODE" \
                 $(transport_receiver_props video1) \
@@ -906,6 +930,8 @@ launch_node2() {
                 transport="$DEMO_TRANSPORT" \
                 http-port="$NODE2_PORT" \
                 node-seed="$NODE2_SEED" \
+                node-properties="properties,label=consumer" \
+                $(demo_nmos_node_props) \
                 receiver-name=audio2 \
                 receiver-caps-mode="$DEMO_RECEIVER_CAPS_MODE" \
                 $(transport_receiver_props audio1) \


### PR DESCRIPTION
## Summary
- Set `node-properties` labels on non-minimal example pipelines and the interactive demo so Nodes show readable names in an NMOS Controller.
- Add optional `DEMO_NMOS_DOMAIN`, `DEMO_REGISTRATION_URL`, and `DEMO_HOST_NAME` (empty = omit; Node defaults apply) and pass them via `demo_nmos_node_props`.
- Leave `minimal-*` scripts and hardcoded example HTTP ports unchanged.

## Test plan
- [x] Source `env.sh` and run a 1080p25 UDP sender/receiver pair; confirm Node labels `producer` / `consumer` in the controller.
- [x] Run `gst-nmos-rs-demo.sh`; confirm demo Nodes label as `producer`, `consumer`, `processor`, `alt-producer`.
- [x] With vars unset, behaviour matches today (no `domain` / `registration-url` / `host-name` on the command line).
- [x] With `DEMO_NMOS_DOMAIN=local`, those pipelines include `domain=local`.