### PR TITLE
gst-nmos-rs: contain inner-chain errors and unblock fake-sink swaps

### DIFF
--- a/rust/gst-nmos-rs/src/inner.rs
+++ b/rust/gst-nmos-rs/src/inner.rs
@@ -186,6 +186,8 @@ pub(crate) fn rebuild_chain_with_opts(
         flush_external_of_ghost(cat, ghost);
     }
 
+    release_fake_sink_clock_wait(cat, ghost);
+
     let probe_id =
         block_and_wait(cat, &probe_pad).context("blocking anchor pad before chain rebuild")?;
 
@@ -592,6 +594,27 @@ fn parent_target_state(bin: &gst::Bin) -> gst::State {
     }
 }
 
+fn current_chain(ghost: &gst::GhostPad) -> Option<gst::Element> {
+    let anchor_outer_pad = ghost.target()?;
+    let anchor = anchor_outer_pad.parent_element()?;
+    if anchor.name() != ANCHOR_NAME {
+        return None;
+    }
+    let link_pad_name = match ghost.direction() {
+        gst::PadDirection::Sink => "src",
+        gst::PadDirection::Src => "sink",
+        _ => return None,
+    };
+    anchor.static_pad(link_pad_name)?.peer()?.parent_element()
+}
+
+/// True when `source` is the current inner chain or one of its children.
+pub(crate) fn source_is_in_current_chain(ghost: &gst::GhostPad, source: &gst::Object) -> bool {
+    current_chain(ghost).is_some_and(|chain| {
+        source == chain.upcast_ref::<gst::Object>() || source.has_as_ancestor(&chain)
+    })
+}
+
 /// True iff the bin's current inner chain is a *real* chain (a
 /// real transport element such as `mxlsink` / `mxlsrc`, identified
 /// by the absence of the `-fake` suffix on its element name) — as
@@ -613,30 +636,37 @@ fn parent_target_state(bin: &gst::Bin) -> gst::State {
 /// re-open so the new real chain's start-up (`mxlsrc.start()` /
 /// `mxlsink.set_caps()` for MXL) sees a clean transport state.
 pub(crate) fn current_chain_is_real(ghost: &gst::GhostPad) -> bool {
-    let Some(anchor_outer_pad) = ghost.target() else {
-        return false;
-    };
-    let Some(anchor) = anchor_outer_pad.parent_element() else {
-        return false;
-    };
-    if anchor.name() != ANCHOR_NAME {
-        return false;
+    current_chain(ghost).is_some_and(|chain| !chain.name().ends_with("-fake"))
+}
+
+/// Stop an outgoing fake sink from waiting on a future timestamp so its
+/// anchor pad can become idle. This changes only the fake chain that is
+/// about to be removed; real transport sinks keep clock synchronization.
+fn release_fake_sink_clock_wait(cat: &gst::DebugCategory, ghost: &gst::GhostPad) {
+    if ghost.direction() != gst::PadDirection::Sink {
+        return;
     }
-    let link_pad_name = match ghost.direction() {
-        gst::PadDirection::Sink => "src",
-        gst::PadDirection::Src => "sink",
-        _ => return false,
+    let Some(chain) = current_chain(ghost).filter(|chain| chain.name().ends_with("-fake")) else {
+        return;
     };
-    let Some(link_pad) = anchor.static_pad(link_pad_name) else {
-        return false;
-    };
-    let Some(chain_pad) = link_pad.peer() else {
-        return false;
-    };
-    let Some(chain) = chain_pad.parent_element() else {
-        return false;
-    };
-    !chain.name().ends_with("-fake")
+    let sink = chain
+        .downcast_ref::<gst::Bin>()
+        .and_then(|bin| bin.by_name("nmossink-fake-sink"))
+        .unwrap_or(chain);
+    gst::debug!(
+        cat,
+        "rebuild_chain: interrupting clock wait on outgoing fake sink `{}`",
+        sink.name(),
+    );
+    // Flipping `sync` does not unschedule an in-flight GstBaseSink wait,
+    // and PLAYING→PAUSED would take the stream lock and block on it.
+    // FLUSH_START on the sink pad is the normal way to unblock from this
+    // thread. No FLUSH_STOP: that event is serialized, and stop_chain
+    // takes this fake to Null immediately after.
+    sink.set_property("sync", false);
+    if let Some(pad) = sink.static_pad("sink") {
+        let _ = pad.send_event(gst::event::FlushStart::new());
+    }
 }
 
 /// Build the `nmossink` fake chain: a `fakesink`, optionally preceded
@@ -3459,6 +3489,71 @@ mod tests {
 
         rebuild_chain(cat, &nmos_bin, &ghost, &sync_sink, "sink")
             .expect("async=false inner must swap while PLAYING");
+
+        let _ = pipeline.set_state(gst::State::Null);
+    }
+
+    #[test]
+    fn rebuild_chain_interrupts_fake_sink_clock_wait() {
+        init_gst();
+        let cat = test_log_cat();
+        let pipeline = gst::Pipeline::new();
+        let src = gst::ElementFactory::make("appsrc")
+            .property("is-live", true)
+            .property("format", gst::Format::Time)
+            .build()
+            .expect("appsrc");
+        let nmos_bin = gst::Bin::with_name("nmossink-sim");
+        let initial = build_fake_sink(None).expect("initial fake sink");
+        let (buffer_seen_tx, buffer_seen_rx) = std::sync::mpsc::channel();
+        initial
+            .static_pad("sink")
+            .expect("fake sink pad")
+            .add_probe(gst::PadProbeType::BUFFER, move |_pad, _info| {
+                let _ = buffer_seen_tx.send(());
+                gst::PadProbeReturn::Ok
+            })
+            .expect("buffer probe");
+        let ghost = build_initial(&nmos_bin, initial, "sink", gst::PadDirection::Sink)
+            .expect("build_initial");
+        nmos_bin.add_pad(&ghost).expect("add ghost pad");
+        let nmos_elem: &gst::Element = nmos_bin.upcast_ref();
+        pipeline
+            .add_many([&src, nmos_elem])
+            .expect("add pipeline children");
+        src.link_pads(Some("src"), &nmos_bin, Some("sink"))
+            .expect("link appsrc to nmossink ghost");
+        pipeline
+            .set_state(gst::State::Playing)
+            .expect("pipeline -> PLAYING");
+        let (_ret, state, _pending) = pipeline.state(gst::ClockTime::from_seconds(5));
+        assert_eq!(state, gst::State::Playing, "pipeline must reach PLAYING");
+
+        let mut buffer = gst::Buffer::with_size(1).expect("buffer");
+        buffer
+            .get_mut()
+            .expect("writable buffer")
+            .set_pts(gst::ClockTime::from_seconds(30));
+        src.downcast_ref::<gstreamer_app::AppSrc>()
+            .expect("appsrc type")
+            .push_buffer(buffer)
+            .expect("push future-dated buffer");
+        buffer_seen_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("buffer must reach the fake sink");
+        // BUFFER probe runs just before GstBaseSink creates its clock id.
+        // FLUSH_START only unschedules a wait that already exists.
+        std::thread::sleep(Duration::from_millis(10));
+
+        let replacement = fakesink_for_rebuild_test("inner-replacement", false);
+        let started = std::time::Instant::now();
+        rebuild_chain(cat, &nmos_bin, &ghost, &replacement, "sink")
+            .expect("swap must interrupt the fake sink's clock wait");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "rebuild_chain waited out the 30s timestamp instead of interrupting it ({:?})",
+            started.elapsed(),
+        );
 
         let _ = pipeline.set_state(gst::State::Null);
     }

--- a/rust/gst-nmos-rs/src/nmossink/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossink/imp.rs
@@ -575,7 +575,64 @@ impl ElementImpl for NmosSink {
     }
 }
 
-impl BinImpl for NmosSink {}
+impl BinImpl for NmosSink {
+    fn handle_message(&self, message: gst::Message) {
+        let gst::MessageView::Error(error) = message.view() else {
+            self.parent_handle_message(message);
+            return;
+        };
+        let Some(source) = message.src().cloned() else {
+            self.parent_handle_message(message);
+            return;
+        };
+        let from_current_chain = self
+            .ghost
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|ghost| inner::source_is_in_current_chain(ghost, &source));
+        if !from_current_chain {
+            self.parent_handle_message(message);
+            return;
+        }
+
+        let debug = error.debug().map(|debug| debug.to_owned());
+        let details = error.details().map(|details| details.to_owned());
+        let glib_error = error.error();
+        self.obj().call_async(move |sink| {
+            let imp = sink.imp();
+            if imp
+                .ghost
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|ghost| inner::source_is_in_current_chain(ghost, &source))
+            {
+                let settings = imp.settings.lock().unwrap().clone();
+                match build_fake_sink_for_settings(&settings)
+                    .and_then(|fake| imp.swap_inner(sink.upcast_ref(), &fake))
+                {
+                    Ok(()) => gst::warning!(
+                        CAT,
+                        "nmossink inner chain posted ERROR; restored fake chain: {glib_error}"
+                    ),
+                    Err(restore_error) => gst::warning!(
+                        CAT,
+                        "nmossink inner chain posted ERROR and fake-chain restore failed: \
+                         {restore_error:#}; original error: {glib_error}"
+                    ),
+                }
+            }
+
+            let warning = gst::message::Warning::builder_from_error(glib_error)
+                .debug_if_some(debug.as_deref())
+                .details_if_some(details)
+                .src(sink)
+                .build();
+            let _ = sink.post_message(warning);
+        });
+    }
+}
 
 impl NmosSink {
     // Locks `settings`; must not be called while that mutex is held.
@@ -1316,5 +1373,41 @@ mod tests {
             intermediate_fake_sink_caps(&plan, &settings).expect("mxl hop"),
             Some(caps),
         );
+    }
+
+    #[test]
+    fn inner_error_restores_fake_chain_without_bus_error() {
+        init_gst();
+        let pipeline = gst::Pipeline::new();
+        let sink = glib::Object::new::<crate::nmossink::NmosSink>();
+        pipeline.add(&sink).expect("add nmossink");
+        let real = gst::ElementFactory::make("fakesink")
+            .name("test-real-sink")
+            .build()
+            .expect("real sink");
+        sink.imp()
+            .swap_inner(sink.upcast_ref(), &real)
+            .expect("install real sink");
+        assert!(sink.imp().current_chain_is_real());
+
+        real.post_message(
+            gst::message::Error::builder(gst::CoreError::Failed, "test inner failure")
+                .src(&real)
+                .build(),
+        )
+        .expect("post inner error");
+
+        let bus = pipeline.bus().expect("pipeline bus");
+        let message = bus
+            .timed_pop_filtered(
+                gst::ClockTime::from_seconds(2),
+                &[gst::MessageType::Error, gst::MessageType::Warning],
+            )
+            .expect("inner error must produce a warning");
+        assert!(
+            matches!(message.view(), gst::MessageView::Warning(_)),
+            "inner error escaped the bin: {message:?}",
+        );
+        assert!(!sink.imp().current_chain_is_real());
     }
 }

--- a/rust/gst-nmos-rs/src/nmossrc/imp.rs
+++ b/rust/gst-nmos-rs/src/nmossrc/imp.rs
@@ -548,7 +548,64 @@ impl ElementImpl for NmosSrc {
     }
 }
 
-impl BinImpl for NmosSrc {}
+impl BinImpl for NmosSrc {
+    fn handle_message(&self, message: gst::Message) {
+        let gst::MessageView::Error(error) = message.view() else {
+            self.parent_handle_message(message);
+            return;
+        };
+        let Some(source) = message.src().cloned() else {
+            self.parent_handle_message(message);
+            return;
+        };
+        let from_current_chain = self
+            .ghost
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|ghost| inner::source_is_in_current_chain(ghost, &source));
+        if !from_current_chain {
+            self.parent_handle_message(message);
+            return;
+        }
+
+        let debug = error.debug().map(|debug| debug.to_owned());
+        let details = error.details().map(|details| details.to_owned());
+        let glib_error = error.error();
+        self.obj().call_async(move |src| {
+            let imp = src.imp();
+            if imp
+                .ghost
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|ghost| inner::source_is_in_current_chain(ghost, &source))
+            {
+                let settings = imp.settings.lock().unwrap().clone();
+                match build_fake_src_for_settings(&settings).and_then(|fake| {
+                    imp.swap_inner(src.upcast_ref(), &fake, inner::RebuildChainOpts::default())
+                }) {
+                    Ok(()) => gst::warning!(
+                        CAT,
+                        "nmossrc inner chain posted ERROR; restored fake chain: {glib_error}"
+                    ),
+                    Err(restore_error) => gst::warning!(
+                        CAT,
+                        "nmossrc inner chain posted ERROR and fake-chain restore failed: \
+                         {restore_error:#}; original error: {glib_error}"
+                    ),
+                }
+            }
+
+            let warning = gst::message::Warning::builder_from_error(glib_error)
+                .debug_if_some(debug.as_deref())
+                .details_if_some(details)
+                .src(src)
+                .build();
+            let _ = src.post_message(warning);
+        });
+    }
+}
 
 impl NmosSrc {
     // Locks `settings`; must not be called while that mutex is held.
@@ -1490,5 +1547,41 @@ mod tests {
             intermediate_fake_src_caps(&plan, &snapshot).expect("fake plan"),
             Some(caps),
         );
+    }
+
+    #[test]
+    fn inner_error_restores_fake_chain_without_bus_error() {
+        init_gst();
+        let pipeline = gst::Pipeline::new();
+        let src = glib::Object::new::<crate::nmossrc::NmosSrc>();
+        pipeline.add(&src).expect("add nmossrc");
+        let real = gst::ElementFactory::make("fakesrc")
+            .name("test-real-src")
+            .build()
+            .expect("real src");
+        src.imp()
+            .swap_inner(src.upcast_ref(), &real, inner::RebuildChainOpts::default())
+            .expect("install real src");
+        assert!(src.imp().current_chain_is_real());
+
+        real.post_message(
+            gst::message::Error::builder(gst::CoreError::Failed, "test inner failure")
+                .src(&real)
+                .build(),
+        )
+        .expect("post inner error");
+
+        let bus = pipeline.bus().expect("pipeline bus");
+        let message = bus
+            .timed_pop_filtered(
+                gst::ClockTime::from_seconds(2),
+                &[gst::MessageType::Error, gst::MessageType::Warning],
+            )
+            .expect("inner error must produce a warning");
+        assert!(
+            matches!(message.view(), gst::MessageView::Warning(_)),
+            "inner error escaped the bin: {message:?}",
+        );
+        assert!(!src.imp().current_chain_is_real());
     }
 }


### PR DESCRIPTION
## Summary
- `nmossink` / `nmossrc` now swallow `ERROR` from the current inner chain, restore the fake path, and post a bus `WARNING`, so a transport failure does not take the pipeline down.
- Mid-PLAYING `rebuild_chain` on `nmossink` interrupts an outgoing fake `fakesink` clock wait by sending `FLUSH_START` on the sink pad (`Element::send_event` is a no-op on a sink-only element). That lets the anchor idle probe fire instead of stalling for a future PTS.
- Regression tests cover both behaviours, including a bound so the clock-wait test cannot pass by waiting out a 30s timestamp.

## Test plan
- [x] `cargo test -p gst-nmos-rs --lib`
- [x] `cargo test -p gst-nmos-rs --lib -- --test-threads=1`
- [x] `cargo clippy -p gst-nmos-rs --all-targets -- -D warnings`